### PR TITLE
Group ID and version are in common with the parent.

### DIFF
--- a/jmetal-algorithm/pom.xml
+++ b/jmetal-algorithm/pom.xml
@@ -2,16 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.uma.jmetal</groupId>
-    <artifactId>jmetal-algorithm</artifactId>
-    <version>5.0-Beta-30-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <parent>
         <groupId>org.uma.jmetal</groupId>
         <artifactId>jmetal</artifactId>
         <version>5.0-Beta-30-SNAPSHOT</version>
     </parent>
+    <artifactId>jmetal-algorithm</artifactId>
+    <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>jMetal algorithms (single- and multi-objective)</description>

--- a/jmetal-core/pom.xml
+++ b/jmetal-core/pom.xml
@@ -2,16 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.uma.jmetal</groupId>
-    <artifactId>jmetal-core</artifactId>
-    <version>5.0-Beta-30-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <parent>
         <groupId>org.uma.jmetal</groupId>
         <artifactId>jmetal</artifactId>
         <version>5.0-Beta-30-SNAPSHOT</version>
     </parent>
+    <artifactId>jmetal-core</artifactId>
+    <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>jMetal core classes (Algorithm, Solution, Problem, Operator, QualityIndicator) and basic utils</description>

--- a/jmetal-exec/pom.xml
+++ b/jmetal-exec/pom.xml
@@ -2,16 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.uma.jmetal</groupId>
-    <artifactId>jmetal-exec</artifactId>
-    <version>5.0-Beta-30-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <parent>
         <groupId>org.uma.jmetal</groupId>
         <artifactId>jmetal</artifactId>
         <version>5.0-Beta-30-SNAPSHOT</version>
     </parent>
+    <artifactId>jmetal-exec</artifactId>
+    <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Runners classes</description>

--- a/jmetal-problem/pom.xml
+++ b/jmetal-problem/pom.xml
@@ -2,16 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.uma.jmetal</groupId>
-    <artifactId>jmetal-problem</artifactId>
-    <version>5.0-Beta-30-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <parent>
         <groupId>org.uma.jmetal</groupId>
         <artifactId>jmetal</artifactId>
         <version>5.0-Beta-30-SNAPSHOT</version>
     </parent>
+    <artifactId>jmetal-problem</artifactId>
+    <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>jMetal problem classes, including single- and multi-objective benchmarks</description>


### PR DESCRIPTION
No need to mention them and Eclipse display a warning when you do so.