### PR TITLE
Fix: background checks still running when push measure destroyed.

### DIFF
--- a/jmetal-core/src/test/java/org/uma/jmetal/util/measurement/impl/MeasureFactoryTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/measurement/impl/MeasureFactoryTest.java
@@ -117,6 +117,41 @@ public class MeasureFactoryTest {
 	}
 
 	@Test
+	public void testCreatePushFromPullStopNotificationsWhenPushDestroyed()
+			throws InterruptedException {
+		// create a pull measure which is always different, thus leading to
+		// generate a notification at every check
+		final boolean[] isCalled = { false };
+		PullMeasure<Integer> pull = new SimplePullMeasure<Integer>() {
+
+			int count = 0;
+
+			@Override
+			public Integer get() {
+				isCalled[0] = true;
+				count++;
+				return count;
+			}
+		};
+
+		// create the push measure
+		MeasureFactory factory = new MeasureFactory();
+		final int period = 10;
+		@SuppressWarnings("unused")
+		PushMeasure<Integer> push = factory.createPushFromPull(pull, period);
+
+		// destroy the push measure
+		push = null;
+		System.gc();
+		System.gc();
+
+		// check no periodical check are made anymore
+		isCalled[0] = false;
+		Thread.sleep(10 * period);
+		assertFalse(isCalled[0]);
+	}
+
+	@Test
 	public void testCreatePushFromPullNotifiesOnlyWhenValueChanged()
 			throws InterruptedException {
 		// create a pull measure which changes only when we change the value of


### PR DESCRIPTION
For the periodical check made on the pull measure to feed the push measure, the thread was stopped when the pull measure was destroyed (no change can happen anymore, so no need to recheck), but not when the push one was destroyed (nothing to feed anymore, so no need to recheck). Now both cases are considered.