### PR TITLE
Generics on quality indicators

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/QualityIndicator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/QualityIndicator.java
@@ -33,6 +33,6 @@ import java.util.List;
  */
 public interface QualityIndicator extends Serializable, DescribedEntity {
   public double execute(Front frontA, Front frontB) ;
-  public double execute(List<? extends Solution> frontA, List<? extends Solution> frontB) ;
+  public <S extends Solution<?>> double execute(List<S> frontA, List<S> frontB) ;
   public String getName() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/hypervolume/impl/PISAHypervolume.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/hypervolume/impl/PISAHypervolume.java
@@ -40,8 +40,8 @@ return null ;
   }
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation object is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/hypervolume/impl/WFGHypervolume.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/hypervolume/impl/WFGHypervolume.java
@@ -26,7 +26,7 @@ public class WFGHypervolume extends SimpleDescribedEntity implements Hypervolume
   }
 
   @Override
-  public double execute(List<? extends Solution> frontA, List<? extends Solution> frontB) {
+  public <S extends Solution<?>> double execute(List<S> frontA, List<S> frontB) {
     return 0;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/Epsilon.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/Epsilon.java
@@ -58,8 +58,8 @@ public class Epsilon extends SimpleDescribedEntity implements QualityIndicator {
   }
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation list is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/ErrorRatio.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/ErrorRatio.java
@@ -49,8 +49,8 @@ public class ErrorRatio extends SimpleDescribedEntity implements QualityIndicato
   }
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation list is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/GeneralizedSpread.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/GeneralizedSpread.java
@@ -64,8 +64,8 @@ public class GeneralizedSpread extends SimpleDescribedEntity implements QualityI
   }
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation object is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/GenerationalDistance.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/GenerationalDistance.java
@@ -58,8 +58,8 @@ public class GenerationalDistance extends SimpleDescribedEntity implements Quali
   }
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation list is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/Hypervolume.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/Hypervolume.java
@@ -57,8 +57,8 @@ public class Hypervolume extends SimpleDescribedEntity implements QualityIndicat
   }
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation object is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/InvertedGenerationalDistance.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/InvertedGenerationalDistance.java
@@ -61,8 +61,8 @@ public class InvertedGenerationalDistance extends SimpleDescribedEntity implemen
   }
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation object is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/R2.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/R2.java
@@ -88,8 +88,8 @@ public class R2 extends SimpleDescribedEntity implements QualityIndicator{
   }
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation object is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/SetCoverage.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/SetCoverage.java
@@ -51,8 +51,8 @@ public class SetCoverage extends SimpleDescribedEntity implements QualityIndicat
   }
 
   @Override
-  public double execute(List<? extends Solution> solutionListA,
-      List<? extends Solution> solutionListB) {
+  public <S extends Solution<?>> double execute(List<S> solutionListA,
+      List<S> solutionListB) {
 
     if (solutionListA == null) {
       throw new JMetalException("The list A is null") ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/Spread.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/Spread.java
@@ -61,8 +61,8 @@ public class Spread extends SimpleDescribedEntity implements QualityIndicator {
 
 
   @Override
-  public double execute(List<? extends Solution> paretoFrontApproximation,
-      List<? extends Solution> trueParetoFront) {
+  public <S extends Solution<?>> double execute(List<S> paretoFrontApproximation,
+      List<S> trueParetoFront) {
 
     if (paretoFrontApproximation == null) {
       throw new JMetalException("The pareto front approximation object is null") ;


### PR DESCRIPTION
I think that you know there is a lot, lot, lot of work to do regarding the generics, because you let almost all of them empty thus they don't provide anything else than warnings. I have started revising them and I plan to go ahead with that, because we cannot say in the paper that we use generics to have a better control at compilation if it is to use them in such a way that they are useless. So here is an example of refinement and it would be nice that you do it with some others in order to build some habits. Otherwise you will just add warnings after warnings with useless empty generics.

Here is this one:
```
public interface QualityIndicator extends Serializable, DescribedEntity {
  public double execute(Front frontA, Front frontB) ;
  public double execute(List<? extends Solution> frontA, List<? extends Solution> frontB) ;
  public String getName() ;
}
```
First of all, 2 warnings tell you that you did not specify the parameters for `Solution` in the second method (1 warning per front).

Here, my assumption is that you don't care about which kind of `Solution` it is, because this interface is not intended to deal with specific types of data. And here is how it is translated:
```
  public double execute(List<? extends Solution<?>> frontA, List<? extends Solution<?>> frontB) ;
```
The question mark should be used when you **do not care** about the type (not when you don't know). Otherwise, it should be specified with a proper type or a parameter. When you do not specify any parameter by letting `Solution` alone, it is interpreted as `Solution<?>`. And now we will see why it is a problem.

So, what does that mean? It means that you can do all of that:
**SAME SOLUTION CLASS**
```
List<MySolution> frontA = ...;
List<MySolution> frontB = ...;
execute(frontA, frontB);
```
where `MySolution` is for instance a `Solution<String>`, but also:
**SAME SOLUTION PARAMETER**
```
List<Solution<Integer>> frontA = ...;
List<Solution<Integer>> frontB = ...;
execute(frontA, frontB);
```
as well as, by extension:
**SIMILAR SOLUTION CLASS**
```
List<MySolution1> frontA = ...;
List<MySolution2> frontB = ...;
execute(frontA, frontB);
```
where `MySolution1` and `MySolution2` are two different `Solution<Integer>`, but also:
**DIFFERENT SOLUTION PARAMETER**
```
List<Solution<Integer>> frontA = ...;
List<Solution<Double>> frontB = ...;
execute(frontA, frontB);
```
and so of course:
**DIFFERENT SOLUTION CLASS**
```
List<MySolution1> frontA = ...;
List<MySolution3> frontB = ...;
execute(frontA, frontB);
```
where `MySolution1 extends Solution<Integer>` and `MySolution3 extends Solution<Double>`

Now, I assume that you were not expecting the two last cases (maybe three), because you want to have two compatible fronts. If it is not the case, you can close this pull request, because I took the additional assumption that they should be compatible, but please read the remaining to know how a given interpretation is translated into generics.

If you want to forbid the two last cases, then you probably want to have the same parameters, and this come with this definition:
```
  public <T> double execute(List<? extends Solution<T>> frontA, List<? extends Solution<T>> frontB) ;
```
Thus, you are telling that there is a given type `T` which is common to both `Solutions`. In such a case, what you forbid are the cases where solutions are *fundamentally* different. `MySolution1` and `MySolution2` can still be used together, because they both extends `Solution<Integer>`, thus they are still similar.

Now let assume that you expect this `execute()` method to be used on solutions coming from the same algorithm, thus they should be as similar as possible (regarding their class, of course, not their data). Thus, you don't want similar solution classes like `MySolution1` and `MySolution2` to be used together. If you reject this assumption, you can close this pull request too, because I take it.

If you want to restrict to equivalent classes, then you should not say that only the parameters of the solutions are the same, but that the solutions themselves are the same, so you should also factor the part `? extends Solution`, not just the solution parameter:
```
public <T, S extends Solution<T>> double execute(List<S> frontA, List<S> frontB) ;
```
Here we factor the definition by creating `S`, and both lists use it, thus they deal with exactly the same type, so you don't allow anymore to use `MySolution1` and `MySolution2` even if they extend the same `Solution<Integer>`. Now you could say that this case should not hold anymore:
```
List<Solution<Integer>> frontA = ...;
List<Solution<Integer>> frontB = ...;
execute(frontA, frontB);
```
Because it is the same thing. But no, it is not: `MySolution1` and `MySolution2` are *specializations* of `Solution<Integer>`. So what happen concretely? Java takes the most restrictive types and assess their strict equivalence. Here, `MySolution1` is not `MySolution2` so it does not accept it. If you try it with a parent class and a child class, same thing. However, for the case where you provide two `Solution<Integer>`, then the most restrictive it can find is precisely this level. It cannot go further. And at this level, we can only assess the equivalence, thus it accepts it. Notice that you cannot cast the arguments to `List<Solution<Integer>>` in order to make it works, because the casting is effective on the root type (`List`), not on its parameters.

Now, if we look closer the definition:
```
public <T, S extends Solution<T>> double execute(List<S> frontA, List<S> frontB) ;
```
Here, it happens that the parameter of the solution `T` is used only once in `S extends Solution<T>`, thus it does not make any sense anymore to have it and we can rewrite it that way:
```
public <S extends Solution<?>> double execute(List<S> frontA, List<S> frontB) ;
```
We are still defining a single `S` which should be used for both lists, but we don't care about the solution parameter. You can add all the parameters you want, but at the end you can replace all the ones which are used only once by `?` and remove their definition, because what generics allow is to describe type equivalences. So if you use it once, no equivalence (which requires at least two elements) is described, so you can remove it.

This is the version I have used in this commit, and I have adapted the implementation correspondingly. If it is not what you want, feel free to close without merging, but please consider to fill your parameters in the future, otherwise you will just add work for revision, because not filling the generic parameters is like not using parameters at all.

Finally, maybe you noticed that we defined the generics at the level of the method itself, not at the class level (e.g. `QualityIndicator<S extends Solution<?>>`). When you introduce generics, it is better to start from the method. One need to declare a generic at the class level is when you want to have equivalences among different methods of the class. Thus, if you have two methods which should deal with the same type of data, then you will define their generic at the class level instead of the method level, because each method definition is independent. This also implies that it cannot change: by defining it at the method level, the concrete type used is determined at the call of the method. Calling the same method from the same instance with different data is possible, as long as they satisfy the constraints when we call the method. By having the generic at the class level, you fix it when you instantiate the instance, thus any call to the method will deal only with the type specified at the instanciation. This is the second case where you can be interested in defining a generic at the class level: when a given instance should always deal with the same type of data, and not adapt at each call.