### PR TITLE
Solution.copy() returns a typed solution.

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/Solution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/Solution.java
@@ -38,7 +38,7 @@ public interface Solution<T> extends Serializable {
   public int getNumberOfViolatedConstraints() ;
   public void setNumberOfViolatedConstraints(int numberOfViolatedConstraints) ;
 
-  public Solution copy() ;
+  public Solution<T> copy() ;
 
   public void setAttribute(Object id, Object value) ;
   public Object getAttribute(Object id) ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
@@ -88,7 +88,7 @@ public class DefaultBinarySolution extends AbstractGenericSolution<BinarySet, Bi
   }
 
   @Override
-  public Solution copy() {
+  public DefaultBinarySolution copy() {
     return new DefaultBinarySolution(this);
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -100,7 +100,7 @@ public class DefaultDoubleBinarySolution
   }
 
   @Override
-  public Solution copy() {
+  public DefaultDoubleBinarySolution copy() {
     return new DefaultDoubleBinarySolution(this);
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -54,7 +54,7 @@ public class DefaultDoubleSolution extends AbstractGenericSolution<Double, Doubl
   }
 
   @Override
-  public Solution copy() {
+  public DefaultDoubleSolution copy() {
     return new DefaultDoubleSolution(this);
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -93,7 +93,7 @@ public class DefaultIntegerDoubleSolution
   }
 
   @Override
-  public Solution copy() {
+  public DefaultIntegerDoubleSolution copy() {
     return new DefaultIntegerDoubleSolution(this);
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
@@ -57,7 +57,7 @@ public class DefaultIntegerPermutationSolution
   }
 
   @Override
-  public Solution copy() {
+  public DefaultIntegerPermutationSolution copy() {
     return new DefaultIntegerPermutationSolution(this);
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -57,7 +57,7 @@ public class DefaultIntegerSolution extends AbstractGenericSolution<Integer, Int
   }
 
   @Override
-  public Solution copy() {
+  public DefaultIntegerSolution copy() {
     return new DefaultIntegerSolution(this);
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/point/impl/PointSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/point/impl/PointSolution.java
@@ -94,7 +94,7 @@ public class PointSolution implements Solution<Double> {
 
   }
 
-  @Override public Solution copy() {
+  @Override public PointSolution copy() {
     return new PointSolution(this);
   }
 


### PR DESCRIPTION
A special case of generics here.

First, I fixed the warning on `Solution.copy()` by replacing:
```
public interface Solution<T> extends Serializable {
  ...
  public Solution copy() ;
  ...
}
```
by:
```
public interface Solution<T> extends Serializable {
  ...
  public Solution<T> copy() ;
  ...
}
```
This way, `copy()` is supposed to return the same type of `Solution` than the instance you make the copy from. This also allows advanced IDE to automatically replace `T` by the corresponding type in concrete implementations.

Now, this has then to be spread among the implementations of this interface, and for instance `DefaultDoubleSolution`, which implements `DoubleSolution` which extends `Solution<Double>`, should be rewritten that way:
```
@Override
public Solution<Double> copy() {
  ...
}
```
And this is how Eclipse for instance would create the method automatically because of adding `T` to the return type of `Solution.copy()`.

Now, this method has a specific use, because it is intended to provide a copy, or a clone, of the original instance. For any other method you could stop with the version above, but here you can rewrite the return type to be exactly the class itself:
```
@Override
public DefaultDoubleSolution copy() {
  ...
}
```
Semantically it makes sense, because you intend to provide an (new) instance of the exactly same type. You can do this change for two reason:
- the type is compatible (`DefaultDoubleSolution` is a `Solution<Double>`, changing it by `Solution<Object>` for instance would not work).
- the return type is not part of the signature of the method (a method is identified by its name and its argument types in order, the return type is not considered) so it can be changed without impacting the identification of the method.

This is what I did for each implementation of the copy method.