### PR TITLE
Fix: confusing naming + remove warning.

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/experiment/SettingsFactory.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/experiment/SettingsFactory.java
@@ -43,8 +43,8 @@ public class SettingsFactory {
     throws JMetalException {
     String base = "org.uma.jmetal.experiment.settings." + algorithmName + "Settings";
     try {
-      Class problemClass = Class.forName(base);
-      Constructor[] constructors = problemClass.getConstructors();
+      Class<?> settingClass = Class.forName(base);
+      Constructor<?>[] constructors = settingClass.getConstructors();
       int i = 0;
       //find the constructor
       while ((i < constructors.length) &&


### PR DESCRIPTION
Just something I noticed in the version 4.5 which is still there. Maybe it comes from a copy-paste which was not fully adapted.
