### PR TITLE
Parameters

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/Parameter.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/Parameter.java
@@ -1,0 +1,32 @@
+package org.uma.jmetal.parameter;
+
+import org.uma.jmetal.algorithm.Algorithm;
+
+/**
+ * A {@link Parameter} aims at describing the {@link Value} of a specific
+ * property, typically of an {@link Algorithm}, such that changing this
+ * {@link Value} would affect its behavior. As such, the {@link Parameter}
+ * allows to retrieve the current {@link Value} through {@link #get()} and
+ * change it through {@link #set(Object)}. It is also identified through its
+ * name ({@link #getName()}) and further detailed through its description (
+ * {@link #getDescription()}).
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ * @param <Value>
+ *            the type of value the {@link Parameter} can manage
+ */
+public interface Parameter<Value> {
+	/**
+	 * 
+	 * @param value
+	 *            the {@link Value} to give to this {@link Parameter}
+	 */
+	public void set(Value value);
+
+	/**
+	 * 
+	 * @return the current {@link Value} of the {@link Parameter}
+	 */
+	public Value get();
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/ParameterManager.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/ParameterManager.java
@@ -1,0 +1,23 @@
+package org.uma.jmetal.parameter;
+
+import java.util.Collection;
+
+/**
+ * A {@link ParameterManager} aims at managing a set of {@link Parameter}s.
+ * Typically, a {@link Parameterable} entity would create a single
+ * {@link ParameterManager} to store all the {@link Parameter}s it would like to
+ * use, each of them being identified by a key. The available keys are provided
+ * by {@link #getParameterKeys()} while retrieving a specific {@link Parameter}
+ * would be done through {@link #getParameter(Object)}.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ */
+public interface ParameterManager extends Iterable<Parameter<?>> {
+	/**
+	 * 
+	 * @return the set of {@link Parameter}s managed by this
+	 *         {@link ParameterManager}
+	 */
+	public Collection<Parameter<?>> getParameters();
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/Parameterable.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/Parameterable.java
@@ -1,0 +1,18 @@
+package org.uma.jmetal.parameter;
+
+/**
+ * A {@link Parameterable} entity is an entity which provides one or several
+ * {@link Parameter}s. To keep it simple, these {@link Parameter}s are provided
+ * through a {@link ParameterManager}.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ */
+public interface Parameterable {
+	/**
+	 * 
+	 * @return the {@link ParameterManager} which stores all the
+	 *         {@link Parameter}s supported by this {@link Parameterable} entity
+	 */
+	public ParameterManager getParameterManager();
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/configuration/Configuration.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/configuration/Configuration.java
@@ -1,0 +1,52 @@
+package org.uma.jmetal.parameter.configuration;
+
+import java.util.Collection;
+
+import org.uma.jmetal.parameter.Parameter;
+
+/**
+ * A {@link Configuration} corresponds to a set of {@link ConfigurationUnit}s,
+ * building a mapping between a set of {@link Parameter}s and some values that
+ * we can apply to them. The different {@link Parameter}s covered by this
+ * {@link Configuration} can be retrieved through {@link #getParameters()} and
+ * the complete {@link ConfigurationUnit} associated to each {@link Parameter}
+ * can be retrieved through {@link #getUnit(Parameter)}.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ */
+public interface Configuration extends Iterable<ConfigurationUnit<?>> {
+
+	/**
+	 * 
+	 * @return all the {@link Parameter}s covered by this {@link Configuration}
+	 */
+	public Collection<Parameter<?>> getParameters();
+
+	/**
+	 * 
+	 * @param parameter
+	 *            the {@link Parameter} to consider
+	 * @return the {@link ConfigurationUnit} which associates this
+	 *         {@link Parameter} with its {@link Value} in this
+	 *         {@link Configuration}
+	 */
+	public <Value> ConfigurationUnit<Value> getUnit(Parameter<Value> parameter);
+
+	/**
+	 * Set all the {@link Parameter}s of this {@link Configuration} to the
+	 * values they are associated with.
+	 * 
+	 * @see #isAllApplied()
+	 */
+	public void applyAll();
+
+	/**
+	 * 
+	 * @return <code>true</code> if all the {@link ConfigurationUnit}s are
+	 *         applied, <code>false</code> otherwise
+	 * @see #applyAll()
+	 */
+	public boolean isAllApplied();
+
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/configuration/ConfigurationUnit.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/configuration/ConfigurationUnit.java
@@ -1,0 +1,46 @@
+package org.uma.jmetal.parameter.configuration;
+
+import org.uma.jmetal.parameter.Parameter;
+
+/**
+ * A {@link ConfigurationUnit} identify a specific {@link Parameter} and a
+ * specific {@link Value} which can be applied to this {@link Parameter}. When
+ * {@link #apply()} is called, the {@link Parameter} is set to the {@link Value}
+ * .
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ * @param <Value>
+ *            the type of {@link Value} the {@link Parameter} supports
+ */
+public interface ConfigurationUnit<Value> {
+
+	/**
+	 * 
+	 * @return the {@link Parameter} targeted by this {@link ConfigurationUnit}
+	 */
+	public Parameter<Value> getParameter();
+
+	/**
+	 * 
+	 * @return the {@link Value} targeted by this {@link ConfigurationUnit}
+	 */
+	public Value getValue();
+
+	/**
+	 * Set the {@link Parameter} returned by {@link #getParameter()} to the
+	 * {@link Value} returned by {@link #getValue()}.
+	 * 
+	 * @see #isApplied()
+	 */
+	public void apply();
+
+	/**
+	 * 
+	 * @return <code>true</code> if the {@link Parameter} returned by
+	 *         {@link #getParameter()} is set to the {@link Value} returned by
+	 *         {@link #getValue()}, <code>false</code> otherwise
+	 * @see #apply()
+	 */
+	public boolean isApplied();
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/configuration/impl/ImmutableConfigurationUnit.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/configuration/impl/ImmutableConfigurationUnit.java
@@ -1,0 +1,65 @@
+package org.uma.jmetal.parameter.configuration.impl;
+
+import org.uma.jmetal.parameter.Parameter;
+import org.uma.jmetal.parameter.configuration.ConfigurationUnit;
+
+/**
+ * An {@link ImmutableConfigurationUnit} is a {@link ConfigurationUnit} which
+ * takes its {@link Parameter} and {@link Value} at the instantiation and can't
+ * change them afterward. However, the {@link Parameter} can still change its
+ * value and the method {@link #apply()} can be called to set the
+ * {@link Parameter} to the stored {@link Value}.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ * @param <Value>
+ */
+public class ImmutableConfigurationUnit<Value> implements
+		ConfigurationUnit<Value> {
+
+	private final Parameter<Value> parameter;
+	private final Value value;
+
+	/**
+	 * Create an {@link ImmutableConfigurationUnit} on the given
+	 * {@link Parameter} and {@link Value}.
+	 * 
+	 * @param parameter
+	 *            the {@link Parameter} to target
+	 * @param value
+	 *            the {@link Value} to target
+	 */
+	public ImmutableConfigurationUnit(Parameter<Value> parameter, Value value) {
+		if (parameter == null) {
+			throw new NullPointerException("No parameter provided");
+		} else {
+			this.parameter = parameter;
+			this.value = value;
+		}
+	}
+
+	@Override
+	public Parameter<Value> getParameter() {
+		return parameter;
+	}
+
+	@Override
+	public Value getValue() {
+		return value;
+	}
+
+	/**
+	 * Equivalent to <code>unit.getParameter().set(unit.getValue())</code>
+	 */
+	@Override
+	public void apply() {
+		parameter.set(value);
+	}
+
+	@Override
+	public boolean isApplied() {
+		Value current = parameter.get();
+		return current == value || current != null && current.equals(value);
+	}
+
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/configuration/impl/SimpleConfiguration.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/configuration/impl/SimpleConfiguration.java
@@ -1,0 +1,141 @@
+package org.uma.jmetal.parameter.configuration.impl;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.uma.jmetal.parameter.Parameter;
+import org.uma.jmetal.parameter.Parameterable;
+import org.uma.jmetal.parameter.configuration.Configuration;
+import org.uma.jmetal.parameter.configuration.ConfigurationUnit;
+
+public class SimpleConfiguration implements Configuration {
+
+	Map<Parameter<?>, ConfigurationUnit<?>> unitMap = new HashMap<Parameter<?>, ConfigurationUnit<?>>();
+
+	public SimpleConfiguration(ConfigurationUnit<?>... units) {
+		this(Arrays.asList(units));
+	}
+
+	public SimpleConfiguration(Iterable<ConfigurationUnit<?>> units) {
+		setAllUnits(units);
+	}
+
+	public SimpleConfiguration(Parameterable algorithm) {
+		for (Parameter<?> parameter : algorithm.getParameterManager()) {
+			storeValue(parameter);
+		}
+	}
+
+	private <Value> void storeValue(Parameter<Value> parameter) {
+		setUnit(new ImmutableConfigurationUnit<Value>(parameter,
+				parameter.get()));
+	}
+
+	@Override
+	public Collection<Parameter<?>> getParameters() {
+		return new LinkedList<>(unitMap.keySet());
+	}
+
+	public <Value> Value getValue(Parameter<Value> parameter) {
+		ConfigurationUnit<Value> unit = getUnit(parameter);
+		if (unit == null) {
+			return null;
+		} else {
+			return unit.getValue();
+		}
+	}
+
+	public <Value> void setValue(Parameter<Value> parameter, Value value) {
+		setUnit(new ImmutableConfigurationUnit<Value>(parameter, value));
+	}
+
+	public void removeValue(Parameter<?> parameter) {
+		removeUnit(parameter);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <Value> ConfigurationUnit<Value> getUnit(Parameter<Value> parameter) {
+		return (ConfigurationUnit<Value>) unitMap.get(parameter);
+	}
+
+	public <Value> void setUnit(ConfigurationUnit<Value> unit) {
+		unitMap.put(unit.getParameter(), unit);
+	}
+
+	public void removeUnit(Parameter<?> parameter) {
+		unitMap.remove(parameter);
+	}
+
+	public Map<Parameter<?>, ConfigurationUnit<?>> getAllUnits(
+			Iterable<Parameter<?>> parameters) {
+		Map<Parameter<?>, ConfigurationUnit<?>> map = new HashMap<>();
+		for (Parameter<?> parameter : parameters) {
+			map.put(parameter, getUnit(parameter));
+		}
+		return map;
+	}
+
+	public void setAllUnits(Iterable<ConfigurationUnit<?>> units) {
+		for (ConfigurationUnit<?> unit : units) {
+			setUnit(unit);
+		}
+	}
+
+	public void removeAllUnits(Iterable<Parameter<?>> parameters) {
+		for (Parameter<?> parameter : parameters) {
+			removeUnit(parameter);
+		}
+	}
+
+	public Map<Parameter<?>, Object> getAllValues(
+			Iterable<Parameter<?>> parameters) {
+		Map<Parameter<?>, Object> map = new HashMap<>();
+		for (Parameter<?> parameter : parameters) {
+			map.put(parameter, getValue(parameter));
+		}
+		return map;
+	}
+
+	public <Value> void setAllValues(Map<Parameter<Value>, Value> map) {
+		for (Entry<Parameter<Value>, Value> entry : map.entrySet()) {
+			Parameter<Value> parameter = entry.getKey();
+			Value value = entry.getValue();
+			setValue(parameter, value);
+		}
+	}
+
+	public void removeAllValues(Iterable<Parameter<?>> parameters) {
+		removeAllUnits(parameters);
+	}
+
+	@Override
+	public void applyAll() {
+		for (ConfigurationUnit<?> unit : this) {
+			unit.apply();
+		}
+	}
+
+	@Override
+	public boolean isAllApplied() {
+		for (ConfigurationUnit<?> unit : this) {
+			if (unit.isApplied()) {
+				// applied so far
+			} else {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public Iterator<ConfigurationUnit<?>> iterator() {
+		return unitMap.values().iterator();
+	}
+
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/impl/MeasurableParameter.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/impl/MeasurableParameter.java
@@ -1,0 +1,94 @@
+package org.uma.jmetal.parameter.impl;
+
+import org.uma.jmetal.measure.Measure;
+import org.uma.jmetal.measure.MeasureListener;
+import org.uma.jmetal.measure.MeasureManager;
+import org.uma.jmetal.measure.PullMeasure;
+import org.uma.jmetal.measure.PushMeasure;
+import org.uma.jmetal.measure.impl.SimplePushMeasure;
+import org.uma.jmetal.parameter.Parameter;
+import org.uma.jmetal.parameter.ParameterManager;
+import org.uma.jmetal.util.naming.impl.SimpleDescribedEntity;
+
+/**
+ * A {@link MeasurableParameter} aims at being usable both as a
+ * {@link Parameter} and a {@link Measure}. This way, one can store it both in a
+ * {@link ParameterManager} and a {@link MeasureManager}. You can directly
+ * instantiate a fully featured {@link MeasurableParameter} with
+ * {@link #MeasurableParameter()} or wrap an existing {@link Parameter} with
+ * {@link #MeasurableParameter(Parameter)}.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ */
+public class MeasurableParameter<Value> extends SimpleDescribedEntity implements
+		Parameter<Value>, PullMeasure<Value>, PushMeasure<Value> {
+
+	/**
+	 * The {@link Parameter} which will fulfill the {@link Parameter} and
+	 * {@link PullMeasure} requirements (method signatures are the same).
+	 */
+	private final Parameter<Value> parameter;
+	/**
+	 * The {@link PushMeasure} which will fulfill the {@link PushMeasure}
+	 * requirements.
+	 */
+	private final SimplePushMeasure<Value> pusher;
+
+	/**
+	 * Create an autonomous {@link MeasurableParameter}.
+	 */
+	public MeasurableParameter() {
+		this(new SimpleParameter<Value>());
+	}
+
+	/**
+	 * Create a {@link MeasurableParameter} based on an existing
+	 * {@link Parameter}. The {@link Parameter} provided is wrapped by this
+	 * {@link MeasurableParameter}, so any modification made to the
+	 * {@link Parameter} is applied to this {@link MeasurableParameter} too, and
+	 * vice-versa.<br/>
+	 * <br/>
+	 * <b>ATTENTION:</b> Although setting the {@link Value} of the original
+	 * {@link Parameter} changes the {@link Value} of the
+	 * {@link MeasurableParameter} wrapping it, no notification is sent by the
+	 * {@link MeasurableParameter} to the {@link MeasureListener}s registered
+	 * through {@link #register(MeasureListener)}. These notifications only
+	 * occur when the {@link MeasurableParameter} itself is used to change the
+	 * {@link Parameter}'s {@link Value}.
+	 * 
+	 * @param parameter
+	 *            the {@link Parameter} to wrap in this
+	 *            {@link MeasurableParameter}
+	 */
+	/*
+	 * TODO Find a solution to ensure that the modifications made to the wrapped
+	 * parameter generate a notification to the registered listeners.
+	 */
+	public MeasurableParameter(Parameter<Value> parameter) {
+		this.parameter = parameter;
+		this.pusher = new SimplePushMeasure<Value>();
+	}
+
+	@Override
+	public void set(Value value) {
+		parameter.set(value);
+		pusher.push(value);
+	}
+
+	@Override
+	public Value get() {
+		return parameter.get();
+	}
+
+	@Override
+	public void register(MeasureListener<Value> listener) {
+		pusher.register(listener);
+	}
+
+	@Override
+	public void unregister(MeasureListener<Value> listener) {
+		pusher.unregister(listener);
+	}
+
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/impl/SimpleParameter.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/impl/SimpleParameter.java
@@ -1,0 +1,65 @@
+package org.uma.jmetal.parameter.impl;
+
+import org.uma.jmetal.parameter.Parameter;
+import org.uma.jmetal.util.naming.impl.SimpleDescribedEntity;
+
+/**
+ * {@link SimpleParameter} is a basic implementation of {@link Parameter}. It
+ * provides a basic support for the most generic properties required by this
+ * interface.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ * @param <Value>
+ */
+public class SimpleParameter<Value> extends SimpleDescribedEntity implements
+		Parameter<Value> {
+
+	/**
+	 * The current {@link Value} of this {@link Parameter}.
+	 */
+	private Value value;
+
+	/**
+	 * Create a {@link SimpleParameter} with a given name and a given
+	 * description.
+	 * 
+	 * @param name
+	 *            the name of the {@link Parameter}
+	 * @param description
+	 *            the description of the {@link Parameter}
+	 */
+	public SimpleParameter(String name, String description) {
+		super(name, description);
+	}
+
+	/**
+	 * Create a {@link SimpleParameter} with a given name and a
+	 * <code>null</code> description.
+	 * 
+	 * @param name
+	 *            the name of the {@link Parameter}
+	 */
+	public SimpleParameter(String name) {
+		super(name);
+	}
+
+	/**
+	 * Create a {@link SimpleParameter} with the class name as its name and a
+	 * <code>null</code> description.
+	 * 
+	 */
+	public SimpleParameter() {
+		super();
+	}
+
+	@Override
+	public void set(Value value) {
+		this.value = value;
+	}
+
+	@Override
+	public Value get() {
+		return value;
+	}
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/parameter/impl/SimpleParameterManager.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/parameter/impl/SimpleParameterManager.java
@@ -1,0 +1,79 @@
+package org.uma.jmetal.parameter.impl;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.uma.jmetal.parameter.Parameter;
+import org.uma.jmetal.parameter.ParameterManager;
+
+/**
+ * This {@link SimpleParameterManager} provides a basic implementation to manage
+ * a collection of {@link Parameter}s. One can use the
+ * {@link #setParameter(Object, Parameter)} method to configure the
+ * {@link Parameter}s individually, or exploit the massive
+ * {@link #setAllParameters(Map)} to register a set of {@link Parameter}s at
+ * once. The corresponding removeXxx and getXxx methods are also available for
+ * each case.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * 
+ */
+public class SimpleParameterManager implements ParameterManager {
+
+	/**
+	 * The {@link Parameter}s registered to this {@link SimpleParameterManager}.
+	 */
+	private Collection<Parameter<?>> parameters = new HashSet<>();
+
+	@Override
+	public Collection<Parameter<?>> getParameters() {
+		return parameters;
+	}
+
+	/**
+	 * 
+	 * @param parameter
+	 *            the {@link Parameter} to register
+	 */
+	public void addParameter(Parameter<?> parameter) {
+		parameters.add(parameter);
+	}
+
+	/**
+	 * 
+	 * @param parameter
+	 *            the {@link Parameter} to remove
+	 */
+	public void removeParameter(Parameter<?> parameter) {
+		this.parameters.remove(parameter);
+	}
+
+	/**
+	 * Massive equivalent of {@link #addParameter(Parameter)}.
+	 * 
+	 * @param parameters
+	 *            the {@link Parameter}s to register with their corresponding
+	 *            keys
+	 */
+	public void addAllParameters(Collection<? extends Parameter<?>> parameters) {
+		this.parameters.addAll(parameters);
+	}
+
+	/**
+	 * Massive equivalent to {@link #removeParameter(Parameter)}.
+	 * 
+	 * @param parameters
+	 *            the {@link Parameter}s to remove
+	 */
+	public void removeAllParameters(
+			Collection<? extends Parameter<?>> parameters) {
+		this.parameters.removeAll(parameters);
+	}
+
+	@Override
+	public Iterator<Parameter<?>> iterator() {
+		return parameters.iterator();
+	}
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/parameter/configuration/impl/ImmutableConfigurationUnitTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/parameter/configuration/impl/ImmutableConfigurationUnitTest.java
@@ -1,0 +1,69 @@
+package org.uma.jmetal.parameter.configuration.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.uma.jmetal.parameter.Parameter;
+import org.uma.jmetal.parameter.impl.SimpleParameter;
+
+public class ImmutableConfigurationUnitTest {
+
+	@Test
+	public void testGetParameter() {
+		Parameter<Integer> parameter = new SimpleParameter<>();
+		Integer value = 3;
+		ImmutableConfigurationUnit<Integer> unit = new ImmutableConfigurationUnit<>(
+				parameter, value);
+		assertEquals(parameter, unit.getParameter());
+	}
+
+	@Test
+	public void testGetValue() {
+		Parameter<Integer> parameter = new SimpleParameter<>();
+		Integer value = 3;
+		ImmutableConfigurationUnit<Integer> unit = new ImmutableConfigurationUnit<>(
+				parameter, value);
+		assertEquals(value, unit.getValue());
+	}
+
+	@Test
+	public void testIsApplied() {
+		Parameter<Integer> parameter = new SimpleParameter<>();
+		Integer value = 3;
+		ImmutableConfigurationUnit<Integer> unit = new ImmutableConfigurationUnit<>(
+				parameter, value);
+
+		parameter.set(5);
+		assertFalse(unit.isApplied());
+
+		parameter.set(3);
+		assertTrue(unit.isApplied());
+
+		parameter.set(null);
+		assertFalse(unit.isApplied());
+	}
+
+	@Test
+	public void testApply() {
+		Parameter<Integer> parameter = new SimpleParameter<>();
+		Integer value = 3;
+		ImmutableConfigurationUnit<Integer> unit = new ImmutableConfigurationUnit<>(
+				parameter, value);
+
+		parameter.set(5);
+		unit.apply();
+		assertEquals(value, unit.getValue());
+		assertTrue(unit.isApplied());
+
+		parameter.set(3);
+		unit.apply();
+		assertEquals(value, unit.getValue());
+		assertTrue(unit.isApplied());
+
+		parameter.set(null);
+		unit.apply();
+		assertEquals(value, unit.getValue());
+		assertTrue(unit.isApplied());
+	}
+
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/parameter/impl/MeasurableParameterTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/parameter/impl/MeasurableParameterTest.java
@@ -1,0 +1,84 @@
+package org.uma.jmetal.parameter.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.uma.jmetal.measure.MeasureListener;
+import org.uma.jmetal.parameter.Parameter;
+
+/**
+ * Because the {@link MeasurableParameter} implements {@link Parameter},
+ * {@link MeasurableParameter} and {@link MeasurableParameter} interfaces, we
+ * extend {@link ParameterTest} to execute basic {@link Parameter} tests and add
+ * manually the tests of {@link PullMeasureTest} and {@link PushMeasureTest} to
+ * execute them too. If other tests are added to {@link ParameterTest}, they
+ * will be automatically added here, but for {@link PullMeasureTest} and
+ * {@link PushMeasureTest} they have to be added manually.
+ */
+public class MeasurableParameterTest {
+
+	@Test
+	public void testNotifiedWhenRegistered() {
+		final Integer[] lastReceived = { null };
+		MeasureListener<Integer> listener = new MeasureListener<Integer>() {
+
+			@Override
+			public void measureGenerated(Integer value) {
+				lastReceived[0] = value;
+			}
+		};
+		MeasurableParameter<Integer> parameter = new MeasurableParameter<>();
+		parameter.register(listener);
+
+		parameter.set(3);
+		assertEquals(3, (Object) lastReceived[0]);
+		parameter.set(null);
+		assertEquals(null, (Object) lastReceived[0]);
+		parameter.set(5);
+		assertEquals(5, (Object) lastReceived[0]);
+	}
+
+	@Test
+	public void testNotNotifiedWhenUnregistered() {
+		final Integer[] lastReceived = { null };
+		MeasureListener<Integer> listener = new MeasureListener<Integer>() {
+
+			@Override
+			public void measureGenerated(Integer value) {
+				lastReceived[0] = value;
+			}
+		};
+		MeasurableParameter<Integer> parameter = new MeasurableParameter<>();
+		parameter.register(listener);
+		parameter.unregister(listener);
+
+		parameter.set(3);
+		assertEquals(null, (Object) lastReceived[0]);
+		parameter.set(-45);
+		assertEquals(null, (Object) lastReceived[0]);
+	}
+
+	@Test
+	public void testSetGetAligned() {
+		MeasurableParameter<Integer> parameter = new MeasurableParameter<>();
+
+		parameter.set(3);
+		assertEquals(3, (Object) parameter.get());
+		parameter.set(null);
+		assertEquals(null, (Object) parameter.get());
+		parameter.set(5);
+		assertEquals(5, (Object) parameter.get());
+	}
+
+	@Test
+	public void testWrappedParameterValueAlignment() {
+		Parameter<Integer> original = new SimpleParameter<>();
+		MeasurableParameter<Integer> wrapper = new MeasurableParameter<>(
+				original);
+
+		wrapper.set(3);
+		assertEquals(3, (Object) original.get());
+		original.set(5);
+		assertEquals(5, (Object) wrapper.get());
+	}
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/parameter/impl/SimpleParameterManagerTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/parameter/impl/SimpleParameterManagerTest.java
@@ -1,0 +1,168 @@
+package org.uma.jmetal.parameter.impl;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.junit.Test;
+import org.mockito.asm.tree.analysis.Value;
+import org.uma.jmetal.parameter.Parameter;
+
+public class SimpleParameterManagerTest {
+
+	@Test
+	public void testStartEmpty() {
+		SimpleParameterManager manager = new SimpleParameterManager();
+		assertTrue(manager.getParameters().isEmpty());
+	}
+
+	@Test
+	public void testAddGetParameters() {
+		SimpleParameterManager manager = new SimpleParameterManager();
+		SimpleParameter<?> parameter1 = new SimpleParameter<>();
+		SimpleParameter<?> parameter2 = new SimpleParameter<>();
+		SimpleParameter<?> parameter3 = new SimpleParameter<>();
+
+		manager.addParameter(parameter1);
+		assertEquals(1, manager.getParameters().size());
+		assertTrue(manager.getParameters().contains(parameter1));
+		assertFalse(manager.getParameters().contains(parameter2));
+		assertFalse(manager.getParameters().contains(parameter3));
+
+		manager.addParameter(parameter2);
+		assertEquals(2, manager.getParameters().size());
+		assertTrue(manager.getParameters().contains(parameter1));
+		assertTrue(manager.getParameters().contains(parameter2));
+		assertFalse(manager.getParameters().contains(parameter3));
+
+		manager.addParameter(parameter3);
+		assertEquals(3, manager.getParameters().size());
+		assertTrue(manager.getParameters().contains(parameter1));
+		assertTrue(manager.getParameters().contains(parameter2));
+		assertTrue(manager.getParameters().contains(parameter3));
+	}
+
+	@Test
+	public void testRemoveParameter() {
+		SimpleParameterManager manager = new SimpleParameterManager();
+		SimpleParameter<?> parameter1 = new SimpleParameter<>();
+		SimpleParameter<?> parameter2 = new SimpleParameter<>();
+		SimpleParameter<?> parameter3 = new SimpleParameter<>();
+
+		manager.addParameter(parameter1);
+		manager.addParameter(parameter2);
+		manager.addParameter(parameter3);
+		assertEquals(3, manager.getParameters().size());
+		assertTrue(manager.getParameters().contains(parameter1));
+		assertTrue(manager.getParameters().contains(parameter2));
+		assertTrue(manager.getParameters().contains(parameter3));
+
+		manager.removeParameter(parameter1);
+		assertEquals(2, manager.getParameters().size());
+		assertFalse(manager.getParameters().contains(parameter1));
+		assertTrue(manager.getParameters().contains(parameter2));
+		assertTrue(manager.getParameters().contains(parameter3));
+
+		manager.removeParameter(parameter2);
+		assertEquals(1, manager.getParameters().size());
+		assertFalse(manager.getParameters().contains(parameter1));
+		assertFalse(manager.getParameters().contains(parameter2));
+		assertTrue(manager.getParameters().contains(parameter3));
+
+		manager.removeParameter(parameter3);
+		assertEquals(0, manager.getParameters().size());
+		assertFalse(manager.getParameters().contains(parameter1));
+		assertFalse(manager.getParameters().contains(parameter2));
+		assertFalse(manager.getParameters().contains(parameter3));
+	}
+
+	@Test
+	public void testAddMultipleParameters() {
+		SimpleParameter<?> parameter1 = new SimpleParameter<>();
+		SimpleParameter<?> parameter2 = new SimpleParameter<>();
+		SimpleParameter<?> parameter3 = new SimpleParameter<>();
+
+		SimpleParameterManager manager = new SimpleParameterManager();
+		manager.addAllParameters(Arrays.asList(parameter1, parameter2,
+				parameter3));
+		assertEquals(3, manager.getParameters().size());
+		assertTrue(manager.getParameters().contains(parameter1));
+		assertTrue(manager.getParameters().contains(parameter2));
+		assertTrue(manager.getParameters().contains(parameter3));
+	}
+
+	@Test
+	public void testRemoveMultipleParameters() {
+		SimpleParameter<?> parameter1 = new SimpleParameter<>();
+		SimpleParameter<?> parameter2 = new SimpleParameter<>();
+		SimpleParameter<?> parameter3 = new SimpleParameter<>();
+
+		SimpleParameterManager manager = new SimpleParameterManager();
+		manager.addAllParameters(Arrays.asList(parameter1, parameter2,
+				parameter3));
+		assertEquals(3, manager.getParameters().size());
+		assertTrue(manager.getParameters().contains(parameter1));
+		assertTrue(manager.getParameters().contains(parameter2));
+		assertTrue(manager.getParameters().contains(parameter3));
+
+		manager.removeAllParameters(Arrays.asList(parameter1, parameter3));
+		assertEquals(1, manager.getParameters().size());
+		assertFalse(manager.getParameters().contains(parameter1));
+		assertTrue(manager.getParameters().contains(parameter2));
+		assertFalse(manager.getParameters().contains(parameter3));
+
+		manager.removeAllParameters(Arrays.asList(parameter1, parameter2));
+		assertEquals(0, manager.getParameters().size());
+	}
+
+	@Test
+	public void testIteratorRecall() {
+		SimpleParameter<Value> parameter1 = new SimpleParameter<Value>();
+		SimpleParameter<Value> parameter2 = new SimpleParameter<Value>();
+		SimpleParameter<Value> parameter3 = new SimpleParameter<Value>();
+		SimpleParameter<Value> parameter4 = new SimpleParameter<Value>();
+
+		SimpleParameterManager manager = new SimpleParameterManager();
+		manager.addParameter(parameter1);
+		manager.addParameter(parameter2);
+		manager.addParameter(parameter3);
+		manager.addParameter(parameter4);
+		manager.removeParameter(parameter3);
+
+		Collection<Parameter<?>> remainingParameters = new LinkedList<>();
+		remainingParameters.add(parameter1);
+		remainingParameters.add(parameter2);
+		remainingParameters.add(parameter4);
+		for (Parameter<?> parameter : manager) {
+			remainingParameters.remove(parameter);
+		}
+		assertTrue(remainingParameters.toString(),
+				remainingParameters.isEmpty());
+	}
+
+	@Test
+	public void testIteratorPrecision() {
+		SimpleParameter<Value> parameter1 = new SimpleParameter<Value>();
+		SimpleParameter<Value> parameter2 = new SimpleParameter<Value>();
+		SimpleParameter<Value> parameter3 = new SimpleParameter<Value>();
+		SimpleParameter<Value> parameter4 = new SimpleParameter<Value>();
+
+		SimpleParameterManager manager = new SimpleParameterManager();
+		manager.addParameter(parameter1);
+		manager.addParameter(parameter2);
+		manager.addParameter(parameter3);
+		manager.addParameter(parameter4);
+		manager.removeParameter(parameter3);
+
+		Collection<Parameter<?>> expectedParameters = new LinkedList<>();
+		expectedParameters.add(parameter1);
+		expectedParameters.add(parameter2);
+		expectedParameters.add(parameter4);
+		for (Parameter<?> parameter : manager) {
+			assertTrue("" + parameter, expectedParameters.contains(parameter));
+		}
+	}
+
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/parameter/impl/SimpleParameterTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/parameter/impl/SimpleParameterTest.java
@@ -1,0 +1,20 @@
+package org.uma.jmetal.parameter.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class SimpleParameterTest {
+
+	@Test
+	public void testSetGetAligned() {
+		SimpleParameter<Integer> parameter = new SimpleParameter<>();
+
+		parameter.set(3);
+		assertEquals(3, (Object) parameter.get());
+		parameter.set(null);
+		assertEquals(null, (Object) parameter.get());
+		parameter.set(5);
+		assertEquals(5, (Object) parameter.get());
+	}
+}


### PR DESCRIPTION
Here are the basic stuff I had since a while to manage parameters. The basic use is the following:
- make `Algorithm extends Parameterable` and implement the additional method in concrete implementations
- you can use the `SimpleParameterManager` to have a basic manager
- for each algorithm, create a `Parameter` for each of its parameters (you can use `SimpleParameter` for simple value storage)

There is additional stuff called `Configuration` to manage settings, such that applying a configuration allows to set a bunch of parameters at once. Maybe we could rename it `Setting` (and `ConfigurationUnit` as `SettingUnit`) to reuse your terms.