### PR TITLE
Time spent in listeners

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/ListenerTimeMeasure.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/ListenerTimeMeasure.java
@@ -51,29 +51,34 @@ public class ListenerTimeMeasure extends SimplePullMeasure<Long> implements
 	 * @param wrapped
 	 *            the {@link MeasureListener} to wrap
 	 * @return the {@link MeasureListener} wrapper
+	 * @throw {@link IllegalArgumentException} if no listener is provided
 	 */
 	public <Value> MeasureListener<Value> wrapListener(
 			final MeasureListener<Value> wrapped) {
-		@SuppressWarnings("unchecked")
-		MeasureListener<Value> wrapper = (MeasureListener<Value>) listenerCache
-				.get(wrapped);
-
-		if (wrapper == null) {
-			wrapper = new MeasureListener<Value>() {
-				@Override
-				public void measureGenerated(Value value) {
-					long start = System.currentTimeMillis();
-					wrapped.measureGenerated(value);
-					long stop = System.currentTimeMillis();
-					time += stop - Math.max(start, lastReset);
-				}
-			};
-			listenerCache.put(wrapped, wrapper);
+		if (wrapped == null) {
+			throw new IllegalArgumentException("No listener provided");
 		} else {
-			// reuse existing one
-		}
+			@SuppressWarnings("unchecked")
+			MeasureListener<Value> wrapper = (MeasureListener<Value>) listenerCache
+					.get(wrapped);
 
-		return wrapper;
+			if (wrapper == null) {
+				wrapper = new MeasureListener<Value>() {
+					@Override
+					public void measureGenerated(Value value) {
+						long start = System.currentTimeMillis();
+						wrapped.measureGenerated(value);
+						long stop = System.currentTimeMillis();
+						time += stop - Math.max(start, lastReset);
+					}
+				};
+				listenerCache.put(wrapped, wrapper);
+			} else {
+				// reuse existing one
+			}
+
+			return wrapper;
+		}
 	}
 
 	/**
@@ -92,42 +97,47 @@ public class ListenerTimeMeasure extends SimplePullMeasure<Long> implements
 	 * @param wrapped
 	 *            the {@link PushMeasure} to wrap
 	 * @return the {@link PushMeasure} wrapper
+	 * @throw {@link IllegalArgumentException} if no measure is provided
 	 */
 	public <Value> PushMeasure<Value> wrapMeasure(
 			final PushMeasure<Value> wrapped) {
-		@SuppressWarnings("unchecked")
-		PushMeasure<Value> wrapper = (PushMeasure<Value>) measureCache
-				.get(wrapped);
-
-		if (wrapper == null) {
-			wrapper = new PushMeasure<Value>() {
-
-				@Override
-				public String getName() {
-					return wrapped.getName();
-				}
-
-				@Override
-				public String getDescription() {
-					return wrapped.getDescription();
-				}
-
-				@Override
-				public void register(MeasureListener<Value> listener) {
-					wrapped.register(wrapListener(listener));
-				}
-
-				@Override
-				public void unregister(MeasureListener<Value> listener) {
-					wrapped.unregister(wrapListener(listener));
-				}
-			};
-			measureCache.put(wrapped, wrapper);
+		if (wrapped == null) {
+			throw new IllegalArgumentException("No measure provided");
 		} else {
-			// reuse existing one
-		}
+			@SuppressWarnings("unchecked")
+			PushMeasure<Value> wrapper = (PushMeasure<Value>) measureCache
+					.get(wrapped);
 
-		return wrapper;
+			if (wrapper == null) {
+				wrapper = new PushMeasure<Value>() {
+
+					@Override
+					public String getName() {
+						return wrapped.getName();
+					}
+
+					@Override
+					public String getDescription() {
+						return wrapped.getDescription();
+					}
+
+					@Override
+					public void register(MeasureListener<Value> listener) {
+						wrapped.register(wrapListener(listener));
+					}
+
+					@Override
+					public void unregister(MeasureListener<Value> listener) {
+						wrapped.unregister(wrapListener(listener));
+					}
+				};
+				measureCache.put(wrapped, wrapper);
+			} else {
+				// reuse existing one
+			}
+
+			return wrapper;
+		}
 	}
 
 	/**

--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/ListenerTimeMeasure.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/ListenerTimeMeasure.java
@@ -1,0 +1,152 @@
+package org.uma.jmetal.measure.impl;
+
+import java.util.WeakHashMap;
+
+import org.uma.jmetal.measure.MeasureListener;
+import org.uma.jmetal.measure.PullMeasure;
+import org.uma.jmetal.measure.PushMeasure;
+
+/**
+ * This measure is a facility to evaluate the time spent in
+ * {@link MeasureListener}s registered in {@link PushMeasure}s. In order to
+ * measure the time spent in a {@link MeasureListener}, you should wrap it by
+ * calling {@link #wrapListener(MeasureListener)}. The wrapper returned should
+ * be used instead of the original {@link MeasureListener} to allow the
+ * {@link ListenerTimeMeasure} to account for its execution time. If you want to
+ * wrap automatically all the {@link MeasureListener}s registered to a given
+ * {@link PushMeasure}, you can wrap the {@link PushMeasure} through
+ * {@link #wrapMeasure(PushMeasure)}: all the {@link MeasureListener}s
+ * registered to the wrapper will be wrapped too. You can restart the evaluation
+ * by calling {@link #reset()}.<br/>
+ * <br/>
+ * Notice that the time accounted is not the physical time but the processing
+ * time: if several listeners run in parallel, their execution time is summed as
+ * if they were running sequentially, thus you can have a measured time which is
+ * superior to the physical time spent. If you want to measure the physical time
+ * spent in the execution of parallel runs, you should use another way.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ */
+public class ListenerTimeMeasure extends SimplePullMeasure<Long> implements
+		PullMeasure<Long> {
+
+	private Long lastReset = 0L;
+	private Long time = 0L;
+	private final WeakHashMap<PushMeasure<?>, PushMeasure<?>> measureCache = new WeakHashMap<PushMeasure<?>, PushMeasure<?>>();
+	private final WeakHashMap<MeasureListener<?>, MeasureListener<?>> listenerCache = new WeakHashMap<MeasureListener<?>, MeasureListener<?>>();
+
+	/**
+	 * This method wrap a {@link MeasureListener} (the wrapped) into another one
+	 * (the wrapper). Any notification made via the wrapper will allow to
+	 * measure how much time has been spent by the wrapped to treat this
+	 * notification.<br/>
+	 * <br/>
+	 * The wrapped listener is not changed, thus it can be reused in other
+	 * {@link PushMeasure}s that we don't want to consider. If a wrapper has
+	 * already been made for the given wrapped, it will be returned and no new
+	 * one will be instantiated (weak references are used to not keep in memory
+	 * the unused wrappers).
+	 * 
+	 * @param wrapped
+	 *            the {@link MeasureListener} to wrap
+	 * @return the {@link MeasureListener} wrapper
+	 */
+	public <Value> MeasureListener<Value> wrapListener(
+			final MeasureListener<Value> wrapped) {
+		@SuppressWarnings("unchecked")
+		MeasureListener<Value> wrapper = (MeasureListener<Value>) listenerCache
+				.get(wrapped);
+
+		if (wrapper == null) {
+			wrapper = new MeasureListener<Value>() {
+				@Override
+				public void measureGenerated(Value value) {
+					long start = System.currentTimeMillis();
+					wrapped.measureGenerated(value);
+					long stop = System.currentTimeMillis();
+					time += stop - Math.max(start, lastReset);
+				}
+			};
+			listenerCache.put(wrapped, wrapper);
+		} else {
+			// reuse existing one
+		}
+
+		return wrapper;
+	}
+
+	/**
+	 * This method wrap a {@link PushMeasure} (the wrapped) into another one
+	 * (the wrapper). Any {@link MeasureListener} registered to the wrapper will
+	 * be automatically wrapped via {@link #wrapListener(MeasureListener)}. This
+	 * allows to ensure that any {@link MeasureListener} registered will be
+	 * considered, independently of who registers it or when it is registered.<br/>
+	 * <br/>
+	 * The wrapped measure is not changed, thus it can be reused to register
+	 * {@link MeasureListener}s that we don't want to consider. If a wrapper has
+	 * already been made for the given wrapped, it will be returned and no new
+	 * one will be instantiated (weak references are used to not keep in memory
+	 * the unused wrappers).
+	 * 
+	 * @param wrapped
+	 *            the {@link PushMeasure} to wrap
+	 * @return the {@link PushMeasure} wrapper
+	 */
+	public <Value> PushMeasure<Value> wrapMeasure(
+			final PushMeasure<Value> wrapped) {
+		@SuppressWarnings("unchecked")
+		PushMeasure<Value> wrapper = (PushMeasure<Value>) measureCache
+				.get(wrapped);
+
+		if (wrapper == null) {
+			wrapper = new PushMeasure<Value>() {
+
+				@Override
+				public String getName() {
+					return wrapped.getName();
+				}
+
+				@Override
+				public String getDescription() {
+					return wrapped.getDescription();
+				}
+
+				@Override
+				public void register(MeasureListener<Value> listener) {
+					wrapped.register(wrapListener(listener));
+				}
+
+				@Override
+				public void unregister(MeasureListener<Value> listener) {
+					wrapped.unregister(wrapListener(listener));
+				}
+			};
+			measureCache.put(wrapped, wrapper);
+		} else {
+			// reuse existing one
+		}
+
+		return wrapper;
+	}
+
+	/**
+	 * @return the time spent in the wrapped {@link MeasureListener}s
+	 */
+	@Override
+	public Long get() {
+		return time;
+	}
+
+	/**
+	 * This method reset the time measured to zero. Notice that
+	 * {@link MeasureListener}s which are still running will be affected
+	 * consequently: their execution time will be measured from the reset time,
+	 * not from their own starting time.
+	 */
+	public void reset() {
+		time = 0L;
+		lastReset = System.currentTimeMillis();
+	}
+
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
@@ -1,0 +1,265 @@
+package org.uma.jmetal.measure.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.uma.jmetal.measure.MeasureListener;
+import org.uma.jmetal.measure.PushMeasure;
+
+public class ListenerTimeMeasureTest {
+
+	private class FakeListener implements MeasureListener<Object> {
+
+		private final long executionTime;
+
+		public FakeListener(long executionTime) {
+			this.executionTime = executionTime;
+		}
+
+		@Override
+		public void measureGenerated(Object value) {
+			try {
+				Thread.sleep(executionTime);
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	};
+
+	@Test
+	public void testFakeListener() {
+		for (long expected : new Long[] { 5L, 10L, 20L }) {
+			FakeListener listener = new FakeListener(expected);
+			int rounds = 10;
+			int average = 0;
+			for (int i = 0; i < rounds; i++) {
+				long start = System.currentTimeMillis();
+				listener.measureGenerated(null);
+				long stop = System.currentTimeMillis();
+				long time = stop - start;
+
+				average += time;
+			}
+			average /= rounds;
+
+			// check we are within a range of 10% around the expected time
+			assertTrue("Time spent: " + average + " instead of " + expected,
+					average > expected * 0.9 && average < expected * 1.1);
+		}
+	}
+
+	@Test
+	public void testCountTimeInListeners() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		MeasureListener<Object> original10ms = new FakeListener(10);
+		MeasureListener<Object> wrapper10ms = measure
+				.wrapListener(original10ms);
+
+		MeasureListener<Object> original20ms = new FakeListener(20);
+		MeasureListener<Object> wrapper20ms = measure
+				.wrapListener(original20ms);
+
+		wrapper10ms.measureGenerated(null);
+		wrapper20ms.measureGenerated(null);
+		wrapper20ms.measureGenerated(null);
+		wrapper10ms.measureGenerated(null);
+		long expected = 60;
+
+		// check we are within a range of 10% around the expected time
+		assertTrue("Time spent: " + measure.get() + " instead of " + expected,
+				measure.get() > expected * 0.9
+						&& measure.get() < expected * 1.1);
+	}
+
+	@Test
+	public void testReturnSameWrapperForSameListener()
+			throws InterruptedException {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		MeasureListener<Object> wrapped = new FakeListener(10);
+		MeasureListener<Object> wrapper = measure.wrapListener(wrapped);
+
+		assertEquals(wrapper, measure.wrapListener(wrapped));
+		assertEquals(wrapper, measure.wrapListener(wrapped));
+		assertEquals(wrapper, measure.wrapListener(wrapped));
+	}
+
+	@Test
+	public void testForgetListenerWrapperIfNotUsedAnymore() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		MeasureListener<Object> wrapped = new FakeListener(10);
+		int lastHashCode = 0;
+		int differences = 0;
+		int rounds = 10;
+		for (int round = 0; round < rounds; round++) {
+			System.gc();
+			MeasureListener<Object> wrapper = measure.wrapListener(wrapped);
+			int hashCode = wrapper.hashCode();
+			if (lastHashCode != hashCode) {
+				differences++;
+			} else {
+				// maybe the same object (hashcode does not guarantee it)
+			}
+		}
+
+		// check the instance always changes with an error of 10%
+		assertTrue("Differences: " + differences + "/" + rounds,
+				differences > rounds * 0.9 && differences <= rounds);
+	}
+
+	@Test
+	public void testCountTimeInMeasures() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		SimplePushMeasure<Object> original10ms = new SimplePushMeasure<>();
+		PushMeasure<Object> wrapper10ms = measure.wrapMeasure(original10ms);
+		wrapper10ms.register(new FakeListener(5));
+		wrapper10ms.register(new FakeListener(5));
+
+		SimplePushMeasure<Object> original20ms = new SimplePushMeasure<>();
+		PushMeasure<Object> wrapper20ms = measure.wrapMeasure(original20ms);
+		wrapper20ms.register(new FakeListener(5));
+		wrapper20ms.register(new FakeListener(10));
+		wrapper20ms.register(new FakeListener(5));
+
+		original10ms.push(null);
+		original20ms.push(null);
+		original20ms.push(null);
+		original10ms.push(null);
+		long expected = 60;
+
+		// check we are within a range of 10% around the expected time
+		assertTrue("Time spent: " + measure.get() + " instead of " + expected,
+				measure.get() > expected * 0.9
+						&& measure.get() < expected * 1.1);
+	}
+
+	@Test
+	public void testReturnSameWrapperForSameMeasure() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		SimplePushMeasure<Object> wrapped = new SimplePushMeasure<Object>();
+		PushMeasure<Object> wrapper = measure.wrapMeasure(wrapped);
+
+		assertEquals(wrapper, measure.wrapMeasure(wrapped));
+		assertEquals(wrapper, measure.wrapMeasure(wrapped));
+		assertEquals(wrapper, measure.wrapMeasure(wrapped));
+	}
+
+	@Test
+	public void testForgetMeasureWrapperIfNotUsedAnymore() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		SimplePushMeasure<Object> wrapped = new SimplePushMeasure<Object>();
+		int lastHashCode = 0;
+		int differences = 0;
+		int rounds = 10;
+		for (int round = 0; round < rounds; round++) {
+			System.gc();
+			PushMeasure<Object> wrapper = measure.wrapMeasure(wrapped);
+			int hashCode = wrapper.hashCode();
+			if (lastHashCode != hashCode) {
+				differences++;
+			} else {
+				// maybe the same object (hashcode does not guarantee it)
+			}
+		}
+
+		// check the instance always changes with an error of 10%
+		assertTrue("Differences: " + differences + "/" + rounds,
+				differences > rounds * 0.9 && differences <= rounds);
+	}
+
+	@Test
+	public void testSameNameAndDescriptionThanOriginalMeasure() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		{
+			String name = "measure 1";
+			String description = null;
+			PushMeasure<Object> original = new SimplePushMeasure<>(name,
+					description);
+			PushMeasure<Object> wrapper = measure.wrapMeasure(original);
+			assertEquals(name, wrapper.getName());
+			assertEquals(description, wrapper.getDescription());
+		}
+
+		{
+			String name = "measure 2";
+			String description = "Some description";
+			PushMeasure<Object> original = new SimplePushMeasure<>(name,
+					description);
+			PushMeasure<Object> wrapper = measure.wrapMeasure(original);
+			assertEquals(name, wrapper.getName());
+			assertEquals(description, wrapper.getDescription());
+		}
+
+		{
+			String name = null;
+			String description = "Unidentified Java Object";
+			PushMeasure<Object> original = new SimplePushMeasure<>(name,
+					description);
+			PushMeasure<Object> wrapper = measure.wrapMeasure(original);
+			assertEquals(name, wrapper.getName());
+			assertEquals(description, wrapper.getDescription());
+		}
+	}
+
+	@Test
+	public void testResetToZeroWhenNoListenerIsRunning() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		MeasureListener<Object> original10ms = new FakeListener(10);
+		MeasureListener<Object> wrapper10ms = measure
+				.wrapListener(original10ms);
+
+		MeasureListener<Object> original20ms = new FakeListener(20);
+		MeasureListener<Object> wrapper20ms = measure
+				.wrapListener(original20ms);
+
+		wrapper10ms.measureGenerated(null);
+		wrapper20ms.measureGenerated(null);
+		wrapper20ms.measureGenerated(null);
+		wrapper10ms.measureGenerated(null);
+
+		measure.reset();
+		assertEquals(0, (long) measure.get());
+	}
+
+	@Test
+	public void testResetToCurrentTimeWhenListenerIsRunning() {
+		final ListenerTimeMeasure measure = new ListenerTimeMeasure();
+
+		MeasureListener<Object> original50ms = new FakeListener(50);
+		MeasureListener<Object> wrapper50ms = measure
+				.wrapListener(original50ms);
+
+		MeasureListener<Object> original50msWithReset = new MeasureListener<Object>() {
+
+			@Override
+			public void measureGenerated(Object value) {
+				try {
+					Thread.sleep(25);
+					measure.reset();
+					Thread.sleep(25);
+				} catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		};
+		MeasureListener<Object> wrapper50msWithReset = measure
+				.wrapListener(original50msWithReset);
+
+		wrapper50ms.measureGenerated(null);
+		wrapper50msWithReset.measureGenerated(null);
+		wrapper50ms.measureGenerated(null);
+		long expected = 75;
+
+		// check we are within a range of 10% around the expected time
+		assertTrue("Time spent: " + measure.get() + " instead of " + expected,
+				measure.get() > expected * 0.9
+						&& measure.get() < expected * 1.1);
+	}
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
@@ -73,6 +73,16 @@ public class ListenerTimeMeasureTest {
 	}
 
 	@Test
+	public void testExceptionOnNullListener() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+		try {
+			measure.wrapListener(null);
+			fail("No exception thrown");
+		} catch (IllegalArgumentException e) {
+		}
+	}
+
+	@Test
 	public void testReturnSameWrapperForSameListener()
 			throws InterruptedException {
 		ListenerTimeMeasure measure = new ListenerTimeMeasure();
@@ -134,6 +144,16 @@ public class ListenerTimeMeasureTest {
 		assertTrue("Time spent: " + measure.get() + " instead of " + expected,
 				measure.get() > expected * 0.9
 						&& measure.get() < expected * 1.1);
+	}
+
+	@Test
+	public void testExceptionOnNullMeasure() {
+		ListenerTimeMeasure measure = new ListenerTimeMeasure();
+		try {
+			measure.wrapMeasure(null);
+			fail("No exception thrown");
+		} catch (IllegalArgumentException e) {
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Add a measure to evaluate the processing time spent into push measure listeners. You can read the documentation, but here is the summary:
- you can wrap listeners to account for their execution time
- you can wrap push measures to automatically wrap any listener registered to them
- you can wrap managers to automatically wrap any push measure they provide
- this measure returns the total amount of time of all the listeners it has wrapped
- you can reset the measure to restart an evaluation

This measure relates to the issue #26 (performances paragraph in my first post) and should help evaluating the impact of the listeners on the algorithm execution:
> Last, but not least, the use of listeners. If an external entity registers a listener which makes some heavy computation, in a single thread program it means that your algorithm will wait for this listener to finish its work before to call the next one. And this algorithm will not come back to its own computation before it has finished to call all the registered listeners. This could have a significant impact on your execution time measures, and you have no control regarding the content of these listeners (and you are not supposed to have any from inside the algorithm). [...] the cleanest way I see now is to provide a measure which provides the time spent in measures management: a default implementation for `MeasureManager` which provides some methods to feed the measures and counting the time spent in these calls would make the trick without taking in charge additional responsibilities regarding the algorithm. As the manager is the one which provides the available measures (from the point of view of the external entity), it can freely add measures on its own and manage them without letting the algorithm knows about it (only the management of the measures provided by the algorithm are delegate to the algorithm).

Rather than creating a `MeasureManager`, I created this measure which allows to manage the different levels (listener/measure/manager), so it should be quite flexible.