### PR TITLE
Fix the generic types to delegate the casting work to the manager.

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/MeasureManager.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/MeasureManager.java
@@ -41,7 +41,7 @@ public interface MeasureManager {
 	 *            the key of the {@link Measure}
 	 * @return the {@link PullMeasure} identified by this key
 	 */
-	public PullMeasure<?> getPullMeasure(Object key);
+	public <T> PullMeasure<T> getPullMeasure(Object key);
 
 	/**
 	 * 
@@ -49,5 +49,5 @@ public interface MeasureManager {
 	 *            the key of the {@link Measure}
 	 * @return the {@link PushMeasure} identified by this key
 	 */
-	public PushMeasure<?> getPushMeasure(Object key);
+	public <T> PushMeasure<T> getPushMeasure(Object key);
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/PullPushMeasure.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/PullPushMeasure.java
@@ -116,6 +116,12 @@ public class PullPushMeasure<Value> implements PullMeasure<Value>,
 	 *            the description of the {@link PullPushMeasure}
 	 */
 	public PullPushMeasure(String name, String description) {
+		/*
+		 * FIXME No way to access the newly created push measure. Probably
+		 * enclosing existing measures and creating a new one are conceptually
+		 * incompatible (the source of push is different) and so should not be
+		 * together in the same class.
+		 */
 		this(new SimplePushMeasure<Value>(name, description), null);
 	}
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/PullPushMeasure.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/PullPushMeasure.java
@@ -10,7 +10,7 @@ import org.uma.jmetal.measure.PushMeasure;
 /**
  * A {@link PullPushMeasure} aims at providing both the {@link PushMeasure} and
  * {@link PullMeasure} abilities into a single {@link Measure}. One could simply
- * built a brand new {@link Measure} by calling
+ * build a brand new {@link Measure} by calling
  * {@link #PullPushMeasure(String, String)}, but in the case where some existing
  * measures are available, he can wrap them into a {@link PullPushMeasure} by
  * calling {@link #PullPushMeasure(PushMeasure, Object)} or other constructors

--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/SimpleMeasureManager.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/SimpleMeasureManager.java
@@ -66,9 +66,10 @@ public class SimpleMeasureManager implements MeasureManager {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public PullMeasure<?> getPullMeasure(Object key) {
-		return pullers.get(key);
+	public <T> PullMeasure<T> getPullMeasure(Object key) {
+		return (PullMeasure<T>) pullers.get(key);
 	}
 
 	/**
@@ -95,9 +96,10 @@ public class SimpleMeasureManager implements MeasureManager {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public PushMeasure<?> getPushMeasure(Object key) {
-		return pushers.get(key);
+	public <T> PushMeasure<T> getPushMeasure(Object key) {
+		return (PushMeasure<T>) pushers.get(key);
 	}
 
 	/**

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIMeasuresRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIMeasuresRunner.java
@@ -101,11 +101,11 @@ public class NSGAIIMeasuresRunner {
     MeasureManager measureManager = ((NSGAIIMeasures)algorithm).getMeasureManager() ;
 
     CountingMeasure iteration =
-        (CountingMeasure) measureManager.getPullMeasure("currentIteration");
+        (CountingMeasure) measureManager.<Long>getPullMeasure("currentIteration");
     DurationMeasure currentComputingTime =
-        (DurationMeasure) measureManager.getPullMeasure("currentExecutionTime");
+        (DurationMeasure) measureManager.<Long>getPullMeasure("currentExecutionTime");
     SingleValueMeasure<Integer> nonDominatedSolutions =
-        (SingleValueMeasure<Integer>) measureManager.getPullMeasure("numberOfNonDominatedSolutionsInPopulation");
+        (SingleValueMeasure<Integer>) measureManager.<Integer>getPullMeasure("numberOfNonDominatedSolutionsInPopulation");
 
     SingleValueMeasure<List<Solution>> solutionListMeasure =
         (SingleValueMeasure) measureManager.getPushMeasure("currentPopulation");


### PR DESCRIPTION
This is to simplify the use of the manager. Otherwise, you always need to cast the result to make something with it. I have modified the runner consequently.