### PR TITLE
list junit and mockito as test dependency

### DIFF
--- a/jmetal-algorithm/pom.xml
+++ b/jmetal-algorithm/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
@@ -61,6 +62,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.10.8</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/jmetal-core/pom.xml
+++ b/jmetal-core/pom.xml
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
@@ -58,6 +59,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.10.8</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
jUnit and mockito depedencies should be in scope `test`, otherwise are required as runtime dependencies, which is really not necessary.