### PR TITLE
Expliciting generics. Some fixes are inferred.

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSS.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSS.java
@@ -25,7 +25,6 @@ import org.uma.jmetal.operator.impl.localsearch.MutationLocalSearch;
 import org.uma.jmetal.problem.ConstrainedProblem;
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.archive.impl.CrowdingDistanceArchive;
 
 
@@ -42,9 +41,9 @@ import java.util.List;
  *   IEEE Transactions on Evolutionary Computation. Vol. 12,
  *   No. 4 (August 2008), pp. 439-457
  */
-public class ABYSS extends AbstractABYSS<DoubleSolution> {
+public class ABYSS extends AbstractABYSS {
   public ABYSS(int numberOfSubranges,int solutionSetSize, int refSet1Size, int refSet2Size, int archiveSize, int maxEvaluations,
-      CrowdingDistanceArchive archive,     CrossoverOperator crossoverOperator,MutationLocalSearch improvement, DoubleProblem problem){
+      CrowdingDistanceArchive<DoubleSolution> archive,     CrossoverOperator<DoubleSolution> crossoverOperator,MutationLocalSearch improvement, DoubleProblem problem){
     super(numberOfSubranges,solutionSetSize,refSet1Size,refSet2Size,archiveSize,maxEvaluations,archive,crossoverOperator,improvement,problem);
   }
   /**
@@ -115,7 +114,7 @@ public class ABYSS extends AbstractABYSS<DoubleSolution> {
           while (solutionSet.size() < solutionSetSize) {
             solution = diversificationGeneration();
             if(problem instanceof ConstrainedProblem){
-              ((ConstrainedProblem)problem).evaluateConstraints(solution);
+              ((ConstrainedProblem<DoubleSolution>)problem).evaluateConstraints(solution);
             }
 
             problem.evaluate(solution);
@@ -140,7 +139,7 @@ public class ABYSS extends AbstractABYSS<DoubleSolution> {
   }
 
   @Override
-  public List<? extends Solution<?>> getResult() {
+  public List<DoubleSolution> getResult() {
     return archive.getSolutionList();
   }
 
@@ -151,7 +150,7 @@ public class ABYSS extends AbstractABYSS<DoubleSolution> {
         solution = super.diversificationGeneration();
         problem.evaluate(solution);
         if(problem instanceof ConstrainedProblem) {
-          ((ConstrainedProblem)problem).evaluateConstraints(solution);
+          ((ConstrainedProblem<DoubleSolution>)problem).evaluateConstraints(solution);
         }
         evaluations++;
         solution = (DoubleSolution) improvementOperator.execute(solution);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSS.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSS.java
@@ -43,7 +43,7 @@ import java.util.List;
  */
 public class ABYSS extends AbstractABYSS {
   public ABYSS(int numberOfSubranges,int solutionSetSize, int refSet1Size, int refSet2Size, int archiveSize, int maxEvaluations,
-      CrowdingDistanceArchive<DoubleSolution> archive,     CrossoverOperator<DoubleSolution> crossoverOperator,MutationLocalSearch improvement, DoubleProblem problem){
+      CrowdingDistanceArchive<DoubleSolution> archive,     CrossoverOperator<DoubleSolution> crossoverOperator,MutationLocalSearch<DoubleSolution> improvement, DoubleProblem problem){
     super(numberOfSubranges,solutionSetSize,refSet1Size,refSet2Size,archiveSize,maxEvaluations,archive,crossoverOperator,improvement,problem);
   }
   /**
@@ -83,7 +83,7 @@ public class ABYSS extends AbstractABYSS {
             solution = refSet1.get(i);
             //solution.unMarked();
             marked.setAttribute(solution,false);
-            solution = (DoubleSolution) improvementOperator.execute(solution);
+            solution = improvementOperator.execute(solution);
             evaluations += improvementOperator.getEvaluations();
             solutionSet.add(solution);
           }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSS.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSS.java
@@ -140,7 +140,7 @@ public class ABYSS extends AbstractABYSS<DoubleSolution> {
   }
 
   @Override
-  public List<? extends Solution> getResult() {
+  public List<? extends Solution<?>> getResult() {
     return archive.getSolutionList();
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSBuilder.java
@@ -1,12 +1,12 @@
 package org.uma.jmetal.algorithm.multiobjective.abyss;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
 import org.uma.jmetal.operator.impl.localsearch.MutationLocalSearch;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
 import org.uma.jmetal.problem.DoubleProblem;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmBuilder;
 import org.uma.jmetal.util.archive.Archive;
 import org.uma.jmetal.util.archive.impl.CrowdingDistanceArchive;
@@ -19,20 +19,20 @@ import org.uma.jmetal.util.archive.impl.CrowdingDistanceArchive;
  *   IEEE Transactions on Evolutionary Computation. Vol. 12,
  *   No. 4 (August 2008), pp. 439-457
  */
-public class ABYSSBuilder implements AlgorithmBuilder {
+public class ABYSSBuilder implements AlgorithmBuilder<ABYSS> {
 
   private DoubleProblem problem     ; // The problem to solve
-  private CrossoverOperator crossoverOperator   ; // Crossover operator
+  private CrossoverOperator<DoubleSolution> crossoverOperator   ; // Crossover operator
   private MutationLocalSearch improvementOperator ; // Operator for improvement
-  private MutationOperator mutationOperator; // Mutation operator
+  private MutationOperator<DoubleSolution> mutationOperator; // Mutation operator
   private int numberOfSubranges; //subranges
   private int populationSize;//Maximum size of the population
   private int refSet1Size;//Maximum size of the reference set one
   private int refSet2Size;//Maximum size of the reference set two
   private int archiveSize;//Maximum size of the external archive
   private int maxEvaluations;//Maximum number of getEvaluations to carry out
-  private CrowdingDistanceArchive archive;
-  public ABYSSBuilder(DoubleProblem problem,Archive archive){
+  private CrowdingDistanceArchive<DoubleSolution> archive;
+  public ABYSSBuilder(DoubleProblem problem,Archive<DoubleSolution> archive){
     this.populationSize = 20;
     this.maxEvaluations = 25000;
     this.archiveSize = 100;
@@ -46,22 +46,22 @@ public class ABYSSBuilder implements AlgorithmBuilder {
     double mutationProbability= 1.0/problem.getNumberOfVariables();
     this.mutationOperator = new PolynomialMutation(mutationProbability,distributionIndex);
     int improvementRounds= 1;
-    this.archive =(CrowdingDistanceArchive)archive;
+    this.archive =(CrowdingDistanceArchive<DoubleSolution>)archive;
     this.improvementOperator = new MutationLocalSearch(improvementRounds,mutationOperator,this.archive,problem);
 
   }
 
   @Override
-  public Algorithm build() {
+  public ABYSS build() {
     return new ABYSS(numberOfSubranges,populationSize,refSet1Size,refSet2Size,archiveSize,maxEvaluations,
         archive,crossoverOperator,improvementOperator,problem);
   }
 
-  public CrossoverOperator getCrossoverOperator() {
+  public CrossoverOperator<DoubleSolution> getCrossoverOperator() {
     return crossoverOperator;
   }
 
-  public ABYSSBuilder setCrossoverOperator(CrossoverOperator crossoverOperator) {
+  public ABYSSBuilder setCrossoverOperator(CrossoverOperator<DoubleSolution> crossoverOperator) {
     this.crossoverOperator = crossoverOperator;
     return  this;
   }
@@ -75,11 +75,11 @@ public class ABYSSBuilder implements AlgorithmBuilder {
     return  this;
   }
 
-  public MutationOperator getMutationOperator() {
+  public MutationOperator<DoubleSolution> getMutationOperator() {
     return mutationOperator;
   }
 
-  public ABYSSBuilder setMutationOperator(MutationOperator mutationOperator) {
+  public ABYSSBuilder setMutationOperator(MutationOperator<DoubleSolution> mutationOperator) {
     this.mutationOperator = mutationOperator;
     return  this;
   }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSBuilder.java
@@ -66,11 +66,11 @@ public class ABYSSBuilder implements AlgorithmBuilder<ABYSS> {
     return  this;
   }
 
-  public MutationLocalSearch getImprovementOperator() {
+  public MutationLocalSearch<DoubleSolution> getImprovementOperator() {
     return improvementOperator;
   }
 
-  public ABYSSBuilder setImprovementOperator(MutationLocalSearch improvementOperator) {
+  public ABYSSBuilder setImprovementOperator(MutationLocalSearch<DoubleSolution> improvementOperator) {
     this.improvementOperator = improvementOperator;
     return  this;
   }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSBuilder.java
@@ -23,7 +23,7 @@ public class ABYSSBuilder implements AlgorithmBuilder<ABYSS> {
 
   private DoubleProblem problem     ; // The problem to solve
   private CrossoverOperator<DoubleSolution> crossoverOperator   ; // Crossover operator
-  private MutationLocalSearch improvementOperator ; // Operator for improvement
+  private MutationLocalSearch<DoubleSolution> improvementOperator ; // Operator for improvement
   private MutationOperator<DoubleSolution> mutationOperator; // Mutation operator
   private int numberOfSubranges; //subranges
   private int populationSize;//Maximum size of the population
@@ -47,7 +47,7 @@ public class ABYSSBuilder implements AlgorithmBuilder<ABYSS> {
     this.mutationOperator = new PolynomialMutation(mutationProbability,distributionIndex);
     int improvementRounds= 1;
     this.archive =(CrowdingDistanceArchive<DoubleSolution>)archive;
-    this.improvementOperator = new MutationLocalSearch(improvementRounds,mutationOperator,this.archive,problem);
+    this.improvementOperator = new MutationLocalSearch<DoubleSolution>(improvementRounds,mutationOperator,this.archive,problem);
 
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/AbstractABYSS.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/AbstractABYSS.java
@@ -36,7 +36,7 @@ import java.util.List;
  *   IEEE Transactions on Evolutionary Computation. Vol. 12,
  *   No. 4 (August 2008), pp. 439-457
  */
-public abstract class AbstractABYSS <S extends Solution> implements Algorithm<List<? extends Solution>> {
+public abstract class AbstractABYSS <S extends Solution<?>> implements Algorithm<List<? extends Solution<?>>> {
   /**
    * Stores the number of subranges in which each encodings.variable is divided. Used in
    * the diversification method. By default it takes the value 4 (see the method
@@ -102,10 +102,10 @@ public abstract class AbstractABYSS <S extends Solution> implements Algorithm<Li
   /**
    * Stores the comparators for dominance and equality, respectively
    */
-  protected Comparator<Solution> dominanceComparator;
-  protected Comparator<Solution> equalComparator;
-  protected Comparator<Solution> fitnessComparator;
-  protected Comparator<Solution> crowdingDistanceComparator;
+  protected Comparator<Solution<?>> dominanceComparator;
+  protected Comparator<Solution<?>> equalComparator;
+  protected Comparator<Solution<?>> fitnessComparator;
+  protected Comparator<Solution<?>> crowdingDistanceComparator;
 
   /**
    * Solution Marked Attributed
@@ -278,7 +278,7 @@ public abstract class AbstractABYSS <S extends Solution> implements Algorithm<Li
           double aux = SolutionUtils.distanceBetweenSolutions(solutionSet.get(j), individual);
 
           if (aux < distanceToSolutionListAttribute.getAttribute(individual)) {
-            Solution auxSolution = solutionSet.get(j);
+            Solution<?> auxSolution = solutionSet.get(j);
             distanceToSolutionListAttribute.setAttribute(auxSolution, aux);
           }
         }
@@ -291,7 +291,7 @@ public abstract class AbstractABYSS <S extends Solution> implements Algorithm<Li
           for (int k = 0; k < refSet2.size(); k++) {
             if (i != j) {
               double aux = SolutionUtils.distanceBetweenSolutions(refSet2.get(j), refSet2.get(k));
-              Solution auxSolution = refSet2.get(j);
+              Solution<?> auxSolution = refSet2.get(j);
               if (aux < distanceToSolutionListAttribute.getAttribute(auxSolution)) {
                 distanceToSolutionListAttribute.setAttribute(auxSolution, aux);
               }//if

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/AbstractABYSS.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/AbstractABYSS.java
@@ -36,7 +36,7 @@ import java.util.List;
  *   IEEE Transactions on Evolutionary Computation. Vol. 12,
  *   No. 4 (August 2008), pp. 439-457
  */
-public abstract class AbstractABYSS <S extends Solution<?>> implements Algorithm<List<? extends Solution<?>>> {
+public abstract class AbstractABYSS implements Algorithm<List<DoubleSolution>> {
   /**
    * Stores the number of subranges in which each encodings.variable is divided. Used in
    * the diversification method. By default it takes the value 4 (see the method
@@ -98,14 +98,14 @@ public abstract class AbstractABYSS <S extends Solution<?>> implements Algorithm
   /**
    * Fitness
    */
-  protected StrengthRawFitness strenghtRawFitness;
+  protected StrengthRawFitness<DoubleSolution> strenghtRawFitness;
   /**
    * Stores the comparators for dominance and equality, respectively
    */
-  protected Comparator<Solution<?>> dominanceComparator;
-  protected Comparator<Solution<?>> equalComparator;
-  protected Comparator<Solution<?>> fitnessComparator;
-  protected Comparator<Solution<?>> crowdingDistanceComparator;
+  protected Comparator<DoubleSolution> dominanceComparator;
+  protected Comparator<DoubleSolution> equalComparator;
+  protected Comparator<DoubleSolution> fitnessComparator;
+  protected Comparator<DoubleSolution> crowdingDistanceComparator;
 
   /**
    * Solution Marked Attributed
@@ -131,7 +131,7 @@ public abstract class AbstractABYSS <S extends Solution<?>> implements Algorithm
   /**
    * Stores the crossover operator
    */
-  protected CrossoverOperator crossoverOperator;
+  protected CrossoverOperator<DoubleSolution> crossoverOperator;
   /**
    * Maximum number of getEvaluations to carry out
    */
@@ -139,8 +139,8 @@ public abstract class AbstractABYSS <S extends Solution<?>> implements Algorithm
 
 
   public AbstractABYSS(int numberOfSubranges,int solutionSetSize, int refSet1Size, int refSet2Size,
-      int archiveSize, int maxEvaluations,Archive archive,
-      CrossoverOperator crossoverOperator,MutationLocalSearch improvementOperator,
+      int archiveSize, int maxEvaluations,Archive<DoubleSolution> archive,
+      CrossoverOperator<DoubleSolution> crossoverOperator,MutationLocalSearch improvementOperator,
       DoubleProblem problem) {
     this.numberOfSubranges=numberOfSubranges;
     this.solutionSetSize = solutionSetSize;
@@ -152,19 +152,19 @@ public abstract class AbstractABYSS <S extends Solution<?>> implements Algorithm
     this.maxEvaluations = maxEvaluations;
     this.evaluations=0;
     randomGenerator = JMetalRandom.getInstance();
-    strenghtRawFitness = new StrengthRawFitness();
+    strenghtRawFitness = new StrengthRawFitness<DoubleSolution>();
     solutionSet = new ArrayList<DoubleSolution>(solutionSetSize);
     refSet1 = new ArrayList<DoubleSolution>(refSet1Size);
     refSet2 = new ArrayList<DoubleSolution>(refSet2Size);
-    dominanceComparator = new DominanceComparator();
-    equalComparator = new EqualSolutionsComparator();
-    fitnessComparator = new StrengthFitnessComparator();
-    crowdingDistanceComparator = new CrowdingDistanceComparator();
+    dominanceComparator = new DominanceComparator<DoubleSolution>();
+    equalComparator = new EqualSolutionsComparator<DoubleSolution>();
+    fitnessComparator = new StrengthFitnessComparator<DoubleSolution>();
+    crowdingDistanceComparator = new CrowdingDistanceComparator<DoubleSolution>();
     this.improvementOperator = improvementOperator;
     marked = new MarkAttribute();
     distanceToSolutionListAttribute = new DistanceToSolutionListAttribute();
     subSet = new ArrayList<DoubleSolution>(solutionSetSize * 1000);
-    this.archive = (CrowdingDistanceArchive)archive;
+    this.archive = (CrowdingDistanceArchive<DoubleSolution>)archive;
     sumOfFrequencyValues       = new int[problem.getNumberOfVariables()] ;
     sumOfReverseFrequencyValues = new int[problem.getNumberOfVariables()] ;
     frequency       = new int[numberOfSubranges][problem.getNumberOfVariables()] ;
@@ -446,8 +446,8 @@ public abstract class AbstractABYSS <S extends Solution<?>> implements Algorithm
           problem.evaluate(offSpring.get(0));
           problem.evaluate(offSpring.get(1));
           if (problem instanceof  ConstrainedProblem) {
-            ((ConstrainedProblem)problem).evaluateConstraints(offSpring.get(0));
-            ((ConstrainedProblem)problem).evaluateConstraints(offSpring.get(1));
+            ((ConstrainedProblem<DoubleSolution>)problem).evaluateConstraints(offSpring.get(0));
+            ((ConstrainedProblem<DoubleSolution>)problem).evaluateConstraints(offSpring.get(1));
           }
           evaluations += 2;
           if (evaluations < maxEvaluations) {
@@ -469,8 +469,8 @@ public abstract class AbstractABYSS <S extends Solution<?>> implements Algorithm
         if ( !marked.getAttribute(parents.get(0)) || !marked.getAttribute(parents.get(1))) {//!parents[0].isMarked() || !parents[1].isMarked()
           offSpring = (List<DoubleSolution>) crossoverOperator.execute(parents);
           if (problem instanceof  ConstrainedProblem) {
-            ((ConstrainedProblem)problem).evaluateConstraints(offSpring.get(0));
-            ((ConstrainedProblem)problem).evaluateConstraints(offSpring.get(1));
+            ((ConstrainedProblem<DoubleSolution>)problem).evaluateConstraints(offSpring.get(0));
+            ((ConstrainedProblem<DoubleSolution>)problem).evaluateConstraints(offSpring.get(1));
           }
           problem.evaluate(offSpring.get(0));
           problem.evaluate(offSpring.get(1));

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/AbstractABYSS.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/AbstractABYSS.java
@@ -94,7 +94,7 @@ public abstract class AbstractABYSS implements Algorithm<List<DoubleSolution>> {
   /**
    * Stores the improvement operator
    */
-  protected MutationLocalSearch improvementOperator;
+  protected MutationLocalSearch<DoubleSolution> improvementOperator;
   /**
    * Fitness
    */
@@ -140,7 +140,7 @@ public abstract class AbstractABYSS implements Algorithm<List<DoubleSolution>> {
 
   public AbstractABYSS(int numberOfSubranges,int solutionSetSize, int refSet1Size, int refSet2Size,
       int archiveSize, int maxEvaluations,Archive<DoubleSolution> archive,
-      CrossoverOperator<DoubleSolution> crossoverOperator,MutationLocalSearch improvementOperator,
+      CrossoverOperator<DoubleSolution> crossoverOperator,MutationLocalSearch<DoubleSolution> improvementOperator,
       DoubleProblem problem) {
     this.numberOfSubranges=numberOfSubranges;
     this.solutionSetSize = solutionSetSize;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss2/AbYSS.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss2/AbYSS.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 11/6/15.
  */
-public class AbYSS<S extends Solution> extends AbstractScatterSearch<S, List<S>> {
+public class AbYSS<S extends Solution<?>> extends AbstractScatterSearch<S, List<S>> {
   protected final int maxEvaluations ;
   protected final Problem<S> problem;
   protected final int referenceSet1Size ;
@@ -21,13 +21,13 @@ public class AbYSS<S extends Solution> extends AbstractScatterSearch<S, List<S>>
 
   protected Archive<S> archive ;
   protected LocalSearchOperator<S> localSearch ;
-  protected CrossoverOperator<List<S>, List<S>> crossover ;
+  protected CrossoverOperator<S> crossover ;
   protected int evaluations;
 
 
   public AbYSS(Problem<S> problem, int maxEvaluations, int populationSize, int referenceSet1Size,
       int referenceSet2Size, int archiveSize, Archive<S> archive, LocalSearchOperator<S> localSearch,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator) {
+      CrossoverOperator<S> crossoverOperator) {
     setPopulationSize(populationSize);
     this.problem = problem ;
     this.maxEvaluations = maxEvaluations ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3.java
@@ -46,28 +46,28 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
   protected int maxIterations;
   protected int iterations;
 
-  protected Comparator dominanceComparator;
+  protected Comparator<DoubleSolution> dominanceComparator;
 
-  protected Ranking ranking;
-  protected DensityEstimator crowdingDistance;
+  protected Ranking<DoubleSolution> ranking;
+  protected DensityEstimator<DoubleSolution> crowdingDistance;
 
-  protected SolutionListEvaluator evaluator;
+  protected SolutionListEvaluator<DoubleSolution> evaluator;
 
   /**
    * Constructor
    */
   public GDE3(DoubleProblem problem, int populationSize, int maxIterations,
       DifferentialEvolutionSelection selection, DifferentialEvolutionCrossover crossover,
-      SolutionListEvaluator evaluator) {
+      SolutionListEvaluator<DoubleSolution> evaluator) {
     this.problem = problem;
     this.populationSize = populationSize;
     this.maxIterations = maxIterations;
     this.crossoverOperator = crossover;
     this.selectionOperator = selection;
 
-    dominanceComparator = new DominanceComparator();
-    ranking = new DominanceRanking();
-    crowdingDistance = new CrowdingDistance();
+    dominanceComparator = new DominanceComparator<DoubleSolution>();
+    ranking = new DominanceRanking<DoubleSolution>();
+    crowdingDistance = new CrowdingDistance<DoubleSolution>();
 
     this.evaluator = evaluator ;
   }
@@ -153,7 +153,7 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
         tmpList.add(population.get(i));
       }
     }
-    Ranking ranking = computeRanking(tmpList);
+    Ranking<DoubleSolution> ranking = computeRanking(tmpList);
     List<DoubleSolution> pop = crowdingDistanceSelection(ranking);
 
     return pop;
@@ -164,15 +164,15 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
   }
 
 
-  protected Ranking computeRanking(List<DoubleSolution> solutionList) {
-    Ranking ranking = new DominanceRanking();
+  protected Ranking<DoubleSolution> computeRanking(List<DoubleSolution> solutionList) {
+    Ranking<DoubleSolution> ranking = new DominanceRanking<DoubleSolution>();
     ranking.computeRanking(solutionList);
 
     return ranking;
   }
 
-  protected List<DoubleSolution> crowdingDistanceSelection(Ranking ranking) {
-    CrowdingDistance crowdingDistance = new CrowdingDistance();
+  protected List<DoubleSolution> crowdingDistanceSelection(Ranking<DoubleSolution> ranking) {
+    CrowdingDistance<DoubleSolution> crowdingDistance = new CrowdingDistance<DoubleSolution>();
     List<DoubleSolution> population = new ArrayList<>(populationSize);
     int rankingIndex = 0;
     while (populationIsNotFull(population)) {
@@ -192,12 +192,12 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
     return population.size() < populationSize;
   }
 
-  protected boolean subfrontFillsIntoThePopulation(Ranking ranking, int rank,
+  protected boolean subfrontFillsIntoThePopulation(Ranking<DoubleSolution> ranking, int rank,
       List<DoubleSolution> population) {
     return ranking.getSubfront(rank).size() < (populationSize - population.size());
   }
 
-  protected void addRankedSolutionsToPopulation(Ranking ranking, int rank,
+  protected void addRankedSolutionsToPopulation(Ranking<DoubleSolution> ranking, int rank,
       List<DoubleSolution> population) {
     List<DoubleSolution> front;
 
@@ -208,11 +208,11 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
     }
   }
 
-  protected void addLastRankedSolutionsToPopulation(Ranking ranking, int rank,
+  protected void addLastRankedSolutionsToPopulation(Ranking<DoubleSolution> ranking, int rank,
       List<DoubleSolution> population) {
     List<DoubleSolution> currentRankedFront = ranking.getSubfront(rank);
 
-    Collections.sort(currentRankedFront, new CrowdingDistanceComparator());
+    Collections.sort(currentRankedFront, new CrowdingDistanceComparator<DoubleSolution>());
 
     int i = 0;
     while (population.size() < populationSize) {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3Builder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3Builder.java
@@ -21,11 +21,14 @@
 
 package org.uma.jmetal.algorithm.multiobjective.gde3;
 
-import org.uma.jmetal.algorithm.Algorithm;
-import org.uma.jmetal.operator.Operator;
+import java.util.List;
+
+import org.uma.jmetal.operator.CrossoverOperator;
+import org.uma.jmetal.operator.SelectionOperator;
 import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.operator.impl.selection.DifferentialEvolutionSelection;
 import org.uma.jmetal.problem.DoubleProblem;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
 import org.uma.jmetal.util.AlgorithmBuilder;
@@ -33,7 +36,7 @@ import org.uma.jmetal.util.AlgorithmBuilder;
 /**
  * This class implements the GDE3 algorithm
  */
-public class GDE3Builder implements AlgorithmBuilder {
+public class GDE3Builder implements AlgorithmBuilder<GDE3> {
   private DoubleProblem problem;
   protected int populationSize;
   protected int maxIterations;
@@ -41,7 +44,7 @@ public class GDE3Builder implements AlgorithmBuilder {
   protected DifferentialEvolutionCrossover crossoverOperator;
   protected DifferentialEvolutionSelection selectionOperator;
 
-  protected SolutionListEvaluator evaluator;
+  protected SolutionListEvaluator<DoubleSolution> evaluator;
 
   /** Constructor */
   public GDE3Builder(DoubleProblem problem) {
@@ -50,7 +53,7 @@ public class GDE3Builder implements AlgorithmBuilder {
     populationSize = 100 ;
     selectionOperator = new DifferentialEvolutionSelection();
     crossoverOperator = new DifferentialEvolutionCrossover() ;
-    evaluator = new SequentialSolutionListEvaluator() ;
+    evaluator = new SequentialSolutionListEvaluator<DoubleSolution>() ;
   }
 
   /* Setters */
@@ -78,22 +81,22 @@ public class GDE3Builder implements AlgorithmBuilder {
     return this;
   }
 
-  public GDE3Builder setSolutionSetEvaluator(SolutionListEvaluator evaluator) {
+  public GDE3Builder setSolutionSetEvaluator(SolutionListEvaluator<DoubleSolution> evaluator) {
     this.evaluator = evaluator ;
 
     return this ;
   }
 
-  public Algorithm build() {
+  public GDE3 build() {
     return new GDE3(problem, populationSize, maxIterations, selectionOperator, crossoverOperator, evaluator) ;
   }
 
   /* Getters */
-  public Operator getCrossoverOperator() {
+  public CrossoverOperator<DoubleSolution> getCrossoverOperator() {
     return crossoverOperator;
   }
 
-  public Operator getSelectionOperator() {
+  public SelectionOperator<List<DoubleSolution>, List<DoubleSolution>> getSelectionOperator() {
     return selectionOperator;
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/ibea/IBEABuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/ibea/IBEABuilder.java
@@ -23,6 +23,8 @@
 
 package org.uma.jmetal.algorithm.multiobjective.ibea;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.SelectionOperator;
@@ -30,26 +32,27 @@ import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
 import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
 import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmBuilder;
 
 /**
  * This class implements the IBEA algorithm
  */
-public class IBEABuilder implements AlgorithmBuilder {
-  private Problem problem;
+public class IBEABuilder implements AlgorithmBuilder<IBEA<DoubleSolution>> {
+  private Problem<DoubleSolution> problem;
   private int populationSize;
   private int archiveSize;
   private int maxEvaluations;
 
-  private CrossoverOperator crossover;
-  private MutationOperator mutation;
-  private SelectionOperator selection;
+  private CrossoverOperator<DoubleSolution> crossover;
+  private MutationOperator<DoubleSolution> mutation;
+  private SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
   /**
    * Constructor
    * @param problem
    */
-  public IBEABuilder(Problem problem) {
+  public IBEABuilder(Problem<DoubleSolution> problem) {
     this.problem = problem;
     populationSize = 100;
     archiveSize = 100;
@@ -63,7 +66,7 @@ public class IBEABuilder implements AlgorithmBuilder {
     double mutationDistributionIndex = 20.0;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
 
-    selection = new BinaryTournamentSelection();
+    selection = new BinaryTournamentSelection<DoubleSolution>();
   }
 
   /* Getters */
@@ -79,15 +82,15 @@ public class IBEABuilder implements AlgorithmBuilder {
     return maxEvaluations;
   }
 
-  public CrossoverOperator getCrossover() {
+  public CrossoverOperator<DoubleSolution> getCrossover() {
     return crossover;
   }
 
-  public MutationOperator getMutation() {
+  public MutationOperator<DoubleSolution> getMutation() {
     return mutation;
   }
 
-  public SelectionOperator getSelection() {
+  public SelectionOperator<List<DoubleSolution>, DoubleSolution> getSelection() {
     return selection;
   }
 
@@ -110,26 +113,26 @@ public class IBEABuilder implements AlgorithmBuilder {
     return this;
   }
 
-  public IBEABuilder setCrossover(CrossoverOperator crossover) {
+  public IBEABuilder setCrossover(CrossoverOperator<DoubleSolution> crossover) {
     this.crossover = crossover;
 
     return this;
   }
 
-  public IBEABuilder setMutation(MutationOperator mutation) {
+  public IBEABuilder setMutation(MutationOperator<DoubleSolution> mutation) {
     this.mutation = mutation;
 
     return this;
   }
 
-  public IBEABuilder setSelection(SelectionOperator selection) {
+  public IBEABuilder setSelection(SelectionOperator<List<DoubleSolution>, DoubleSolution> selection) {
     this.selection = selection;
 
     return this;
   }
 
-  public IBEA build() {
-    return new IBEA(problem, populationSize, archiveSize, maxEvaluations, selection, crossover,
+  public IBEA<DoubleSolution> build() {
+    return new IBEA<DoubleSolution>(problem, populationSize, archiveSize, maxEvaluations, selection, crossover,
         mutation);
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCell.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCell.java
@@ -38,7 +38,7 @@ public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, L
   private CrowdingDistanceArchive<S> archive;
   protected final Problem<S> problem;
 
-  private Comparator<Solution<?>> dominanceComparator;
+  private Comparator<S> dominanceComparator;
   private LocationAttribute<S> location;
 
   /**
@@ -55,7 +55,7 @@ public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, L
    */
   public MOCell(Problem<S> problem, int maxEvaluations, int populationSize, int archiveSize,
       Neighborhood<S> neighborhood,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
       SelectionOperator<List<S>, S> selectionOperator, SolutionListEvaluator<S> evaluator) {
     super();
     this.problem = problem;
@@ -67,7 +67,7 @@ public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, L
     this.crossoverOperator = crossoverOperator;
     this.mutationOperator = mutationOperator;
     this.selectionOperator = selectionOperator;
-    this.dominanceComparator = new DominanceComparator() ;
+    this.dominanceComparator = new DominanceComparator<S>() ;
 
 
     this.evaluator = evaluator ;
@@ -173,7 +173,7 @@ public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, L
       crowdingDistance.computeDensityEstimator(rank.getSubfront(j));
     }
 
-    Collections.sort(this.currentNeighbors,new RankingAndCrowdingDistanceComparator());
+    Collections.sort(this.currentNeighbors,new RankingAndCrowdingDistanceComparator<S>());
     S worst = this.currentNeighbors.get(this.currentNeighbors.size()-1);
 
     if (location.getAttribute(worst) == -1) { //The worst is the offspring

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCell.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCell.java
@@ -24,7 +24,7 @@ import java.util.*;
  *
  * @param <S>
  */
-public class MOCell<S extends Solution> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
   protected int evaluations;
   protected int maxEvaluations;
   protected int populationSize;
@@ -38,7 +38,7 @@ public class MOCell<S extends Solution> extends AbstractGeneticAlgorithm<S, List
   private CrowdingDistanceArchive<S> archive;
   protected final Problem<S> problem;
 
-  private Comparator<Solution> dominanceComparator;
+  private Comparator<Solution<?>> dominanceComparator;
   private LocationAttribute<S> location;
 
   /**
@@ -56,7 +56,7 @@ public class MOCell<S extends Solution> extends AbstractGeneticAlgorithm<S, List
   public MOCell(Problem<S> problem, int maxEvaluations, int populationSize, int archiveSize,
       Neighborhood<S> neighborhood,
       CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
-      SelectionOperator selectionOperator, SolutionListEvaluator<S> evaluator) {
+      SelectionOperator<List<S>, S> selectionOperator, SolutionListEvaluator<S> evaluator) {
     super();
     this.problem = problem;
     this.maxEvaluations = maxEvaluations;
@@ -165,10 +165,10 @@ public class MOCell<S extends Solution> extends AbstractGeneticAlgorithm<S, List
     currentNeighbors.add(offspringPopulation.get(0));
     location.setAttribute(offspringPopulation.get(0), -1);
 
-    Ranking rank = new DominanceRanking();
+    Ranking<S> rank = new DominanceRanking<S>();
     rank.computeRanking(currentNeighbors);
 
-    CrowdingDistance crowdingDistance = new CrowdingDistance();
+    CrowdingDistance<S> crowdingDistance = new CrowdingDistance<S>();
     for (int j = 0; j < rank.getNumberOfSubfronts(); j++) {
       crowdingDistance.computeDensityEstimator(rank.getSubfront(j));
     }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCellBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCellBuilder.java
@@ -1,6 +1,5 @@
 package org.uma.jmetal.algorithm.multiobjective.mocell;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.SelectionOperator;
@@ -20,7 +19,7 @@ import java.util.List;
 /**
  * Created by juanjo
  *  */
-public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
+public class MOCellBuilder<S extends Solution<?>> implements AlgorithmBuilder<MOCell<S>> {
   public enum MOCellVariant {MOCell, SteadyStateMOCell, Measures}
 
   /**
@@ -30,16 +29,16 @@ public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
   private int maxEvaluations;
   private int populationSize;
   private int archiveSize ;
-  private CrossoverOperator<List<S>, List<S>>  crossoverOperator;
+  private CrossoverOperator<S>  crossoverOperator;
   private MutationOperator<S> mutationOperator;
-  private SelectionOperator selectionOperator;
-  private SolutionListEvaluator evaluator;
+  private SelectionOperator<List<S>,S> selectionOperator;
+  private SolutionListEvaluator<S> evaluator;
   private Neighborhood<S> neighborhood ;
 
   /**
    * MOCellBuilder constructor
    */
-  public MOCellBuilder(Problem<S> problem, CrossoverOperator<List<S>, List<S>> crossoverOperator,
+  public MOCellBuilder(Problem<S> problem, CrossoverOperator<S> crossoverOperator,
       MutationOperator<S> mutationOperator) {
     this.problem = problem;
     maxEvaluations = 25000;
@@ -47,12 +46,12 @@ public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
     archiveSize = 100 ;
     this.crossoverOperator = crossoverOperator ;
     this.mutationOperator = mutationOperator ;
-    selectionOperator = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
-    this.neighborhood = new C9((int)Math.sqrt(populationSize), (int)Math.sqrt(populationSize)) ;
-    evaluator = new SequentialSolutionListEvaluator();
+    selectionOperator = new BinaryTournamentSelection<S>(new RankingAndCrowdingDistanceComparator<S>());
+    this.neighborhood = new C9<S>((int)Math.sqrt(populationSize), (int)Math.sqrt(populationSize)) ;
+    evaluator = new SequentialSolutionListEvaluator<S>();
   }
 
-  public MOCellBuilder setMaxEvaluations(int maxEvaluations) {
+  public MOCellBuilder<S> setMaxEvaluations(int maxEvaluations) {
     if (maxEvaluations < 0) {
       throw new JMetalException("maxEvaluations is negative: " + maxEvaluations);
     }
@@ -61,7 +60,7 @@ public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public MOCellBuilder setPopulationSize(int populationSize) {
+  public MOCellBuilder<S> setPopulationSize(int populationSize) {
     if (populationSize < 0) {
       throw new JMetalException("Population size is negative: " + populationSize);
     }
@@ -71,7 +70,7 @@ public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public MOCellBuilder setArchiveSize(int archiveSize) {
+  public MOCellBuilder<S> setArchiveSize(int archiveSize) {
     if (archiveSize < 0) {
       throw new JMetalException("archive size is negative: " + populationSize);
     }
@@ -81,13 +80,13 @@ public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public MOCellBuilder setNeighborhood(Neighborhood<S> neighborhood) {
+  public MOCellBuilder<S> setNeighborhood(Neighborhood<S> neighborhood) {
     this.neighborhood = neighborhood;
 
     return this;
   }
 
-  public MOCellBuilder setSelectionOperator(SelectionOperator selectionOperator) {
+  public MOCellBuilder<S> setSelectionOperator(SelectionOperator<List<S>,S> selectionOperator) {
     if (selectionOperator == null) {
       throw new JMetalException("selectionOperator is null");
     }
@@ -96,7 +95,7 @@ public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public MOCellBuilder setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public MOCellBuilder<S> setSolutionListEvaluator(SolutionListEvaluator<S> evaluator) {
     if (evaluator == null) {
       throw new JMetalException("evaluator is null");
     }
@@ -105,15 +104,15 @@ public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public Algorithm<List<S>> build() {
-    Algorithm<List<S>> algorithm = new MOCell<S>(problem, maxEvaluations, populationSize,
+  public MOCell<S> build() {
+    MOCell<S> algorithm = new MOCell<S>(problem, maxEvaluations, populationSize,
         archiveSize, neighborhood, crossoverOperator, mutationOperator, selectionOperator, evaluator);
     
     return algorithm ;
   }
 
   /* Getters */
-  public Problem getProblem() {
+  public Problem<S> getProblem() {
     return problem;
   }
 
@@ -129,19 +128,19 @@ public class MOCellBuilder<S extends Solution> implements AlgorithmBuilder {
     return archiveSize ;
   }
 
-  public CrossoverOperator getCrossoverOperator() {
+  public CrossoverOperator<S> getCrossoverOperator() {
     return crossoverOperator;
   }
 
-  public MutationOperator getMutationOperator() {
+  public MutationOperator<S> getMutationOperator() {
     return mutationOperator;
   }
 
-  public SelectionOperator getSelectionOperator() {
+  public SelectionOperator<List<S>,S> getSelectionOperator() {
     return selectionOperator;
   }
 
-  public SolutionListEvaluator getSolutionListEvaluator() {
+  public SolutionListEvaluator<S> getSolutionListEvaluator() {
     return evaluator;
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mochc/MOCHC.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mochc/MOCHC.java
@@ -50,26 +50,26 @@ public class MOCHC extends AbstractEvolutionaryAlgorithm<BinarySolution, List<Bi
   private int convergenceValue;
   private double preservedPopulation;
   private double initialConvergenceCount;
-  private CrossoverOperator<List<BinarySolution>, List<BinarySolution>> crossover;
+  private CrossoverOperator<BinarySolution> crossover;
   private MutationOperator<BinarySolution> cataclysmicMutation;
-  private SelectionOperator newGenerationSelection;
-  private SelectionOperator parentSelection;
+  private SelectionOperator<List<BinarySolution>, List<BinarySolution>> newGenerationSelection;
+  private SelectionOperator<List<BinarySolution>, BinarySolution> parentSelection;
   private int evaluations;
   private int minimumDistance;
   private int size;
-  private Comparator comparator;
+  private Comparator<BinarySolution> comparator;
 
-  private SolutionListEvaluator evaluator;
+  private SolutionListEvaluator<BinarySolution> evaluator;
 
   /**
    * Constructor
    */
   public MOCHC(BinaryProblem problem, int populationSize, int maxEvaluations, int convergenceValue,
       double preservedPopulation, double initialConvergenceCount,
-      CrossoverOperator<List<BinarySolution>, List<BinarySolution>> crossoverOperator,
+      CrossoverOperator<BinarySolution> crossoverOperator,
       MutationOperator<BinarySolution> cataclysmicMutation,
-      SelectionOperator newGenerationSelection, SelectionOperator parentSelection,
-      SolutionListEvaluator evaluator) {
+      SelectionOperator<List<BinarySolution>, List<BinarySolution>> newGenerationSelection, SelectionOperator<List<BinarySolution>, BinarySolution> parentSelection,
+      SolutionListEvaluator<BinarySolution> evaluator) {
     super();
     this.problem = problem;
     this.populationSize = populationSize;
@@ -88,7 +88,7 @@ public class MOCHC extends AbstractEvolutionaryAlgorithm<BinarySolution, List<Bi
     }
     minimumDistance = (int) Math.floor(this.initialConvergenceCount * size);
 
-    comparator = new CrowdingDistanceComparator();
+    comparator = new CrowdingDistanceComparator<BinarySolution>();
   }
 
   @Override protected void initProgress() {
@@ -150,8 +150,7 @@ public class MOCHC extends AbstractEvolutionaryAlgorithm<BinarySolution, List<Bi
     union.addAll(population);
     union.addAll(offspringPopulation);
 
-    List<BinarySolution> newPopulation =
-        (List<BinarySolution>) newGenerationSelection.execute(union);
+    List<BinarySolution> newPopulation = newGenerationSelection.execute(union);
 
     if (solutionSetsAreEquals(population, newPopulation)) {
       minimumDistance--;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mochc/MOCHCBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mochc/MOCHCBuilder.java
@@ -4,10 +4,13 @@ package org.uma.jmetal.algorithm.multiobjective.mochc;
  * Created by ajnebro on 21/11/14.
  */
 
+import java.util.List;
+
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.SelectionOperator;
 import org.uma.jmetal.problem.BinaryProblem;
+import org.uma.jmetal.solution.BinarySolution;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
 import org.uma.jmetal.util.AlgorithmBuilder;
@@ -15,22 +18,22 @@ import org.uma.jmetal.util.AlgorithmBuilder;
 /**
  * Builder class
  */
-public class MOCHCBuilder implements AlgorithmBuilder {
+public class MOCHCBuilder implements AlgorithmBuilder<MOCHC> {
   BinaryProblem problem;
-  SolutionListEvaluator evaluator;
+  SolutionListEvaluator<BinarySolution> evaluator;
   int populationSize;
   int maxEvaluations;
   int convergenceValue;
   double preservedPopulation;
   double initialConvergenceCount;
-  CrossoverOperator crossoverOperator;
-  MutationOperator cataclysmicMutation;
-  SelectionOperator parentSelection;
-  SelectionOperator newGenerationSelection;
+  CrossoverOperator<BinarySolution> crossoverOperator;
+  MutationOperator<BinarySolution> cataclysmicMutation;
+  SelectionOperator<List<BinarySolution>, BinarySolution> parentSelection;
+  SelectionOperator<List<BinarySolution>, List<BinarySolution>> newGenerationSelection;
 
   public MOCHCBuilder(BinaryProblem problem) {
     this.problem = problem;
-    evaluator = new SequentialSolutionListEvaluator() ;
+    evaluator = new SequentialSolutionListEvaluator<BinarySolution>() ;
     populationSize = 100 ;
     maxEvaluations = 25000 ;
     convergenceValue = 3 ;
@@ -58,19 +61,19 @@ public class MOCHCBuilder implements AlgorithmBuilder {
     return convergenceValue;
   }
 
-  public CrossoverOperator getCrossover() {
+  public CrossoverOperator<BinarySolution> getCrossover() {
     return crossoverOperator;
   }
 
-  public MutationOperator getCataclysmicMutation() {
+  public MutationOperator<BinarySolution> getCataclysmicMutation() {
     return cataclysmicMutation;
   }
 
-  public SelectionOperator getParentSelection() {
+  public SelectionOperator<List<BinarySolution>,BinarySolution> getParentSelection() {
     return parentSelection;
   }
 
-  public SelectionOperator getNewGenerationSelection() {
+  public SelectionOperator<List<BinarySolution>, List<BinarySolution>> getNewGenerationSelection() {
     return newGenerationSelection;
   }
 
@@ -109,31 +112,31 @@ public class MOCHCBuilder implements AlgorithmBuilder {
     return this;
   }
 
-  public MOCHCBuilder setCrossover(CrossoverOperator crossover) {
+  public MOCHCBuilder setCrossover(CrossoverOperator<BinarySolution> crossover) {
     this.crossoverOperator = crossover;
 
     return this;
   }
 
-  public MOCHCBuilder setCataclysmicMutation(MutationOperator cataclysmicMutation) {
+  public MOCHCBuilder setCataclysmicMutation(MutationOperator<BinarySolution> cataclysmicMutation) {
     this.cataclysmicMutation = cataclysmicMutation;
 
     return this;
   }
 
-  public MOCHCBuilder setParentSelection(SelectionOperator parentSelection) {
+  public MOCHCBuilder setParentSelection(SelectionOperator<List<BinarySolution>, BinarySolution> parentSelection) {
     this.parentSelection = parentSelection;
 
     return this;
   }
 
-  public MOCHCBuilder setNewGenerationSelection(SelectionOperator newGenerationSelection) {
+  public MOCHCBuilder setNewGenerationSelection(SelectionOperator<List<BinarySolution>, List<BinarySolution>> newGenerationSelection) {
     this.newGenerationSelection = newGenerationSelection;
 
     return this;
   }
 
-  public MOCHCBuilder setEvaluator(SolutionListEvaluator evaluator) {
+  public MOCHCBuilder setEvaluator(SolutionListEvaluator<BinarySolution> evaluator) {
     this.evaluator = evaluator;
 
     return this;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/AbstractMOEAD.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/AbstractMOEAD.java
@@ -36,11 +36,11 @@ import java.util.Vector;
  * @author Antonio J. Nebro
  * @version 1.0
  */
-public abstract class AbstractMOEAD<S extends Solution> implements Algorithm<List<? extends Solution>> {
+public abstract class AbstractMOEAD<S extends Solution<?>> implements Algorithm<List<S>> {
   protected enum NeighborType {NEIGHBOR, POPULATION}
   public enum FunctionType {TCHE, PBI, AGG}
 
-  protected Problem problem ;
+  protected Problem<S> problem ;
 
   /** Z vector in Zhang & Li paper */
   protected double[] idealPoint;
@@ -54,7 +54,7 @@ public abstract class AbstractMOEAD<S extends Solution> implements Algorithm<Lis
   /** nr in Zhang & Li paper */
   protected int maximumNumberOfReplacedSolutions;
 
-  protected Solution[] indArray;
+  protected Solution<?>[] indArray;
   protected FunctionType functionType;
 
   protected String dataDirectory;
@@ -68,13 +68,13 @@ public abstract class AbstractMOEAD<S extends Solution> implements Algorithm<Lis
 
   protected JMetalRandom randomGenerator ;
 
-  protected CrossoverOperator crossoverOperator ;
-  protected MutationOperator mutationOperator ;
+  protected CrossoverOperator<S> crossoverOperator ;
+  protected MutationOperator<S> mutationOperator ;
 
   protected int numberOfThreads ;
 
-  public AbstractMOEAD(Problem problem, int populationSize, int resultPopulationSize,
-      int maxEvaluations, CrossoverOperator crossoverOperator, MutationOperator mutation,
+  public AbstractMOEAD(Problem<S> problem, int populationSize, int resultPopulationSize,
+      int maxEvaluations, CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutation,
       FunctionType functionType, String dataDirectory, double neighborhoodSelectionProbability,
       int maximumNumberOfReplacedSolutions, int neighborSize) {
     this.problem = problem ;
@@ -171,7 +171,7 @@ public abstract class AbstractMOEAD<S extends Solution> implements Algorithm<Lis
     }
   }
 
-  void updateIdealPoint(Solution individual) {
+  void updateIdealPoint(S individual) {
     for (int n = 0; n < problem.getNumberOfObjectives(); n++) {
       if (individual.getObjective(n) < idealPoint[n]) {
         idealPoint[n] = individual.getObjective(n);
@@ -238,7 +238,7 @@ public abstract class AbstractMOEAD<S extends Solution> implements Algorithm<Lis
     }
   }
 
-  void updateNeighborhood(Solution individual, int subProblemId, NeighborType neighborType) throws JMetalException {
+  void updateNeighborhood(S individual, int subProblemId, NeighborType neighborType) throws JMetalException {
     int size;
     int time;
 
@@ -276,7 +276,7 @@ public abstract class AbstractMOEAD<S extends Solution> implements Algorithm<Lis
     }
   }
 
-  double fitnessFunction(Solution individual, double[] lambda) throws JMetalException {
+  double fitnessFunction(S individual, double[] lambda) throws JMetalException {
     double fitness;
 
     if (MOEAD.FunctionType.TCHE.equals(functionType)) {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/ConstraintMOEAD.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/ConstraintMOEAD.java
@@ -20,7 +20,6 @@ import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.problem.ConstrainedProblem;
 import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.comparator.impl.ViolationThresholdComparator;
 
 import java.util.List;
@@ -38,12 +37,12 @@ public class ConstraintMOEAD extends AbstractMOEAD<DoubleSolution>  {
   private DifferentialEvolutionCrossover differentialEvolutionCrossover ;
   private ViolationThresholdComparator<DoubleSolution> violationThresholdComparator ;
 
-  public ConstraintMOEAD(Problem problem,
+  public ConstraintMOEAD(Problem<DoubleSolution> problem,
       int populationSize,
       int resultPopulationSize,
       int maxEvaluations,
-      MutationOperator mutation,
-      CrossoverOperator crossover,
+      MutationOperator<DoubleSolution> mutation,
+      CrossoverOperator<DoubleSolution> crossover,
       FunctionType functionType,
       String dataDirectory,
       double neighborhoodSelectionProbability,
@@ -54,7 +53,7 @@ public class ConstraintMOEAD extends AbstractMOEAD<DoubleSolution>  {
         neighborSize);
 
     differentialEvolutionCrossover = (DifferentialEvolutionCrossover)crossoverOperator ;
-    violationThresholdComparator = new ViolationThresholdComparator() ;
+    violationThresholdComparator = new ViolationThresholdComparator<DoubleSolution>() ;
   }
 
   @Override public void run() {
@@ -84,7 +83,7 @@ public class ConstraintMOEAD extends AbstractMOEAD<DoubleSolution>  {
         mutationOperator.execute(child);
         problem.evaluate(child);
         if (problem instanceof ConstrainedProblem) {
-          ((ConstrainedProblem) problem).evaluateConstraints(child);
+          ((ConstrainedProblem<DoubleSolution>) problem).evaluateConstraints(child);
         }
         evaluations++;
 
@@ -107,14 +106,14 @@ public class ConstraintMOEAD extends AbstractMOEAD<DoubleSolution>  {
 
       problem.evaluate(newSolution);
       if (problem instanceof ConstrainedProblem) {
-        ((ConstrainedProblem) problem).evaluateConstraints(newSolution);
+        ((ConstrainedProblem<DoubleSolution>) problem).evaluateConstraints(newSolution);
       }
       population.add(newSolution);
     }
   }
 
   @Override
-  void updateNeighborhood(Solution individual, int subproblemId, NeighborType neighborType) {
+  void updateNeighborhood(DoubleSolution individual, int subproblemId, NeighborType neighborType) {
     int size;
     int time;
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEAD.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEAD.java
@@ -34,12 +34,12 @@ import java.util.List;
 public class MOEAD extends AbstractMOEAD<DoubleSolution> {
   private DifferentialEvolutionCrossover differentialEvolutionCrossover ;
 
-  public MOEAD(Problem problem,
+  public MOEAD(Problem<DoubleSolution> problem,
       int populationSize,
       int resultPopulationSize,
       int maxEvaluations,
-      MutationOperator mutation,
-      CrossoverOperator crossover,
+      MutationOperator<DoubleSolution> mutation,
+      CrossoverOperator<DoubleSolution> crossover,
       FunctionType functionType,
       String dataDirectory,
       double neighborhoodSelectionProbability,

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADBuilder.java
@@ -13,12 +13,12 @@
 
 package org.uma.jmetal.algorithm.multiobjective.moead;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
 import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmBuilder;
 
 /**
@@ -27,10 +27,10 @@ import org.uma.jmetal.util.AlgorithmBuilder;
  * @author Antonio J. Nebro
  * @version 1.0
  */
-public class MOEADBuilder implements AlgorithmBuilder {
+public class MOEADBuilder implements AlgorithmBuilder<AbstractMOEAD<DoubleSolution>> {
   public enum Variant {MOEAD, ConstraintMOEAD, MOEADDRA} ;
 
-  private Problem problem ;
+  private Problem<DoubleSolution> problem ;
 
   /** T in Zhang & Li paper */
   private int neighborSize;
@@ -41,8 +41,8 @@ public class MOEADBuilder implements AlgorithmBuilder {
 
   private MOEAD.FunctionType functionType;
 
-  private CrossoverOperator crossover;
-  private MutationOperator mutation;
+  private CrossoverOperator<DoubleSolution> crossover;
+  private MutationOperator<DoubleSolution> mutation;
   private String dataDirectory;
 
   private int populationSize;
@@ -55,7 +55,7 @@ public class MOEADBuilder implements AlgorithmBuilder {
   private Variant moeadVariant ;
 
   /** Constructor */
-  public MOEADBuilder(Problem problem, Variant variant) {
+  public MOEADBuilder(Problem<DoubleSolution> problem, Variant variant) {
     this.problem = problem ;
     populationSize = 300 ;
     resultPopulationSize = 300 ;
@@ -92,11 +92,11 @@ public class MOEADBuilder implements AlgorithmBuilder {
     return dataDirectory;
   }
 
-  public MutationOperator getMutation() {
+  public MutationOperator<DoubleSolution> getMutation() {
     return mutation;
   }
 
-  public CrossoverOperator getCrossover() {
+  public CrossoverOperator<DoubleSolution> getCrossover() {
     return crossover;
   }
 
@@ -158,13 +158,13 @@ public class MOEADBuilder implements AlgorithmBuilder {
     return this ;
   }
 
-  public MOEADBuilder setCrossover(CrossoverOperator crossover) {
+  public MOEADBuilder setCrossover(CrossoverOperator<DoubleSolution> crossover) {
     this.crossover = crossover ;
 
     return this ;
   }
 
-  public MOEADBuilder setMutation(MutationOperator mutation) {
+  public MOEADBuilder setMutation(MutationOperator<DoubleSolution> mutation) {
     this.mutation = mutation ;
 
     return this ;
@@ -182,8 +182,8 @@ public class MOEADBuilder implements AlgorithmBuilder {
     return this ;
   }
 
-  public Algorithm build() {
-    Algorithm algorithm = null ;
+  public AbstractMOEAD<DoubleSolution> build() {
+    AbstractMOEAD<DoubleSolution> algorithm = null ;
     if (moeadVariant.equals(Variant.MOEAD)) {
       algorithm = new MOEAD(problem, populationSize, resultPopulationSize, maxEvaluations, mutation,
           crossover, functionType, dataDirectory, neighborhoodSelectionProbability,

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDRA.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDRA.java
@@ -19,7 +19,6 @@ import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
@@ -39,14 +38,14 @@ import java.util.List;
 public class MOEADDRA extends AbstractMOEAD<DoubleSolution> {
   private DifferentialEvolutionCrossover differentialEvolutionCrossover ;
 
-  private Solution[] savedValues;
+  private DoubleSolution[] savedValues;
   private double[] utility;
   private int[] frequency;
 
   JMetalRandom randomGenerator ;
 
-  public MOEADDRA(Problem problem, int populationSize, int resultPopulationSize, int maxEvaluations,
-      MutationOperator mutation, CrossoverOperator crossover, FunctionType functionType,
+  public MOEADDRA(Problem<DoubleSolution> problem, int populationSize, int resultPopulationSize, int maxEvaluations,
+      MutationOperator<DoubleSolution> mutation, CrossoverOperator<DoubleSolution> crossover, FunctionType functionType,
       String dataDirectory, double neighborhoodSelectionProbability,
       int maximumNumberOfReplacedSolutions, int neighborSize) {
     super(problem, populationSize, resultPopulationSize, maxEvaluations, crossover, mutation, functionType,
@@ -55,7 +54,7 @@ public class MOEADDRA extends AbstractMOEAD<DoubleSolution> {
 
     differentialEvolutionCrossover = (DifferentialEvolutionCrossover)crossoverOperator ;
 
-    savedValues = new Solution[populationSize];
+    savedValues = new DoubleSolution[populationSize];
     utility = new double[populationSize];
     frequency = new int[populationSize];
     for (int i = 0; i < utility.length; i++) {
@@ -113,7 +112,7 @@ public class MOEADDRA extends AbstractMOEAD<DoubleSolution> {
 
       problem.evaluate(newSolution);
       population.add(newSolution);
-      savedValues[i] = newSolution.copy();
+      savedValues[i] = (DoubleSolution) newSolution.copy();
     }
   }
 
@@ -133,7 +132,7 @@ public class MOEADDRA extends AbstractMOEAD<DoubleSolution> {
         uti = (0.95 + (0.05 * delta / 0.001)) * utility[n];
         utility[n] = uti < 1.0 ? uti : 1.0;
       }
-      savedValues[n] = population.get(n).copy();
+      savedValues[n] = (DoubleSolution) population.get(n).copy();
     }
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAII.java
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * Created by Antonio J. Nebro on 30/10/14.
  */
-public class NSGAII<S extends  Solution> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class NSGAII<S extends  Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
   protected final int maxIterations;
   protected final int populationSize;
 
@@ -35,7 +35,7 @@ public class NSGAII<S extends  Solution> extends AbstractGeneticAlgorithm<S, Lis
    */
   public NSGAII(Problem<S> problem, int maxIterations, int populationSize,
       CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
-      SelectionOperator selectionOperator, SolutionListEvaluator<S> evaluator) {
+      SelectionOperator<List<S>, S> selectionOperator, SolutionListEvaluator<S> evaluator) {
     super() ;
     this.problem = problem;
     this.maxIterations = maxIterations;
@@ -119,14 +119,14 @@ public class NSGAII<S extends  Solution> extends AbstractGeneticAlgorithm<S, Lis
   }
 
   protected Ranking<S> computeRanking(List<S> solutionList) {
-    Ranking ranking = new DominanceRanking();
+    Ranking<S> ranking = new DominanceRanking<S>();
     ranking.computeRanking(solutionList);
 
     return ranking;
   }
 
-  protected List<S> crowdingDistanceSelection(Ranking ranking) {
-    CrowdingDistance crowdingDistance = new CrowdingDistance();
+  protected List<S> crowdingDistanceSelection(Ranking<S> ranking) {
+    CrowdingDistance<S> crowdingDistance = new CrowdingDistance<S>();
     List<S> population = new ArrayList<>(populationSize);
     int rankingIndex = 0;
     while (populationIsNotFull(population)) {
@@ -146,11 +146,11 @@ public class NSGAII<S extends  Solution> extends AbstractGeneticAlgorithm<S, Lis
     return population.size() < populationSize;
   }
 
-  protected boolean subfrontFillsIntoThePopulation(Ranking ranking, int rank, List<S> population) {
+  protected boolean subfrontFillsIntoThePopulation(Ranking<S> ranking, int rank, List<S> population) {
     return ranking.getSubfront(rank).size() < (populationSize - population.size());
   }
 
-  protected void addRankedSolutionsToPopulation(Ranking ranking, int rank, List<S> population) {
+  protected void addRankedSolutionsToPopulation(Ranking<S> ranking, int rank, List<S> population) {
     List<S> front;
 
     front = ranking.getSubfront(rank);
@@ -160,7 +160,7 @@ public class NSGAII<S extends  Solution> extends AbstractGeneticAlgorithm<S, Lis
     }
   }
 
-  protected void addLastRankedSolutionsToPopulation(Ranking ranking, int rank, List<S> population) {
+  protected void addLastRankedSolutionsToPopulation(Ranking<S> ranking, int rank, List<S> population) {
     List<S> currentRankedFront = ranking.getSubfront(rank);
 
     Collections.sort(currentRankedFront, new CrowdingDistanceComparator());

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAII.java
@@ -34,7 +34,7 @@ public class NSGAII<S extends  Solution<?>> extends AbstractGeneticAlgorithm<S, 
    * Constructor
    */
   public NSGAII(Problem<S> problem, int maxIterations, int populationSize,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
       SelectionOperator<List<S>, S> selectionOperator, SolutionListEvaluator<S> evaluator) {
     super() ;
     this.problem = problem;
@@ -163,7 +163,7 @@ public class NSGAII<S extends  Solution<?>> extends AbstractGeneticAlgorithm<S, 
   protected void addLastRankedSolutionsToPopulation(Ranking<S> ranking, int rank, List<S> population) {
     List<S> currentRankedFront = ranking.getSubfront(rank);
 
-    Collections.sort(currentRankedFront, new CrowdingDistanceComparator());
+    Collections.sort(currentRankedFront, new CrowdingDistanceComparator<S>());
 
     int i = 0;
     while (population.size() < populationSize) {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIBuilder.java
@@ -1,6 +1,5 @@
 package org.uma.jmetal.algorithm.multiobjective.nsgaii;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.SelectionOperator;
@@ -17,7 +16,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 16/11/14.
  */
-public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
+public class NSGAIIBuilder<S extends Solution<?>> implements AlgorithmBuilder<NSGAII<S>> {
   public enum NSGAIIVariant {NSGAII, SteadyStateNSGAII, Measures}
 
   /**
@@ -26,30 +25,30 @@ public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
   private final Problem<S> problem;
   private int maxIterations;
   private int populationSize;
-  private CrossoverOperator<List<S>, List<S>>  crossoverOperator;
+  private CrossoverOperator<S>  crossoverOperator;
   private MutationOperator<S> mutationOperator;
-  private SelectionOperator selectionOperator;
-  private SolutionListEvaluator evaluator;
+  private SelectionOperator<List<S>, S> selectionOperator;
+  private SolutionListEvaluator<S> evaluator;
 
   private NSGAIIVariant variant;
 
   /**
    * NSGAIIBuilder constructor
    */
-  public NSGAIIBuilder(Problem<S> problem, CrossoverOperator<List<S>, List<S>> crossoverOperator,
+  public NSGAIIBuilder(Problem<S> problem, CrossoverOperator<S> crossoverOperator,
       MutationOperator<S> mutationOperator, NSGAIIVariant variant) {
     this.problem = problem;
     maxIterations = 250;
     populationSize = 100;
     this.crossoverOperator = crossoverOperator ;
     this.mutationOperator = mutationOperator ;
-    selectionOperator = new BinaryTournamentSelection();
-    evaluator = new SequentialSolutionListEvaluator();
+    selectionOperator = new BinaryTournamentSelection<S>();
+    evaluator = new SequentialSolutionListEvaluator<S>();
 
     this.variant = variant ;
   }
 
-  public NSGAIIBuilder setMaxIterations(int maxIterations) {
+  public NSGAIIBuilder<S> setMaxIterations(int maxIterations) {
     if (maxIterations < 0) {
       throw new JMetalException("maxIterations is negative: " + maxIterations);
     }
@@ -58,7 +57,7 @@ public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public NSGAIIBuilder setPopulationSize(int populationSize) {
+  public NSGAIIBuilder<S> setPopulationSize(int populationSize) {
     if (populationSize < 0) {
       throw new JMetalException("Population size is negative: " + populationSize);
     }
@@ -68,7 +67,7 @@ public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public NSGAIIBuilder setSelectionOperator(SelectionOperator selectionOperator) {
+  public NSGAIIBuilder<S> setSelectionOperator(SelectionOperator<List<S>, S> selectionOperator) {
     if (selectionOperator == null) {
       throw new JMetalException("selectionOperator is null");
     }
@@ -77,7 +76,7 @@ public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public NSGAIIBuilder setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public NSGAIIBuilder<S> setSolutionListEvaluator(SolutionListEvaluator<S> evaluator) {
     if (evaluator == null) {
       throw new JMetalException("evaluator is null");
     }
@@ -86,8 +85,8 @@ public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public Algorithm<List<S>> build() {
-    Algorithm<List<S>> algorithm = null ;
+  public NSGAII<S> build() {
+    NSGAII<S> algorithm = null ;
     if (variant.equals(NSGAIIVariant.NSGAII)) {
       algorithm = new NSGAII<S>(problem, maxIterations, populationSize, crossoverOperator,
           mutationOperator, selectionOperator, evaluator);
@@ -95,7 +94,7 @@ public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
       algorithm = new SteadyStateNSGAII<S>(problem, maxIterations, populationSize, crossoverOperator,
           mutationOperator, selectionOperator, evaluator);
     } else if (variant.equals(NSGAIIVariant.Measures)) {
-      algorithm = new NSGAIIMeasures(problem, maxIterations, populationSize, crossoverOperator,
+      algorithm = new NSGAIIMeasures<S>(problem, maxIterations, populationSize, crossoverOperator,
           mutationOperator, selectionOperator, evaluator);
     }
 
@@ -103,7 +102,7 @@ public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
   }
 
   /* Getters */
-  public Problem getProblem() {
+  public Problem<S> getProblem() {
     return problem;
   }
 
@@ -115,19 +114,19 @@ public class NSGAIIBuilder<S extends Solution> implements AlgorithmBuilder {
     return populationSize;
   }
 
-  public CrossoverOperator getCrossoverOperator() {
+  public CrossoverOperator<S> getCrossoverOperator() {
     return crossoverOperator;
   }
 
-  public MutationOperator getMutationOperator() {
+  public MutationOperator<S> getMutationOperator() {
     return mutationOperator;
   }
 
-  public SelectionOperator getSelectionOperator() {
+  public SelectionOperator<List<S>, S> getSelectionOperator() {
     return selectionOperator;
   }
 
-  public SolutionListEvaluator getSolutionListEvaluator() {
+  public SolutionListEvaluator<S> getSolutionListEvaluator() {
     return evaluator;
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIMeasures.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIMeasures.java
@@ -17,7 +17,7 @@ import java.util.List;
  * @author Antonio J. Nebro
  * @version 1.0
  */
-public class NSGAIIMeasures<S extends Solution> extends NSGAII<S> implements Measurable {
+public class NSGAIIMeasures<S extends Solution<?>> extends NSGAII<S> implements Measurable {
   private CountingMeasure iterations ;
   private BasicMeasure<Integer> numberOfFeasibleSolutionsInPopulation ;
   private DurationMeasure durationMeasure ;
@@ -31,8 +31,8 @@ public class NSGAIIMeasures<S extends Solution> extends NSGAII<S> implements Mea
    * Constructor
    */
   public NSGAIIMeasures(Problem<S> problem, int maxIterations, int populationSize,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
-      SelectionOperator selectionOperator, SolutionListEvaluator evaluator) {
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
+      SelectionOperator<List<S>, S> selectionOperator, SolutionListEvaluator<S> evaluator) {
     super(problem, maxIterations, populationSize, crossoverOperator, mutationOperator, selectionOperator, evaluator) ;
 
     initMeasures() ;
@@ -56,7 +56,7 @@ public class NSGAIIMeasures<S extends Solution> extends NSGAII<S> implements Mea
     population = super.evaluatePopulation(population);
 
     int countFeasibleSolutions = 0 ;
-    for (Solution solution : population) {
+    for (S solution : population) {
       if (solution.getOverallConstraintViolationDegree() == 0) {
         countFeasibleSolutions ++ ;
       }
@@ -104,7 +104,7 @@ public class NSGAIIMeasures<S extends Solution> extends NSGAII<S> implements Mea
       List<S> offspringPopulation) {
     List<S> pop = super.replacement(population, offspringPopulation) ;
 
-    Ranking ranking = computeRanking(pop);
+    Ranking<S> ranking = computeRanking(pop);
     numberOfNonDominatedSolutionsInPopulation.set(ranking.getSubfront(0).size());
 
     return pop;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/SteadyStateNSGAII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/SteadyStateNSGAII.java
@@ -13,13 +13,13 @@ import java.util.List;
 /**
  * Created by ajnebro on 30/10/14.
  */
-public class SteadyStateNSGAII<S extends Solution> extends NSGAII<S> {
+public class SteadyStateNSGAII<S extends Solution<?>> extends NSGAII<S> {
   /**
    * Constructor
    */
   public SteadyStateNSGAII(Problem<S> problem, int maxIterations, int populationSize,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
-      SelectionOperator selectionOperator, SolutionListEvaluator evaluator) {
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
+      SelectionOperator<List<S>, S> selectionOperator, SolutionListEvaluator<S> evaluator) {
     super(problem, maxIterations, populationSize, crossoverOperator, mutationOperator,
         selectionOperator, evaluator);
   }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIIIBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIIIBuilder.java
@@ -1,9 +1,12 @@
 package org.uma.jmetal.algorithm.multiobjective.nsgaiii;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.SelectionOperator;
 import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
 import org.uma.jmetal.util.AlgorithmBuilder;
@@ -11,65 +14,65 @@ import org.uma.jmetal.util.AlgorithmBuilder;
 /**
  * Builder class
  */
-public class NSGAIIIBuilder implements AlgorithmBuilder {
+public class NSGAIIIBuilder<S extends Solution<?>> implements AlgorithmBuilder<NSGAIII<S>> {
 
   // no access modifier means access from classes within the same package
-  Problem problem;
+  Problem<S> problem;
   int maxEvaluations;
   int populationSize;
-  CrossoverOperator crossoverOperator;
-  MutationOperator mutationOperator;
-  SelectionOperator selectionOperator;
-  SolutionListEvaluator evaluator;
+  CrossoverOperator<S> crossoverOperator;
+  MutationOperator<S> mutationOperator;
+  SelectionOperator<List<S>, S> selectionOperator;
+  SolutionListEvaluator<S> evaluator;
   int divisions;
 
   /**
    * Builder constructor
    */
-  public NSGAIIIBuilder(Problem problem) {
+  public NSGAIIIBuilder(Problem<S> problem) {
     this.problem = problem;
     maxEvaluations = 25000;
     populationSize = 100;
-    evaluator = new SequentialSolutionListEvaluator();
+    evaluator = new SequentialSolutionListEvaluator<S>();
   }
 
-  public NSGAIIIBuilder setMaxEvaluations(int maxEvaluations) {
+  public NSGAIIIBuilder<S> setMaxEvaluations(int maxEvaluations) {
     this.maxEvaluations = maxEvaluations;
 
     return this;
   }
 
-  public NSGAIIIBuilder setPopulationSize(int populationSize) {
+  public NSGAIIIBuilder<S> setPopulationSize(int populationSize) {
     this.populationSize = populationSize;
 
     return this;
   }
 
-  public NSGAIIIBuilder setCrossoverOperator(CrossoverOperator crossoverOperator) {
+  public NSGAIIIBuilder<S> setCrossoverOperator(CrossoverOperator<S> crossoverOperator) {
     this.crossoverOperator = crossoverOperator;
 
     return this;
   }
 
-  public NSGAIIIBuilder setMutationOperator(MutationOperator mutationOperator) {
+  public NSGAIIIBuilder<S> setMutationOperator(MutationOperator<S> mutationOperator) {
     this.mutationOperator = mutationOperator;
 
     return this;
   }
 
-  public NSGAIIIBuilder setSelectionOperator(SelectionOperator selectionOperator) {
+  public NSGAIIIBuilder<S> setSelectionOperator(SelectionOperator<List<S>, S> selectionOperator) {
     this.selectionOperator = selectionOperator;
 
     return this;
   }
 
-  public NSGAIIIBuilder setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public NSGAIIIBuilder<S> setSolutionListEvaluator(SolutionListEvaluator<S> evaluator) {
     this.evaluator = evaluator;
 
     return this;
   }
 
-  public NSGAIIIBuilder setDivisions(int div) {
+  public NSGAIIIBuilder<S> setDivisions(int div) {
     this.divisions = div;
     return this;
   }
@@ -78,7 +81,7 @@ public class NSGAIIIBuilder implements AlgorithmBuilder {
     return this.divisions;
   }
 
-  public NSGAIII build() {
-    return new NSGAIII(this);
+  public NSGAIII<S> build() {
+    return new NSGAIII<S>(this);
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/ReferencePoint.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/ReferencePoint.java
@@ -15,10 +15,10 @@ import java.util.List;
  * This implementation is based on the code of Tsung-Che Chiang
  * http://web.ntnu.edu.tw/~tcchiang/publications/nsga3cpp/nsga3cpp.htm
  */
-public class ReferencePoint {
+public class ReferencePoint<S extends Solution<?>> {
   public List<Double> position;
   private int memberSize;
-  private List<Pair<Solution, Double>> potentialMembers;
+  private List<Pair<S, Double>> potentialMembers;
 
   /**
    * Constructor
@@ -31,7 +31,7 @@ public class ReferencePoint {
     potentialMembers = new ArrayList<>();
   }
 
-  public ReferencePoint(ReferencePoint point) {
+  public ReferencePoint(ReferencePoint<S> point) {
     position = new ArrayList<>(point.position.size());
     for (Double d : point.position) {
       position.add(new Double(d));
@@ -41,19 +41,19 @@ public class ReferencePoint {
   }
 
 
-  public static void generateReferencePoints(List<ReferencePoint> referencePoints,
+  public static <S extends Solution<?>> void generateReferencePoints(List<ReferencePoint<S>> referencePoints,
       int numberOfObjectives, List<Integer> numberOfDivisions) {
 
-    ReferencePoint refPoint = new ReferencePoint(numberOfObjectives);
+    ReferencePoint<S> refPoint = new ReferencePoint<S>(numberOfObjectives);
     generateRecursive(referencePoints, refPoint, numberOfObjectives, numberOfDivisions.get(0),
         numberOfDivisions.get(0), 0);
   }
 
-  private static void generateRecursive(List<ReferencePoint> referencePoints,
-      ReferencePoint refPoint, int numberOfObjectives, int left, int total, int element) {
+  private static <S extends Solution<?>> void generateRecursive(List<ReferencePoint<S>> referencePoints,
+      ReferencePoint<S> refPoint, int numberOfObjectives, int left, int total, int element) {
     if (element == (numberOfObjectives - 1)) {
       refPoint.position.set(element, (double) left / total);
-      referencePoints.add(new ReferencePoint(refPoint));
+      referencePoints.add(new ReferencePoint<S>(refPoint));
     } else {
       for (int i = 0; i <= left; i += 1) {
         refPoint.position.set(element, (double) i / total);
@@ -85,14 +85,14 @@ public class ReferencePoint {
     this.memberSize++;
   }
 
-  public void AddPotentialMember(Solution member_ind, double distance) {
-    this.potentialMembers.add(new ImmutablePair<Solution, Double>(member_ind, distance));
+  public void AddPotentialMember(S member_ind, double distance) {
+    this.potentialMembers.add(new ImmutablePair<S, Double>(member_ind, distance));
   }
 
-  public Solution FindClosestMember() {
+  public S FindClosestMember() {
     double min_dist = Double.MAX_VALUE;
-    Solution min_indv = null;
-    for (Pair<Solution, Double> p : this.potentialMembers) {
+    S min_indv = null;
+    for (Pair<S, Double> p : this.potentialMembers) {
       if (p.getRight() < min_dist) {
         min_dist = p.getRight();
         min_indv = p.getLeft();
@@ -102,15 +102,15 @@ public class ReferencePoint {
     return min_indv;
   }
 
-  public Solution RandomMember() {
+  public S RandomMember() {
     int index = this.potentialMembers.size() > 1 ?
         JMetalRandom.getInstance().nextInt(0, this.potentialMembers.size() - 1) :
         0;
     return this.potentialMembers.get(index).getLeft();
   }
 
-  public void RemovePotentialMember(Solution solution) {
-    Iterator<Pair<Solution, Double>> it = this.potentialMembers.iterator();
+  public void RemovePotentialMember(S solution) {
+    Iterator<Pair<S, Double>> it = this.potentialMembers.iterator();
     while (it.hasNext())
       if (it.next().getLeft()==(solution)) // this removal is based only on references
         it.remove();

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/omopso/OMOPSO.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/omopso/OMOPSO.java
@@ -26,7 +26,6 @@ import org.uma.jmetal.operator.impl.mutation.NonUniformMutation;
 import org.uma.jmetal.operator.impl.mutation.UniformMutation;
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.archive.impl.CrowdingDistanceArchive;
 import org.uma.jmetal.util.archive.impl.NonDominatedSolutionListArchive;
 import org.uma.jmetal.util.comparator.CrowdingDistanceComparator;
@@ -44,7 +43,7 @@ public class OMOPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Li
 
   private DoubleProblem problem;
 
-  SolutionListEvaluator evaluator;
+  SolutionListEvaluator<DoubleSolution> evaluator;
 
   private int swarmSize;
   private int archiveSize;
@@ -58,8 +57,8 @@ public class OMOPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Li
 
   private double[][] speed;
 
-  private Comparator<Solution> dominanceComparator;
-  private Comparator<Solution> crowdingDistanceComparator;
+  private Comparator<DoubleSolution> dominanceComparator;
+  private Comparator<DoubleSolution> crowdingDistanceComparator;
 
   private UniformMutation uniformMutation;
   private NonUniformMutation nonUniformMutation;
@@ -67,10 +66,10 @@ public class OMOPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Li
   private double eta = 0.0075;
 
   private JMetalRandom randomGenerator;
-  private CrowdingDistance crowdingDistance;
+  private CrowdingDistance<DoubleSolution> crowdingDistance;
 
   /** Constructor */
-  public OMOPSO(DoubleProblem problem, SolutionListEvaluator evaluator, int swarmSize, int maxIterations,
+  public OMOPSO(DoubleProblem problem, SolutionListEvaluator<DoubleSolution> evaluator, int swarmSize, int maxIterations,
       int archiveSize, UniformMutation uniformMutation, NonUniformMutation nonUniformMutation) {
     this.problem = problem ;
     this.evaluator = evaluator ;
@@ -84,15 +83,15 @@ public class OMOPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Li
 
     localBest = new DoubleSolution[swarmSize];
     leaderArchive = new CrowdingDistanceArchive<DoubleSolution>(this.archiveSize);
-    epsilonArchive = new NonDominatedSolutionListArchive(new DominanceComparator(eta));
+    epsilonArchive = new NonDominatedSolutionListArchive<DoubleSolution>(new DominanceComparator<DoubleSolution>(eta));
 
-    dominanceComparator = new DominanceComparator();
-    crowdingDistanceComparator = new CrowdingDistanceComparator();
+    dominanceComparator = new DominanceComparator<DoubleSolution>();
+    crowdingDistanceComparator = new CrowdingDistanceComparator<DoubleSolution>();
 
     speed = new double[swarmSize][problem.getNumberOfVariables()];
 
     randomGenerator = JMetalRandom.getInstance() ;
-    crowdingDistance = new CrowdingDistance();
+    crowdingDistance = new CrowdingDistance<DoubleSolution>();
   }
 
   @Override public void run() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/omopso/OMOPSOBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/omopso/OMOPSOBuilder.java
@@ -26,13 +26,14 @@ import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.impl.mutation.NonUniformMutation;
 import org.uma.jmetal.operator.impl.mutation.UniformMutation;
 import org.uma.jmetal.problem.DoubleProblem;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.AlgorithmBuilder;
 
 /** Class implementing the OMOPSO algorithm */
-public class OMOPSOBuilder implements AlgorithmBuilder {
+public class OMOPSOBuilder implements AlgorithmBuilder<OMOPSO> {
   protected DoubleProblem problem;
-  protected SolutionListEvaluator evaluator;
+  protected SolutionListEvaluator<DoubleSolution> evaluator;
 
   private int swarmSize = 100 ;
   private int archiveSize = 100 ;
@@ -41,7 +42,7 @@ public class OMOPSOBuilder implements AlgorithmBuilder {
   private UniformMutation uniformMutation ;
   private NonUniformMutation nonUniformMutation ;
 
-  public OMOPSOBuilder(DoubleProblem problem, SolutionListEvaluator evaluator) {
+  public OMOPSOBuilder(DoubleProblem problem, SolutionListEvaluator<DoubleSolution> evaluator) {
     this.evaluator = evaluator ;
     this.problem = problem ;
   }
@@ -64,13 +65,13 @@ public class OMOPSOBuilder implements AlgorithmBuilder {
     return this ;
   }
 
-  public OMOPSOBuilder setUniformMutation(MutationOperator uniformMutation) {
+  public OMOPSOBuilder setUniformMutation(MutationOperator<DoubleSolution> uniformMutation) {
     this.uniformMutation = (UniformMutation)uniformMutation ;
 
     return this ;
   }
 
-  public OMOPSOBuilder setNonUniformMutation(MutationOperator nonUniformMutation) {
+  public OMOPSOBuilder setNonUniformMutation(MutationOperator<DoubleSolution> nonUniformMutation) {
     this.nonUniformMutation = (NonUniformMutation)nonUniformMutation ;
 
     return this ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/paes/PAES.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/paes/PAES.java
@@ -31,7 +31,7 @@ import java.util.List;
  *
  * This class implements the PAES algorithm.
  */
-public class PAES<S extends Solution> extends AbstractEvolutionStrategy<S, List<S>> {
+public class PAES<S extends Solution<?>> extends AbstractEvolutionStrategy<S, List<S>> {
   private Problem<S> problem;
 
   private int archiveSize;
@@ -41,8 +41,8 @@ public class PAES<S extends Solution> extends AbstractEvolutionStrategy<S, List<
 
   private MutationOperator<S> mutationOperator;
 
-  private AdaptiveGridArchive archive;
-  private Comparator comparator;
+  private AdaptiveGridArchive<S> archive;
+  private Comparator<S> comparator;
 
   /**
    * Constructor
@@ -55,8 +55,8 @@ public class PAES<S extends Solution> extends AbstractEvolutionStrategy<S, List<
     this.biSections = biSections;
     this.mutationOperator = mutationOperator;
 
-    archive = new AdaptiveGridArchive(archiveSize, biSections, problem.getNumberOfObjectives());
-    comparator = new DominanceComparator();
+    archive = new AdaptiveGridArchive<S>(archiveSize, biSections, problem.getNumberOfObjectives());
+    comparator = new DominanceComparator<S>();
   }
 
   /* Getters */
@@ -72,7 +72,7 @@ public class PAES<S extends Solution> extends AbstractEvolutionStrategy<S, List<
     return biSections;
   }
 
-  public MutationOperator getMutationOperator() {
+  public MutationOperator<S> getMutationOperator() {
     return mutationOperator;
   }
 
@@ -141,7 +141,7 @@ public class PAES<S extends Solution> extends AbstractEvolutionStrategy<S, List<
    * @param solution        The actual guide of PAES
    * @param mutatedSolution A candidate guide
    */
-  public S test(S solution, S mutatedSolution, AdaptiveGridArchive archive) {
+  public S test(S solution, S mutatedSolution, AdaptiveGridArchive<S> archive) {
 
     int originalLocation = archive.getGrid().location(solution);
     int mutatedLocation = archive.getGrid().location(mutatedSolution);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/paes/PAESBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/paes/PAESBuilder.java
@@ -21,7 +21,7 @@ import org.uma.jmetal.util.AlgorithmBuilder;
 /**
  * Created by ajnebro on 17/11/14.
  */
-public class PAESBuilder<S extends Solution>  implements AlgorithmBuilder {
+public class PAESBuilder<S extends Solution<?>>  implements AlgorithmBuilder<PAES<S>> {
   public Problem<S> problem;
 
   public int archiveSize;
@@ -34,31 +34,31 @@ public class PAESBuilder<S extends Solution>  implements AlgorithmBuilder {
     this.problem = problem;
   }
 
-  public PAESBuilder setArchiveSize(int archiveSize) {
+  public PAESBuilder<S> setArchiveSize(int archiveSize) {
     this.archiveSize = archiveSize;
 
     return this;
   }
 
-  public PAESBuilder setMaxEvaluations(int maxEvaluations) {
+  public PAESBuilder<S> setMaxEvaluations(int maxEvaluations) {
     this.maxEvaluations = maxEvaluations;
 
     return this;
   }
 
-  public PAESBuilder setBiSections(int biSections) {
+  public PAESBuilder<S> setBiSections(int biSections) {
     this.biSections = biSections;
 
     return this;
   }
 
-  public PAESBuilder setMutationOperator(MutationOperator<S> mutation) {
+  public PAESBuilder<S> setMutationOperator(MutationOperator<S> mutation) {
     mutationOperator = mutation;
 
     return this;
   }
 
-  public PAES build() {
+  public PAES<S> build() {
     return new PAES<S>(problem, archiveSize, maxEvaluations, biSections, mutationOperator);
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2.java
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 4/4/15.
  */
-public class PESA2<S extends Solution> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class PESA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
   private int maxEvaluations ;
   private int archiveSize ;
   private int populationSize ;
@@ -26,13 +26,13 @@ public class PESA2<S extends Solution> extends AbstractGeneticAlgorithm<S, List<
   private int evaluations ;
 
   protected final Problem<S> problem;
-  protected SelectionOperator<AdaptiveGridArchive, S> selectionOperator ;
+  protected SelectionOperator<AdaptiveGridArchive<S>, S> selectionOperator ;
 
   private AdaptiveGridArchive<S> archive;
   protected final SolutionListEvaluator<S> evaluator;
 
   public PESA2(Problem<S> problem, int maxEvaluations, int populationSize, int archiveSize,
-      int biSections, CrossoverOperator<List<S>, List<S>> crossoverOperator,
+      int biSections, CrossoverOperator<S> crossoverOperator,
       MutationOperator<S> mutationOperator, SolutionListEvaluator<S> evaluator) {
     this.problem = problem ;
     this.maxEvaluations = maxEvaluations ;
@@ -42,7 +42,7 @@ public class PESA2<S extends Solution> extends AbstractGeneticAlgorithm<S, List<
 
     this.crossoverOperator = crossoverOperator;
     this.mutationOperator = mutationOperator;
-    this.selectionOperator = new PESA2Selection();
+    this.selectionOperator = new PESA2Selection<S>();
 
     this.evaluator = evaluator ;
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2Builder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2Builder.java
@@ -1,6 +1,5 @@
 package org.uma.jmetal.algorithm.multiobjective.pesa2;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.problem.Problem;
@@ -10,25 +9,23 @@ import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
 
-import java.util.List;
-
 /**
  * Created by Antonio J. Nebro
  */
-public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
+public class PESA2Builder<S extends Solution<?>> implements AlgorithmBuilder<PESA2<S>> {
   private final Problem<S> problem;
   private int maxEvaluations ;
   private int archiveSize ;
   private int populationSize ;
   private int biSections ;
-  private CrossoverOperator<List<S>, List<S>> crossoverOperator;
+  private CrossoverOperator<S> crossoverOperator;
   private MutationOperator<S> mutationOperator;
-  private SolutionListEvaluator evaluator;
+  private SolutionListEvaluator<S> evaluator;
 
   /**
    * Constructor
    */
-  public PESA2Builder(Problem problem, CrossoverOperator<List<S>, List<S>> crossoverOperator,
+  public PESA2Builder(Problem<S> problem, CrossoverOperator<S> crossoverOperator,
       MutationOperator<S> mutationOperator) {
     this.problem = problem;
     maxEvaluations = 250;
@@ -38,10 +35,10 @@ public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
     this.crossoverOperator = crossoverOperator ;
     this.mutationOperator = mutationOperator ;
 
-    evaluator = new SequentialSolutionListEvaluator();
+    evaluator = new SequentialSolutionListEvaluator<S>();
   }
 
-  public PESA2Builder setMaxEvaluations(int maxEvaluations) {
+  public PESA2Builder<S> setMaxEvaluations(int maxEvaluations) {
     if (maxEvaluations < 0) {
       throw new JMetalException("maxEvaluations is negative: " + maxEvaluations);
     }
@@ -50,7 +47,7 @@ public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public PESA2Builder setArchiveSize(int archiveSize) {
+  public PESA2Builder<S> setArchiveSize(int archiveSize) {
     if (archiveSize < 0) {
       throw new JMetalException("archiveSize is negative: " + maxEvaluations);
     }
@@ -59,7 +56,7 @@ public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public PESA2Builder setBisections(int biSections) {
+  public PESA2Builder<S> setBisections(int biSections) {
     if (biSections < 0) {
       throw new JMetalException("biSections is negative: " + maxEvaluations);
     }
@@ -68,7 +65,7 @@ public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public PESA2Builder setPopulationSize(int populationSize) {
+  public PESA2Builder<S> setPopulationSize(int populationSize) {
     if (populationSize < 0) {
       throw new JMetalException("Population size is negative: " + populationSize);
     }
@@ -78,7 +75,7 @@ public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public PESA2Builder setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public PESA2Builder<S> setSolutionListEvaluator(SolutionListEvaluator<S> evaluator) {
     if (evaluator == null) {
       throw new JMetalException("evaluator is null");
     }
@@ -87,8 +84,8 @@ public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public Algorithm build() {
-    Algorithm algorithm  ;
+  public PESA2<S> build() {
+    PESA2<S> algorithm  ;
     algorithm = new PESA2<S>(problem, maxEvaluations, populationSize, archiveSize, biSections,
         crossoverOperator, mutationOperator, evaluator);
     
@@ -96,7 +93,7 @@ public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
   }
 
   /* Getters */
-  public Problem getProblem() {
+  public Problem<S> getProblem() {
     return problem;
   }
 
@@ -108,15 +105,15 @@ public class PESA2Builder<S extends Solution> implements AlgorithmBuilder {
     return populationSize;
   }
 
-  public CrossoverOperator getCrossoverOperator() {
+  public CrossoverOperator<S> getCrossoverOperator() {
     return crossoverOperator;
   }
 
-  public MutationOperator getMutationOperator() {
+  public MutationOperator<S> getMutationOperator() {
     return mutationOperator;
   }
 
-  public SolutionListEvaluator getSolutionListEvaluator() {
+  public SolutionListEvaluator<S> getSolutionListEvaluator() {
     return evaluator;
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/util/PESA2Selection.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/util/PESA2Selection.java
@@ -29,7 +29,7 @@ import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 /**
  * This class implements a selection operator as the used in the PESA-II algorithm
  */
-public class PESA2Selection<S extends Solution> implements SelectionOperator<AdaptiveGridArchive, S> {
+public class PESA2Selection<S extends Solution<?>> implements SelectionOperator<AdaptiveGridArchive<S>, S> {
 
   private JMetalRandom randomGenerator ;
 
@@ -37,7 +37,7 @@ public class PESA2Selection<S extends Solution> implements SelectionOperator<Ada
     randomGenerator = JMetalRandom.getInstance() ;
 	}
 
-  @Override public S execute(AdaptiveGridArchive archive) {
+  @Override public S execute(AdaptiveGridArchive<S> archive) {
     int selected;
     int hypercube1 = archive.getGrid().randomOccupiedHypercube();
     int hypercube2 = archive.getGrid().randomOccupiedHypercube();

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/randomsearch/RandomSearch.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/randomsearch/RandomSearch.java
@@ -21,6 +21,8 @@
 
 package org.uma.jmetal.algorithm.multiobjective.randomsearch;
 
+import java.util.List;
+
 import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.Solution;
@@ -29,16 +31,16 @@ import org.uma.jmetal.util.archive.impl.NonDominatedSolutionListArchive;
 /**
  * This class implements a simple random search algorithm.
  */
-public class RandomSearch implements Algorithm {
-  private Problem problem ;
+public class RandomSearch<S extends Solution<?>> implements Algorithm<List<S>> {
+  private Problem<S> problem ;
   private int maxEvaluations ;
-  NonDominatedSolutionListArchive nonDominatedArchive ;
+  NonDominatedSolutionListArchive<S> nonDominatedArchive ;
 
   /** Constructor */
-  public RandomSearch(Problem problem, int maxEvaluations) {
+  public RandomSearch(Problem<S> problem, int maxEvaluations) {
     this.problem = problem ;
     this.maxEvaluations = maxEvaluations ;
-    nonDominatedArchive = new NonDominatedSolutionListArchive();
+    nonDominatedArchive = new NonDominatedSolutionListArchive<S>();
   }
 
   /* Getter */
@@ -51,7 +53,7 @@ public class RandomSearch implements Algorithm {
 
     evaluations = 0;
 
-    Solution newSolution;
+    S newSolution;
     for (int i = 0; i < maxEvaluations; i++) {
       newSolution = problem.createSolution() ;
       problem.evaluate(newSolution);
@@ -61,7 +63,7 @@ public class RandomSearch implements Algorithm {
     }
   }
 
-  @Override public Object getResult() {
+  @Override public List<S> getResult() {
     return nonDominatedArchive.getSolutionList();
   }
 } 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/randomsearch/RandomSearchBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/randomsearch/RandomSearchBuilder.java
@@ -21,15 +21,15 @@
 
 package org.uma.jmetal.algorithm.multiobjective.randomsearch;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.AlgorithmBuilder;
 
 /**
  * This class implements a simple random search algorithm.
  */
-public class RandomSearchBuilder implements AlgorithmBuilder {
-  private Problem problem ;
+public class RandomSearchBuilder<S extends Solution<?>> implements AlgorithmBuilder<RandomSearch<S>> {
+  private Problem<S> problem ;
   private int maxEvaluations ;
 
   /* Getter */
@@ -38,18 +38,18 @@ public class RandomSearchBuilder implements AlgorithmBuilder {
   }
 
 
-  public RandomSearchBuilder(Problem problem) {
+  public RandomSearchBuilder(Problem<S> problem) {
     this.problem = problem ;
     maxEvaluations = 25000 ;
   }
 
-  public RandomSearchBuilder setMaxEvaluations(int maxEvaluations) {
+  public RandomSearchBuilder<S> setMaxEvaluations(int maxEvaluations) {
     this.maxEvaluations = maxEvaluations ;
 
     return this ;
   }
 
-  public Algorithm build() {
-    return new RandomSearch(problem, maxEvaluations) ;
+  public RandomSearch<S> build() {
+    return new RandomSearch<S>(problem, maxEvaluations) ;
   }
 } 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSO.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSO.java
@@ -17,7 +17,6 @@ import org.uma.jmetal.algorithm.impl.AbstractParticleSwarmOptimization;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.archive.Archive;
 import org.uma.jmetal.util.archive.impl.CrowdingDistanceArchive;
@@ -59,24 +58,24 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
 
   private Archive<DoubleSolution> leaders;
   private double[][] speed;
-  private Comparator<Solution> dominanceComparator;
-  private Comparator<Solution> crowdingDistanceComparator;
+  private Comparator<DoubleSolution> dominanceComparator;
+  private Comparator<DoubleSolution> crowdingDistanceComparator;
 
-  private MutationOperator mutation;
+  private MutationOperator<DoubleSolution> mutation;
 
   private double deltaMax[];
   private double deltaMin[];
 
-  private SolutionListEvaluator evaluator;
+  private SolutionListEvaluator<DoubleSolution> evaluator;
 
   /**
    * Constructor
    */
   public SMPSO(DoubleProblem problem, int swarmSize, Archive<DoubleSolution> leaders,
-      MutationOperator mutationOperator, int maxIterations, double r1Min, double r1Max,
+      MutationOperator<DoubleSolution> mutationOperator, int maxIterations, double r1Min, double r1Max,
       double r2Min, double r2Max, double c1Min, double c1Max, double c2Min, double c2Max,
       double weightMin, double weightMax, double changeVelocity1, double changeVelocity2,
-      SolutionListEvaluator evaluator) {
+      SolutionListEvaluator<DoubleSolution> evaluator) {
     this.problem = problem;
     this.swarmSize = swarmSize;
     this.leaders = leaders;
@@ -99,8 +98,8 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
     randomGenerator = JMetalRandom.getInstance();
     this.evaluator = evaluator;
 
-    dominanceComparator = new DominanceComparator();
-    crowdingDistanceComparator = new CrowdingDistanceComparator();
+    dominanceComparator = new DominanceComparator<DoubleSolution>();
+    crowdingDistanceComparator = new CrowdingDistanceComparator<DoubleSolution>();
     best = new DoubleSolution[swarmSize];
     speed = new double[swarmSize][problem.getNumberOfVariables()];
 
@@ -136,9 +135,9 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
 
   protected void updateLeadersDensityEstimator() {
     if (leaders instanceof CrowdingDistanceArchive) {
-      ((CrowdingDistanceArchive) leaders).computeDistance();
+      ((CrowdingDistanceArchive<DoubleSolution>) leaders).computeDistance();
     } else if (leaders instanceof FastHypervolumeArchive) {
-      ((FastHypervolumeArchive) leaders).computeHVContribution();
+      ((FastHypervolumeArchive<DoubleSolution>) leaders).computeHVContribution();
     } else {
       throw new JMetalException("Invalid setArchive type");
     }
@@ -191,7 +190,7 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
 
   @Override protected void initializeParticlesMemory(List<DoubleSolution> swarm) {
     for (int i = 0; i < swarm.size(); i++) {
-      Solution particle = swarm.get(i).copy();
+      DoubleSolution particle = (DoubleSolution) swarm.get(i).copy();
       best[i] = (DoubleSolution) particle;
     }
   }
@@ -273,7 +272,7 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
   }
 
   protected DoubleSolution selectGlobalBest() {
-    Solution one, two;
+    DoubleSolution one, two;
     DoubleSolution bestGlobal;
     int pos1 = randomGenerator.nextInt(0, leaders.getSolutionList().size() - 1);
     int pos2 = randomGenerator.nextInt(0, leaders.getSolutionList().size() - 1);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSOBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSOBuilder.java
@@ -27,7 +27,7 @@ import org.uma.jmetal.util.AlgorithmBuilder;
 /**
  * Created by antonio on 24/09/14.
  */
-public class SMPSOBuilder implements AlgorithmBuilder {
+public class SMPSOBuilder implements AlgorithmBuilder<SMPSO> {
   private DoubleProblem problem;
 
   private double c1Max;
@@ -48,13 +48,13 @@ public class SMPSOBuilder implements AlgorithmBuilder {
 
   protected int archiveSize;
 
-  protected MutationOperator mutationOperator;
+  protected MutationOperator<DoubleSolution> mutationOperator;
 
   private Archive<DoubleSolution> leaders;
 
-  private SolutionListEvaluator evaluator;
+  private SolutionListEvaluator<DoubleSolution> evaluator;
 
-  public SMPSOBuilder(DoubleProblem problem, Archive leaders) {
+  public SMPSOBuilder(DoubleProblem problem, Archive<DoubleSolution> leaders) {
     this.problem = problem;
     this.leaders = leaders;
 
@@ -75,7 +75,7 @@ public class SMPSOBuilder implements AlgorithmBuilder {
     changeVelocity2 = -1;
 
     mutationOperator = new PolynomialMutation(1.0/problem.getNumberOfVariables(), 20.0) ;
-    evaluator = new SequentialSolutionListEvaluator() ;
+    evaluator = new SequentialSolutionListEvaluator<DoubleSolution>() ;
   }
 
   /* Getters */
@@ -119,7 +119,7 @@ public class SMPSOBuilder implements AlgorithmBuilder {
     return c2Min;
   }
 
-  public MutationOperator getMutation() {
+  public MutationOperator<DoubleSolution> getMutation() {
     return mutationOperator;
   }
 
@@ -152,7 +152,7 @@ public class SMPSOBuilder implements AlgorithmBuilder {
     return this;
   }
 
-  public SMPSOBuilder setMutation(MutationOperator mutation) {
+  public SMPSOBuilder setMutation(MutationOperator<DoubleSolution> mutation) {
     mutationOperator = mutation;
 
     return this;
@@ -236,7 +236,7 @@ public class SMPSOBuilder implements AlgorithmBuilder {
     return this;
   }
 
-  public SMPSOBuilder setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public SMPSOBuilder setSolutionListEvaluator(SolutionListEvaluator<DoubleSolution> evaluator) {
     this.evaluator = evaluator ;
 
     return this ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 17/4/15.
  */
-public class SMSEMOA<S extends Solution> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class SMSEMOA<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
   protected final int maxEvaluations;
   protected final int populationSize;
   protected final double offset ;
@@ -137,7 +137,7 @@ public class SMSEMOA<S extends Solution> extends AbstractGeneticAlgorithm<S, Lis
   }
 
   protected Ranking<S> computeRanking(List<S> solutionList) {
-    Ranking ranking = new DominanceRanking();
+    Ranking<S> ranking = new DominanceRanking<S>();
     ranking.computeRanking(solutionList);
 
     return ranking;
@@ -173,7 +173,7 @@ public class SMSEMOA<S extends Solution> extends AbstractGeneticAlgorithm<S, Lis
         }
       }
 
-      HypervolumeContribution hvContribution = new HypervolumeContribution() ;
+      HypervolumeContribution<S> hvContribution = new HypervolumeContribution<S>() ;
 
       // calculate contributions and sort
       double[] contributions = hvContributions(FrontUtils.convertFrontToArray(invertedFront));

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA.java
@@ -39,7 +39,7 @@ public class SMSEMOA<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, 
    * Constructor
    */
   public SMSEMOA(Problem<S> problem, int maxEvaluations, int populationSize, double offset,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
       SelectionOperator<List<S>, S> selectionOperator) {
     super() ;
     this.problem = problem;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA2.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA2.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 17/4/15.
  */
-public class SMSEMOA2<S extends Solution> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class SMSEMOA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
   protected final int maxEvaluations;
   protected final int populationSize;
   protected final double offset ;
@@ -31,7 +31,7 @@ public class SMSEMOA2<S extends Solution> extends AbstractGeneticAlgorithm<S, Li
    * Constructor
    */
   public SMSEMOA2(Problem<S> problem, int maxEvaluations, int populationSize, double offset,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
       SelectionOperator<List<S>, S> selectionOperator, Hypervolume hypervolume) {
     super() ;
     this.problem = problem;
@@ -129,7 +129,7 @@ public class SMSEMOA2<S extends Solution> extends AbstractGeneticAlgorithm<S, Li
   }
 
   protected Ranking<S> computeRanking(List<S> solutionList) {
-    Ranking ranking = new DominanceRanking();
+    Ranking<S> ranking = new DominanceRanking<S>();
     ranking.computeRanking(solutionList);
 
     return ranking;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOABuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOABuilder.java
@@ -1,6 +1,5 @@
 package org.uma.jmetal.algorithm.multiobjective.smsemoa;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.SelectionOperator;
@@ -14,7 +13,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 17/4/15.
  */
-public class SMSEMOABuilder<S extends Solution> implements AlgorithmBuilder {
+public class SMSEMOABuilder<S extends Solution<?>> implements AlgorithmBuilder<SMSEMOA<S>> {
   private static final double DEFAULT_OFFSET = 100.0 ;
 
   protected Problem<S> problem;
@@ -22,13 +21,13 @@ public class SMSEMOABuilder<S extends Solution> implements AlgorithmBuilder {
   protected int populationSize;
   protected int maxEvaluations;
 
-  private CrossoverOperator<List<S>, List<S>> crossoverOperator;
+  private CrossoverOperator<S> crossoverOperator;
   private MutationOperator<S> mutationOperator;
-  protected SelectionOperator selectionOperator;
+  protected SelectionOperator<List<S>, S> selectionOperator;
 
   protected double offset ;
 
-  public SMSEMOABuilder(Problem<S> problem, CrossoverOperator<List<S>, List<S>> crossoverOperator,
+  public SMSEMOABuilder(Problem<S> problem, CrossoverOperator<S> crossoverOperator,
       MutationOperator<S> mutationOperator) {
     this.problem = problem ;
     this.offset = DEFAULT_OFFSET ;
@@ -37,46 +36,46 @@ public class SMSEMOABuilder<S extends Solution> implements AlgorithmBuilder {
 
     this.crossoverOperator = crossoverOperator ;
     this.mutationOperator = mutationOperator ;
-    this.selectionOperator = new RandomSelection() ;
+    this.selectionOperator = new RandomSelection<S>() ;
   }
 
-  public SMSEMOABuilder setPopulationSize(int populationSize) {
+  public SMSEMOABuilder<S> setPopulationSize(int populationSize) {
     this.populationSize = populationSize ;
 
     return this ;
   }
 
-  public SMSEMOABuilder setMaxEvaluations(int maxEvaluations) {
+  public SMSEMOABuilder<S> setMaxEvaluations(int maxEvaluations) {
     this.maxEvaluations = maxEvaluations ;
 
     return this ;
   }
 
-  public SMSEMOABuilder setCrossoverOperator(CrossoverOperator<List<S>, List<S>> crossover) {
+  public SMSEMOABuilder<S> setCrossoverOperator(CrossoverOperator<S> crossover) {
     crossoverOperator = crossover ;
 
     return this ;
   }
 
-  public SMSEMOABuilder setMutationOperator(MutationOperator<S> mutation) {
+  public SMSEMOABuilder<S> setMutationOperator(MutationOperator<S> mutation) {
     mutationOperator = mutation ;
 
     return this ;
   }
 
-  public SMSEMOABuilder setSelectionOperator(SelectionOperator selection) {
+  public SMSEMOABuilder<S> setSelectionOperator(SelectionOperator<List<S>, S> selection) {
     selectionOperator = selection ;
 
     return this ;
   }
 
-  public SMSEMOABuilder setOffset(double offset) {
+  public SMSEMOABuilder<S> setOffset(double offset) {
     this.offset = offset ;
 
     return this ;
   }
 
-  @Override public Algorithm<List<S>> build() {
+  @Override public SMSEMOA<S> build() {
     return new SMSEMOA<S>(problem, maxEvaluations, populationSize, offset,
         crossoverOperator, mutationOperator, selectionOperator);
   }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/SPEA2.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/SPEA2.java
@@ -16,19 +16,19 @@ import java.util.List;
 /**
  * @author Juanjo
  **/
-public class SPEA2<S extends Solution> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class SPEA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
   protected final int maxIterations;
   protected final int populationSize;
   protected final Problem<S> problem;
   protected final SolutionListEvaluator<S> evaluator;
   protected int iterations;
   protected List<S> archive;
-  private final static StrengthRawFitness strenghtRawFitness = new StrengthRawFitness();
-  private final EnvironmentalSelection environmentalSelection;
+  private final StrengthRawFitness<S> strenghtRawFitness = new StrengthRawFitness<S>();
+  private final EnvironmentalSelection<S> environmentalSelection;
 
   public SPEA2(Problem<S> problem, int maxIterations, int populationSize,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
-      SelectionOperator selectionOperator, SolutionListEvaluator evaluator) {
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
+      SelectionOperator<List<S>, S> selectionOperator, SolutionListEvaluator<S> evaluator) {
     super();
     this.problem = problem;
     this.maxIterations = maxIterations;
@@ -37,7 +37,7 @@ public class SPEA2<S extends Solution> extends AbstractGeneticAlgorithm<S, List<
     this.crossoverOperator = crossoverOperator;
     this.mutationOperator = mutationOperator;
     this.selectionOperator = selectionOperator;
-    this.environmentalSelection = new EnvironmentalSelection(populationSize);
+    this.environmentalSelection = new EnvironmentalSelection<S>(populationSize);
 
     this.archive = new ArrayList<>(populationSize);
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/SPEA2Builder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/SPEA2Builder.java
@@ -1,6 +1,5 @@
 package org.uma.jmetal.algorithm.multiobjective.spea2;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.SelectionOperator;
@@ -17,7 +16,7 @@ import java.util.List;
 /**
  * Created by juanjo 
  */
-public class SPEA2Builder<S extends Solution> implements AlgorithmBuilder {
+public class SPEA2Builder<S extends Solution<?>> implements AlgorithmBuilder<SPEA2<S>> {
 
   /**
    * SPEA2Builder class
@@ -25,26 +24,26 @@ public class SPEA2Builder<S extends Solution> implements AlgorithmBuilder {
   private final Problem<S> problem;
   private int maxIterations;
   private int populationSize;
-  private CrossoverOperator<List<S>, List<S>> crossoverOperator;
+  private CrossoverOperator<S> crossoverOperator;
   private MutationOperator<S> mutationOperator;
-  private SelectionOperator selectionOperator;
-  private SolutionListEvaluator evaluator;
+  private SelectionOperator<List<S>, S> selectionOperator;
+  private SolutionListEvaluator<S> evaluator;
 
   /**
    * SPEA2Builder constructor
    */
-  public SPEA2Builder(Problem problem, CrossoverOperator<List<S>, List<S>> crossoverOperator,
+  public SPEA2Builder(Problem<S> problem, CrossoverOperator<S> crossoverOperator,
       MutationOperator<S> mutationOperator) {
     this.problem = problem;
     maxIterations = 250;
     populationSize = 100;
     this.crossoverOperator = crossoverOperator ;
     this.mutationOperator = mutationOperator ;
-    selectionOperator = new BinaryTournamentSelection();
-    evaluator = new SequentialSolutionListEvaluator();
+    selectionOperator = new BinaryTournamentSelection<S>();
+    evaluator = new SequentialSolutionListEvaluator<S>();
   }
 
-  public SPEA2Builder setMaxIterations(int maxIterations) {
+  public SPEA2Builder<S> setMaxIterations(int maxIterations) {
     if (maxIterations < 0) {
       throw new JMetalException("maxIterations is negative: " + maxIterations);
     }
@@ -53,7 +52,7 @@ public class SPEA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public SPEA2Builder setPopulationSize(int populationSize) {
+  public SPEA2Builder<S> setPopulationSize(int populationSize) {
     if (populationSize < 0) {
       throw new JMetalException("Population size is negative: " + populationSize);
     }
@@ -63,7 +62,7 @@ public class SPEA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public SPEA2Builder setSelectionOperator(SelectionOperator selectionOperator) {
+  public SPEA2Builder<S> setSelectionOperator(SelectionOperator<List<S>, S> selectionOperator) {
     if (selectionOperator == null) {
       throw new JMetalException("selectionOperator is null");
     }
@@ -72,7 +71,7 @@ public class SPEA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public SPEA2Builder setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public SPEA2Builder<S> setSolutionListEvaluator(SolutionListEvaluator<S> evaluator) {
     if (evaluator == null) {
       throw new JMetalException("evaluator is null");
     }
@@ -81,8 +80,8 @@ public class SPEA2Builder<S extends Solution> implements AlgorithmBuilder {
     return this;
   }
 
-  public Algorithm build() {
-    Algorithm algorithm = null ;
+  public SPEA2<S> build() {
+    SPEA2<S> algorithm = null ;
     algorithm = new SPEA2<S>(problem, maxIterations, populationSize, crossoverOperator,
           mutationOperator, selectionOperator, evaluator);
     
@@ -90,7 +89,7 @@ public class SPEA2Builder<S extends Solution> implements AlgorithmBuilder {
   }
 
   /* Getters */
-  public Problem getProblem() {
+  public Problem<S> getProblem() {
     return problem;
   }
 
@@ -102,19 +101,19 @@ public class SPEA2Builder<S extends Solution> implements AlgorithmBuilder {
     return populationSize;
   }
 
-  public CrossoverOperator getCrossoverOperator() {
+  public CrossoverOperator<S> getCrossoverOperator() {
     return crossoverOperator;
   }
 
-  public MutationOperator getMutationOperator() {
+  public MutationOperator<S> getMutationOperator() {
     return mutationOperator;
   }
 
-  public SelectionOperator getSelectionOperator() {
+  public SelectionOperator<List<S>, S> getSelectionOperator() {
     return selectionOperator;
   }
 
-  public SolutionListEvaluator getSolutionListEvaluator() {
+  public SolutionListEvaluator<S> getSolutionListEvaluator() {
     return evaluator;
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/util/EnvironmentalSelection.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/util/EnvironmentalSelection.java
@@ -14,10 +14,10 @@ import java.util.*;
  * @author Juanjo Durillo
  * @param <S>
  */
-public class EnvironmentalSelection<S extends Solution> implements SelectionOperator<List<S>,List<S>> {
+public class EnvironmentalSelection<S extends Solution<?>> implements SelectionOperator<List<S>,List<S>> {
 
   private int solutionsToSelect = 0;
-  private final StrengthRawFitness strengthRawFitness= new StrengthRawFitness();
+  private final StrengthRawFitness<S> strengthRawFitness= new StrengthRawFitness<S>();
 
   public EnvironmentalSelection(int solutionsToSelect) {
     this.solutionsToSelect = solutionsToSelect;
@@ -62,7 +62,7 @@ public class EnvironmentalSelection<S extends Solution> implements SelectionOper
 
     double [][] distance = SolutionListUtils.distanceMatrix(aux);
     List<List<Pair<Integer, Double>> > distanceList = new ArrayList<>();
-    LocationAttribute location = new LocationAttribute(aux);
+    LocationAttribute<S> location = new LocationAttribute<S>(aux);
     for (int pos = 0; pos < aux.size(); pos++) {
       List<Pair<Integer, Double>> distanceNodeList = new ArrayList<>();
       for (int ref = 0; ref < aux.size(); ref++) {
@@ -75,11 +75,9 @@ public class EnvironmentalSelection<S extends Solution> implements SelectionOper
 
 
     for (int q = 0; q < distanceList.size(); q++){
-      Collections.sort(distanceList.get(q),new Comparator () {
+      Collections.sort(distanceList.get(q),new Comparator<Pair<Integer, Double>> () {
         @Override
-        public int compare(Object o1, Object o2) {
-          Pair<Integer, Double> pair1 = (Pair<Integer, Double>)o1;
-          Pair<Integer, Double> pair2 = (Pair<Integer, Double>)o2;
+        public int compare(Pair<Integer, Double> pair1, Pair<Integer, Double> pair2) {
           if (pair1.getRight()  < pair2.getRight()) {
             return -1;
           } else if (pair1.getRight()  > pair2.getRight()) {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/util/EnvironmentalSelection.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/util/EnvironmentalSelection.java
@@ -49,7 +49,7 @@ public class EnvironmentalSelection<S extends Solution<?>> implements SelectionO
     }
 
     if (aux.size() < size){
-      StrengthFitnessComparator comparator = new StrengthFitnessComparator();
+      StrengthFitnessComparator<S> comparator = new StrengthFitnessComparator<S>();
       Collections.sort(source,comparator);
       int remain = size - aux.size();
       for (i = 0; i < remain; i++){

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolution.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolution.java
@@ -26,7 +26,6 @@ import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.operator.impl.selection.DifferentialEvolutionSelection;
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.comparator.ObjectiveComparator;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 
@@ -35,12 +34,12 @@ import java.util.*;
 /**
  * This class implements a differential evolution algorithm.
  */
-public class DifferentialEvolution extends AbstractDifferentialEvolution<Solution> {
+public class DifferentialEvolution extends AbstractDifferentialEvolution<DoubleSolution> {
   private DoubleProblem problem;
   private int populationSize;
   private int maxEvaluations;
-  private SolutionListEvaluator evaluator;
-  private Comparator<Solution> comparator;
+  private SolutionListEvaluator<DoubleSolution> evaluator;
+  private Comparator<DoubleSolution> comparator;
 
   private int evaluations;
 
@@ -56,7 +55,7 @@ public class DifferentialEvolution extends AbstractDifferentialEvolution<Solutio
    */
   public DifferentialEvolution(DoubleProblem problem, int maxEvaluations, int populationSize,
       DifferentialEvolutionCrossover crossoverOperator,
-      DifferentialEvolutionSelection selectionOperator, SolutionListEvaluator evaluator) {
+      DifferentialEvolutionSelection selectionOperator, SolutionListEvaluator<DoubleSolution> evaluator) {
     this.problem = problem;
     this.maxEvaluations = maxEvaluations;
     this.populationSize = populationSize;
@@ -64,7 +63,7 @@ public class DifferentialEvolution extends AbstractDifferentialEvolution<Solutio
     this.selectionOperator = selectionOperator;
     this.evaluator = evaluator;
 
-    comparator = new ObjectiveComparator(0);
+    comparator = new ObjectiveComparator<DoubleSolution>(0);
   }
   
   public int getEvaluations() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionBuilder.java
@@ -3,6 +3,7 @@ package org.uma.jmetal.algorithm.singleobjective.differentialevolution;
 import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.operator.impl.selection.DifferentialEvolutionSelection;
 import org.uma.jmetal.problem.DoubleProblem;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
@@ -17,7 +18,7 @@ public class DifferentialEvolutionBuilder {
   private int maxEvaluations;
   private DifferentialEvolutionCrossover crossoverOperator;
   private DifferentialEvolutionSelection selectionOperator;
-  private SolutionListEvaluator evaluator;
+  private SolutionListEvaluator<DoubleSolution> evaluator;
 
   public DifferentialEvolutionBuilder(DoubleProblem problem) {
     this.problem = problem;
@@ -25,7 +26,7 @@ public class DifferentialEvolutionBuilder {
     this.maxEvaluations = 25000;
     this.crossoverOperator = new DifferentialEvolutionCrossover(0.5, 0.5, "rand/1/bin");
     this.selectionOperator = new DifferentialEvolutionSelection();
-    this.evaluator = new SequentialSolutionListEvaluator();
+    this.evaluator = new SequentialSolutionListEvaluator<DoubleSolution>();
   }
 
   public DifferentialEvolutionBuilder setPopulationSize(int populationSize) {
@@ -60,7 +61,7 @@ public class DifferentialEvolutionBuilder {
     return this;
   }
 
-  public DifferentialEvolutionBuilder setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public DifferentialEvolutionBuilder setSolutionListEvaluator(SolutionListEvaluator<DoubleSolution> evaluator) {
     this.evaluator = evaluator;
 
     return this;
@@ -92,7 +93,7 @@ public class DifferentialEvolutionBuilder {
     return selectionOperator;
   }
 
-  public SolutionListEvaluator getSolutionListEvaluator() {
+  public SolutionListEvaluator<DoubleSolution> getSolutionListEvaluator() {
     return evaluator;
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
@@ -24,7 +24,6 @@ import org.uma.jmetal.algorithm.impl.AbstractEvolutionStrategy;
 import org.uma.jmetal.algorithm.singleobjective.evolutionstrategy.util.CMAESUtils;
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.comparator.ObjectiveComparator;
 
@@ -35,7 +34,7 @@ import java.util.*;
  */
 public class CovarianceMatrixAdaptationEvolutionStrategy
     extends AbstractEvolutionStrategy<DoubleSolution, DoubleSolution> {
-  private Comparator<Solution> comparator ;
+  private Comparator<DoubleSolution> comparator ;
   private int lambda ;
   private int evaluations ;
   private int maxEvaluations ;
@@ -122,7 +121,7 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
 
     long seed = System.currentTimeMillis();
     rand = new Random(seed);
-    comparator = new ObjectiveComparator(0);
+    comparator = new ObjectiveComparator<DoubleSolution>(0);
 
     initializeInternalParameters();
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/ElitistEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/ElitistEvolutionStrategy.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * Class implementing a (mu + lambda) Evolution Strategy (lambda must be divisible by mu)
  */
-public class ElitistEvolutionStrategy<S extends Solution> extends AbstractEvolutionStrategy<S, S> {
+public class ElitistEvolutionStrategy<S extends Solution<?>> extends AbstractEvolutionStrategy<S, S> {
   private Problem<S> problem;
 
   private int mu;
@@ -43,7 +43,7 @@ public class ElitistEvolutionStrategy<S extends Solution> extends AbstractEvolut
   private int evaluations;
   private MutationOperator<S> mutation;
 
-  private Comparator comparator;
+  private Comparator<S> comparator;
 
   /**
    * Constructor
@@ -56,7 +56,7 @@ public class ElitistEvolutionStrategy<S extends Solution> extends AbstractEvolut
     this.maxEvaluations = maxEvaluations;
     this.mutation = mutation;
 
-    comparator = new ObjectiveComparator(0);
+    comparator = new ObjectiveComparator<S>(0);
   }
 
   @Override protected void initProgress() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/EvolutionStrategyBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/EvolutionStrategyBuilder.java
@@ -10,7 +10,7 @@ import org.uma.jmetal.util.JMetalException;
 /**
  * Created by ajnebro on 10/3/15.
  */
-public class EvolutionStrategyBuilder<S extends Solution> implements AlgorithmBuilder {
+public class EvolutionStrategyBuilder<S extends Solution<?>> implements AlgorithmBuilder<Algorithm<S>> {
   public enum EvolutionStrategyVariant {ELITIST, NON_ELITIST}
 
   private Problem<S> problem;
@@ -30,19 +30,19 @@ public class EvolutionStrategyBuilder<S extends Solution> implements AlgorithmBu
     this.variant = variant ;
   }
 
-  public EvolutionStrategyBuilder setMu(int mu) {
+  public EvolutionStrategyBuilder<S> setMu(int mu) {
     this.mu = mu;
 
     return this;
   }
 
-  public EvolutionStrategyBuilder setLambda(int lambda) {
+  public EvolutionStrategyBuilder<S> setLambda(int lambda) {
     this.lambda = lambda;
 
     return this;
   }
 
-  public EvolutionStrategyBuilder setMaxEvaluations(int maxEvaluations) {
+  public EvolutionStrategyBuilder<S> setMaxEvaluations(int maxEvaluations) {
     this.maxEvaluations = maxEvaluations;
 
     return this;
@@ -71,7 +71,7 @@ public class EvolutionStrategyBuilder<S extends Solution> implements AlgorithmBu
     return maxEvaluations;
   }
 
-  public MutationOperator getMutation() {
+  public MutationOperator<S> getMutation() {
     return mutation;
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/NonElitistEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/NonElitistEvolutionStrategy.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * Class implementing a (mu + lambda) Evolution Strategy (lambda must be divisible by mu)
  */
-public class NonElitistEvolutionStrategy<S extends Solution> extends AbstractEvolutionStrategy<S, S> {
+public class NonElitistEvolutionStrategy<S extends Solution<?>> extends AbstractEvolutionStrategy<S, S> {
   private Problem<S> problem;
 
   private int mu;
@@ -43,7 +43,7 @@ public class NonElitistEvolutionStrategy<S extends Solution> extends AbstractEvo
   private int evaluations;
   private MutationOperator<S> mutation;
 
-  private Comparator<Solution> comparator;
+  private Comparator<S> comparator;
 
   /**
    * Constructor
@@ -56,7 +56,7 @@ public class NonElitistEvolutionStrategy<S extends Solution> extends AbstractEvo
     this.maxEvaluations = maxEvaluations;
     this.mutation = mutation;
 
-    comparator = new ObjectiveComparator(0);
+    comparator = new ObjectiveComparator<S>(0);
   }
 
   @Override protected void initProgress() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/GenerationalGeneticAlgorithm.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/GenerationalGeneticAlgorithm.java
@@ -14,22 +14,22 @@ import java.util.*;
 /**
  * Created by ajnebro on 26/10/14.
  */
-public class GenerationalGeneticAlgorithm<S extends Solution> extends AbstractGeneticAlgorithm<S, S> {
-  private Comparator<Solution> comparator;
+public class GenerationalGeneticAlgorithm<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, S> {
+  private Comparator<S> comparator;
   private int maxEvaluations;
   private int populationSize;
   private int evaluations;
 
   private Problem<S> problem;
 
-  private SolutionListEvaluator evaluator;
+  private SolutionListEvaluator<S> evaluator;
 
   /**
    * Constructor
    */
   public GenerationalGeneticAlgorithm(Problem<S> problem, int maxEvaluations, int populationSize,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
-      SelectionOperator selectionOperator, SolutionListEvaluator evaluator) {
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
+      SelectionOperator<List<S>, S> selectionOperator, SolutionListEvaluator<S> evaluator) {
     this.problem = problem;
     this.maxEvaluations = maxEvaluations;
     this.populationSize = populationSize;
@@ -40,7 +40,7 @@ public class GenerationalGeneticAlgorithm<S extends Solution> extends AbstractGe
 
     this.evaluator = evaluator;
 
-    comparator = new ObjectiveComparator(0);
+    comparator = new ObjectiveComparator<S>(0);
   }
 
   @Override protected boolean isStoppingConditionReached() {
@@ -56,7 +56,7 @@ public class GenerationalGeneticAlgorithm<S extends Solution> extends AbstractGe
     return population;
   }
 
-  @Override protected List<S> replacement(List population, List offspringPopulation) {
+  @Override protected List<S> replacement(List<S> population, List<S> offspringPopulation) {
     Collections.sort(population, comparator);
     offspringPopulation.add(population.get(0));
     offspringPopulation.add(population.get(1));

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/GeneticAlgorithmBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/GeneticAlgorithmBuilder.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 10/12/14.
  */
-public class GeneticAlgorithmBuilder<S extends Solution> {
+public class GeneticAlgorithmBuilder<S extends Solution<?>> {
   public enum GeneticAlgorithmVariant {GENERATIONAL, STEADY_STATE}
   /**
    * Builder class
@@ -24,19 +24,19 @@ public class GeneticAlgorithmBuilder<S extends Solution> {
   private Problem<S> problem;
   private int maxEvaluations;
   private int populationSize;
-  private CrossoverOperator<List<S>, List<S>> crossoverOperator;
+  private CrossoverOperator<S> crossoverOperator;
   private MutationOperator<S> mutationOperator;
-  private SelectionOperator selectionOperator;
-  private SolutionListEvaluator evaluator;
+  private SelectionOperator<List<S>, S> selectionOperator;
+  private SolutionListEvaluator<S> evaluator;
 
   private GeneticAlgorithmVariant variant ;
-  private SelectionOperator defaultSelectionOperator = new BinaryTournamentSelection() ;
+  private SelectionOperator<List<S>, S> defaultSelectionOperator = new BinaryTournamentSelection<S>() ;
 
   /**
    * Builder constructor
    */
   public GeneticAlgorithmBuilder(Problem<S> problem,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator,
+      CrossoverOperator<S> crossoverOperator,
       MutationOperator<S> mutationOperator, GeneticAlgorithmVariant variant) {
     this.problem = problem;
     maxEvaluations = 25000;
@@ -45,30 +45,30 @@ public class GeneticAlgorithmBuilder<S extends Solution> {
     this.crossoverOperator = crossoverOperator ;
     this.selectionOperator = defaultSelectionOperator ;
 
-    evaluator = new SequentialSolutionListEvaluator();
+    evaluator = new SequentialSolutionListEvaluator<S>();
 
     this.variant = variant ;
   }
 
-  public GeneticAlgorithmBuilder setMaxEvaluations(int maxEvaluations) {
+  public GeneticAlgorithmBuilder<S> setMaxEvaluations(int maxEvaluations) {
     this.maxEvaluations = maxEvaluations;
 
     return this;
   }
 
-  public GeneticAlgorithmBuilder setPopulationSize(int populationSize) {
+  public GeneticAlgorithmBuilder<S> setPopulationSize(int populationSize) {
     this.populationSize = populationSize;
 
     return this;
   }
 
-  public GeneticAlgorithmBuilder setSelectionOperator(SelectionOperator selectionOperator) {
+  public GeneticAlgorithmBuilder<S> setSelectionOperator(SelectionOperator<List<S>, S> selectionOperator) {
     this.selectionOperator = selectionOperator;
 
     return this;
   }
 
-  public GeneticAlgorithmBuilder setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public GeneticAlgorithmBuilder<S> setSolutionListEvaluator(SolutionListEvaluator<S> evaluator) {
     this.evaluator = evaluator;
 
     return this;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/SteadyStateGeneticAlgorithm.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/SteadyStateGeneticAlgorithm.java
@@ -16,8 +16,8 @@ import java.util.List;
 /**
  * Created by ajnebro on 26/10/14.
  */
-public class SteadyStateGeneticAlgorithm<S extends Solution> extends AbstractGeneticAlgorithm<S, S> {
-  private Comparator<Solution> comparator;
+public class SteadyStateGeneticAlgorithm<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, S> {
+  private Comparator<S> comparator;
   private int maxEvaluations;
   private int populationSize;
   private int evaluations;
@@ -28,8 +28,8 @@ public class SteadyStateGeneticAlgorithm<S extends Solution> extends AbstractGen
    * Constructor
    */
   public SteadyStateGeneticAlgorithm(Problem<S> problem, int maxEvaluations, int populationSize,
-      CrossoverOperator<List<S>, List<S>> crossoverOperator, MutationOperator<S> mutationOperator,
-      SelectionOperator selectionOperator) {
+      CrossoverOperator<S> crossoverOperator, MutationOperator<S> mutationOperator,
+      SelectionOperator<List<S>, S> selectionOperator) {
     this.problem = problem;
     this.maxEvaluations = maxEvaluations;
     this.populationSize = populationSize;
@@ -38,7 +38,7 @@ public class SteadyStateGeneticAlgorithm<S extends Solution> extends AbstractGen
     this.mutationOperator = mutationOperator;
     this.selectionOperator = selectionOperator;
 
-    comparator = new ObjectiveComparator(0);
+    comparator = new ObjectiveComparator<S>(0);
   }
 
   @Override protected boolean isStoppingConditionReached() {

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCellIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCellIT.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 public class MOCellIT {
   Algorithm<List<DoubleSolution>> algorithm;
   DoubleProblem problem ;
-  CrossoverOperator<List<DoubleSolution>,List<DoubleSolution>> crossover;
+  CrossoverOperator<DoubleSolution> crossover;
   MutationOperator<DoubleSolution> mutation;
 
   @Before
@@ -40,7 +40,7 @@ public class MOCellIT {
 
   @Test
   public void shouldTheAlgorithmReturnANumberOfSolutionsWhenSolvingASimpleProblem() throws Exception {
-    algorithm = new MOCellBuilder(problem, crossover, mutation)
+    algorithm = new MOCellBuilder<DoubleSolution>(problem, crossover, mutation)
         .build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
@@ -57,7 +57,7 @@ public class MOCellIT {
 
   @Test
   public void shouldTheHypervolumeHaveAMininumValue() throws Exception {
-    algorithm = new MOCellBuilder(problem, crossover, mutation)
+    algorithm = new MOCellBuilder<DoubleSolution>(problem, crossover, mutation)
         .build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIBuilderTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIBuilderTest.java
@@ -26,10 +26,10 @@ import static org.mockito.Mockito.when;
  */
 public class NSGAIIBuilderTest {
   private NSGAIIBuilder<DoubleSolution> builder;
-  private Problem problem;
+  private Problem<DoubleSolution> problem;
   private static final double EPSILON = 0.000000000000001;
   private static final int NUMBER_OF_VARIABLES_OF_THE_MOCKED_PROBLEM = 20;
-  private CrossoverOperator<List<DoubleSolution>,List<DoubleSolution>> crossover;
+  private CrossoverOperator<DoubleSolution> crossover;
   private MutationOperator<DoubleSolution> mutation;
 
   @Before public void startup() {
@@ -44,7 +44,7 @@ public class NSGAIIBuilderTest {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    builder = new NSGAIIBuilder(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII);
+    builder = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII);
   }
 
   @After public void cleanup() {
@@ -53,7 +53,7 @@ public class NSGAIIBuilderTest {
   }
 
   @Test public void buildAlgorithm() {
-    NSGAII algorithm = (NSGAII) builder.build();
+    NSGAII<DoubleSolution> algorithm = builder.build();
     assertNotNull(algorithm);
   }
 
@@ -94,7 +94,7 @@ public class NSGAIIBuilderTest {
   }
 
   @Test public void setNewSelectionOperator() {
-    SelectionOperator selection = mock(SelectionOperator.class);
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection = mock(SelectionOperator.class);
     assertNotEquals(selection, builder.getSelectionOperator());
     builder.setSelectionOperator(selection);
     assertEquals(selection, builder.getSelectionOperator());
@@ -105,8 +105,8 @@ public class NSGAIIBuilderTest {
   }
 
   @Test public void setNewEvaluator() {
-    MultithreadedSolutionListEvaluator evaluator =
-        new MultithreadedSolutionListEvaluator(2, problem);
+    MultithreadedSolutionListEvaluator<DoubleSolution> evaluator =
+        new MultithreadedSolutionListEvaluator<DoubleSolution>(2, problem);
     assertNotEquals(evaluator, builder.getSolutionListEvaluator());
     builder.setSolutionListEvaluator(evaluator);
     assertEquals(evaluator, builder.getSolutionListEvaluator());

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIIT.java
@@ -6,10 +6,8 @@ import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
-import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.problem.multiobjective.Kursawe;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.AlgorithmRunner;
 
 import java.util.List;
@@ -17,12 +15,12 @@ import java.util.List;
 import static org.junit.Assert.assertTrue;
 
 public class NSGAIIIT {
-  Algorithm<List<Solution>> algorithm;
+  Algorithm<List<DoubleSolution>> algorithm;
 
   @Test
   public void shouldTheAlgorithmReturnANumberOfSolutionsWhenSolvingASimpleProblem() throws Exception {
-    Problem problem = new Kursawe() ;
-    CrossoverOperator<List<DoubleSolution>,List<DoubleSolution>> crossover;
+    Kursawe problem = new Kursawe() ;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
 
     double crossoverProbability = 0.9 ;
@@ -33,12 +31,12 @@ public class NSGAIIIT {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    algorithm = new NSGAIIBuilder(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII).build() ;
+    algorithm = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII).build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
         .execute() ;
 
-    List<Solution> population = algorithm.getResult() ;
+    List<DoubleSolution> population = algorithm.getResult() ;
 
     /*
     Rationale: the default problem is Kursawe, and usually NSGA-II, configured with standard

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSOIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSOIT.java
@@ -22,7 +22,7 @@ public class SMPSOIT {
   public void shouldTheAlgorithmReturnANumberOfSolutionsWhenSolvingASimpleProblem() throws Exception {
     DoubleProblem problem = new ZDT4() ;
 
-    algorithm = new SMPSOBuilder(problem, new CrowdingDistanceArchive(100)).build() ;
+    algorithm = new SMPSOBuilder(problem, new CrowdingDistanceArchive<DoubleSolution>(100)).build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
         .execute();
@@ -40,7 +40,7 @@ public class SMPSOIT {
   public void shouldTheHypervolumeHaveAMininumValue() throws Exception {
     DoubleProblem problem = new ZDT4() ;
 
-    algorithm = new SMPSOBuilder(problem, new CrowdingDistanceArchive(100)).build() ;
+    algorithm = new SMPSOBuilder(problem, new CrowdingDistanceArchive<DoubleSolution>(100)).build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
         .execute();

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOAIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOAIT.java
@@ -8,7 +8,6 @@ import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
 import org.uma.jmetal.operator.impl.selection.RandomSelection;
 import org.uma.jmetal.problem.DoubleProblem;
-import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.problem.multiobjective.zdt.ZDT4;
 import org.uma.jmetal.qualityindicator.impl.Hypervolume;
 import org.uma.jmetal.solution.DoubleSolution;
@@ -25,8 +24,8 @@ public class SMSEMOAIT {
 
   @Test
   public void shouldTheAlgorithmReturnANumberOfSolutionsWhenSolvingASimpleProblem() throws Exception {
-    Problem problem = new ZDT4() ;
-    CrossoverOperator<List<DoubleSolution>,List<DoubleSolution>> crossover;
+    ZDT4 problem = new ZDT4() ;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
 
     double crossoverProbability = 0.9 ;
@@ -38,7 +37,7 @@ public class SMSEMOAIT {
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
     algorithm = new SMSEMOABuilder<>(problem, crossover, mutation)
-        .setSelectionOperator(new RandomSelection())
+        .setSelectionOperator(new RandomSelection<DoubleSolution>())
         .setMaxEvaluations(25000)
         .setPopulationSize(100)
         .build() ;
@@ -59,7 +58,7 @@ public class SMSEMOAIT {
   public void shouldTheHypervolumeHaveAMininumValue() throws Exception {
     DoubleProblem problem = new ZDT4() ;
 
-    CrossoverOperator<List<DoubleSolution>,List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
 
     double crossoverProbability = 0.9 ;
@@ -71,7 +70,7 @@ public class SMSEMOAIT {
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
     algorithm = new SMSEMOABuilder<>(problem, crossover, mutation)
-        .setSelectionOperator(new RandomSelection())
+        .setSelectionOperator(new RandomSelection<DoubleSolution>())
         .setMaxEvaluations(25000)
         .setPopulationSize(100)
         .build();

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionBuilderTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionBuilderTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.operator.impl.selection.DifferentialEvolutionSelection;
 import org.uma.jmetal.problem.DoubleProblem;
-import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.evaluator.impl.MultithreadedSolutionListEvaluator;
@@ -86,8 +85,8 @@ public class DifferentialEvolutionBuilderTest {
   }
 
   @Test public void setNewEvaluator() {
-    MultithreadedSolutionListEvaluator evaluator =
-        new MultithreadedSolutionListEvaluator(2, problem);
+    MultithreadedSolutionListEvaluator<DoubleSolution> evaluator =
+        new MultithreadedSolutionListEvaluator<DoubleSolution>(2, problem);
     assertNotEquals(evaluator, builder.getSolutionListEvaluator());
     builder.setSolutionListEvaluator(evaluator);
     assertEquals(evaluator, builder.getSolutionListEvaluator());

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionTest.java
@@ -41,7 +41,7 @@ public class DifferentialEvolutionTest {
 
   @Mock private DifferentialEvolutionSelection selection;
 
-  @Mock private SequentialSolutionListEvaluator evaluator;
+  @Mock private SequentialSolutionListEvaluator<DoubleSolution> evaluator;
 
   @Mock private DoubleProblem problem;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionStrategy.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionStrategy.java
@@ -6,6 +6,6 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by ajnebro on 26/10/14.
  */
-public abstract class AbstractEvolutionStrategy<S extends Solution, Result> extends AbstractEvolutionaryAlgorithm<S, Result> {
+public abstract class AbstractEvolutionStrategy<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, Result> {
   protected MutationOperator<S> mutationOperator ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
@@ -10,7 +10,7 @@ import java.util.List;
  * @param <S> Solution
  * @param <R> Result
  */
-public abstract class AbstractEvolutionaryAlgorithm<S extends Solution, R>  implements Algorithm<R>{
+public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, R>  implements Algorithm<R>{
   private List<S> population;
 
   public List<S> getPopulation() {

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 26/10/14.
  */
-public abstract class AbstractGeneticAlgorithm<S extends Solution, Result> extends AbstractEvolutionaryAlgorithm<S, Result> {
+public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, Result> {
   protected SelectionOperator<List<S>, S> selectionOperator ;
   protected CrossoverOperator<List<S>, List<S>> crossoverOperator ;
   protected MutationOperator<S> mutationOperator ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
@@ -12,6 +12,6 @@ import java.util.List;
  */
 public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, Result> {
   protected SelectionOperator<List<S>, S> selectionOperator ;
-  protected CrossoverOperator<List<S>, List<S>> crossoverOperator ;
+  protected CrossoverOperator<S> crossoverOperator ;
   protected MutationOperator<S> mutationOperator ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractParticleSwarmOptimization.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractParticleSwarmOptimization.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 26/10/14.
  */
-public abstract class AbstractParticleSwarmOptimization<S extends Solution, Result> implements Algorithm <Result> {
+public abstract class AbstractParticleSwarmOptimization<S extends Solution<?>, Result> implements Algorithm <Result> {
   protected abstract void initProgress() ;
   protected abstract void updateProgress() ;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractScatterSearch.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractScatterSearch.java
@@ -11,7 +11,7 @@ import java.util.List;
  * @param <S> Solution
  * @param <R> Result
  */
-public abstract class AbstractScatterSearch<S extends Solution, R>  implements Algorithm<R>{
+public abstract class AbstractScatterSearch<S extends Solution<?>, R>  implements Algorithm<R>{
   private List<S> population;
 
   public List<S> getPopulation() {

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/CrossoverOperator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/CrossoverOperator.java
@@ -7,7 +7,5 @@ import java.util.List;
 /**
  * Created by Antonio J. Nebro on 04/09/14.
  */
-public interface CrossoverOperator<
-        Source extends List<? extends Solution>,
-        Result extends List<? extends Solution>> extends Operator<Source,Result> {
+public interface CrossoverOperator<S extends Solution<?>> extends Operator<List<S>,List<S>> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/LocalSearchOperator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/LocalSearchOperator.java
@@ -5,7 +5,7 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by cbarba on 5/3/15.
  */
-public interface LocalSearchOperator <Source extends Solution> extends Operator<Source, Source> {
+public interface LocalSearchOperator <Source extends Solution<?>> extends Operator<Source, Source> {
     /**
      * Returns the number of evaluations made by the local search operator
      */

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/MutationOperator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/MutationOperator.java
@@ -5,5 +5,5 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by Antonio J. Nebro on 05/09/14.
  */
-public interface MutationOperator<Source extends Solution> extends Operator<Source, Source> {
+public interface MutationOperator<Source extends Solution<?>> extends Operator<Source, Source> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/BLXAlphaCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/BLXAlphaCrossover.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @author Antonio J. Nebro.
  * @version 1.0
  */
-public class BLXAlphaCrossover implements CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> {
+public class BLXAlphaCrossover implements CrossoverOperator<DoubleSolution> {
   private static final double DEFAULT_ALPHA = 0.5;
 
   private double crossoverProbability;

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/DifferentialEvolutionCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/DifferentialEvolutionCrossover.java
@@ -46,7 +46,7 @@ import java.util.List;
  * - current-to-rand/1/bin (current-to-best/1/bin)
  * - current-to-rand/1/exp (current-to-best/1/exp)
  */
-public class DifferentialEvolutionCrossover implements CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> {
+public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleSolution> {
   private static final double DEFAULT_CR = 0.5;
   private static final double DEFAULT_F = 0.5;
   private static final double DEFAULT_K = 0.5;

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/HUXCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/HUXCrossover.java
@@ -32,7 +32,7 @@ import java.util.List;
  * @author Juan J. Durillo
  * @version 1.0
  */
-public class HUXCrossover implements CrossoverOperator<List<BinarySolution>, List<BinarySolution>> {
+public class HUXCrossover implements CrossoverOperator<BinarySolution> {
   private double crossoverProbability ;
   private JMetalRandom randomGenerator ;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/IntegerSBXCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/IntegerSBXCrossover.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** This class allows to apply a SBX crossover operator using two parent solutions (Integer encoding) */
-public class IntegerSBXCrossover implements CrossoverOperator<List<IntegerSolution>, List<IntegerSolution>> {
+public class IntegerSBXCrossover implements CrossoverOperator<IntegerSolution> {
   /** EPS defines the minimum difference allowed between real values */
   private static final double EPS = 1.0e-14;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/NullCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/NullCrossover.java
@@ -27,21 +27,21 @@ import java.util.List;
  * @author Antonio J. Nebro
  * @version 1.0
  */
-public class NullCrossover<Source extends List<? extends Solution>, Result extends List<? extends Solution>>
-    implements CrossoverOperator<Source, Result> {
+public class NullCrossover<S extends Solution<?>>
+    implements CrossoverOperator<S> {
 
   /** Execute() method */
-  @Override public Result execute(Source source) {
+  @Override public List<S> execute(List<S> source) {
     if (null == source) {
       throw new JMetalException("Null parameter") ;
     } else if (source.size() != 2) {
       throw new JMetalException("There must be two parents instead of " + source.size()) ;
     }
 
-    List<Solution> list = new ArrayList<>() ;
-    list.add(source.get(0).copy()) ;
-    list.add(source.get(1).copy()) ;
+    List<S> list = new ArrayList<>() ;
+    list.add((S) source.get(0).copy()) ;
+    list.add((S) source.get(1).copy()) ;
 
-    return (Result) list ;
+    return list ;
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/PMXCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/PMXCrossover.java
@@ -36,7 +36,7 @@ import java.util.List;
  * the type of those variables must be VariableType_.Permutation.
  */
 public class PMXCrossover implements
-    CrossoverOperator<List<PermutationSolution<Integer>>, List<PermutationSolution<Integer>>> {
+    CrossoverOperator<PermutationSolution<Integer>> {
   private double crossoverProbability = 1.0;
   private JMetalRandom randomGenerator ;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/SBXCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/SBXCrossover.java
@@ -33,7 +33,7 @@ import java.util.List;
  * @author Juan J. Durillo
  * @version 1.0
  */
-public class SBXCrossover implements CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> {
+public class SBXCrossover implements CrossoverOperator<DoubleSolution> {
   /** EPS defines the minimum difference allowed between real values */
   private static final double EPS = 1.0e-14;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/SinglePointCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/SinglePointCrossover.java
@@ -28,7 +28,7 @@ import java.util.List;
  *
  * This class implements a single point crossover operator.
  */
-public class SinglePointCrossover implements CrossoverOperator<List<BinarySolution>, List<BinarySolution>> {
+public class SinglePointCrossover implements CrossoverOperator<BinarySolution> {
   private double crossoverProbability ;
   private JMetalRandom randomGenerator ;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/localsearch/MutationLocalSearch.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/localsearch/MutationLocalSearch.java
@@ -16,19 +16,19 @@ import java.util.Comparator;
  * mutation operator. An archive is used to store the non-dominated solutions
  * found during the search.
  */
-public class MutationLocalSearch implements LocalSearchOperator<Solution>{
+public class MutationLocalSearch<S extends Solution<?>> implements LocalSearchOperator<S>{
 
 
     /**
      * Stores the problem to solve
      */
-    private Problem problem;
+    private Problem<S> problem;
 
     /**
      * Stores a reference to the archive in which the non-dominated solutions are
      * inserted
      */
-    private Archive archive;
+    private Archive<S> archive;
 
     private int improvementRounds ;
 
@@ -36,12 +36,12 @@ public class MutationLocalSearch implements LocalSearchOperator<Solution>{
      * Stores comparators for dealing with constraints and dominance checking,
      * respectively.
      */
-    private Comparator constraintComparator ;
-    private Comparator dominanceComparator ;
+    private Comparator<S> constraintComparator ;
+    private Comparator<S> dominanceComparator ;
     /**
      * Stores the mutation operator
      */
-    private MutationOperator mutationOperator;
+    private MutationOperator<S> mutationOperator;
 
     /**
      * Stores the number of evaluations_ carried out
@@ -58,14 +58,14 @@ public class MutationLocalSearch implements LocalSearchOperator<Solution>{
 
      */
 
-    public  MutationLocalSearch(int improvementRounds,MutationOperator mutationOperator,
-                                Archive archive,Problem problem ){
+    public  MutationLocalSearch(int improvementRounds,MutationOperator<S> mutationOperator,
+                                Archive<S> archive,Problem<S> problem ){
         this.problem=problem;
         this.mutationOperator=mutationOperator;
         this.improvementRounds=improvementRounds;
         this.archive=archive;
-        dominanceComparator  = new DominanceComparator();
-        constraintComparator = new OverallConstraintViolationComparator();
+        dominanceComparator  = new DominanceComparator<S>();
+        constraintComparator = new OverallConstraintViolationComparator<S>();
         evaluations=0;
     }
 
@@ -78,7 +78,7 @@ public class MutationLocalSearch implements LocalSearchOperator<Solution>{
      * @param  solution representing a solution
      * @return An object containing the new improved solution
      */
-    public Solution  execute(Solution solution)  {
+    public S  execute(S solution)  {
         int i = 0;
         int best = 0;
         evaluations = 0;
@@ -86,12 +86,12 @@ public class MutationLocalSearch implements LocalSearchOperator<Solution>{
         int rounds = improvementRounds;
 
         if (rounds <= 0)
-            return solution.copy();
+            return (S) solution.copy();
 
         do
         {
             i++;
-            Solution mutatedSolution = solution.copy();
+            S mutatedSolution = (S) solution.copy();
 
             mutationOperator.execute(mutatedSolution);
 
@@ -100,7 +100,7 @@ public class MutationLocalSearch implements LocalSearchOperator<Solution>{
             if (problem.getNumberOfConstraints() > 0)
             {
 
-                ((ConstrainedProblem)problem).evaluateConstraints(mutatedSolution);
+                ((ConstrainedProblem<S>)problem).evaluateConstraints(mutatedSolution);
                 best = constraintComparator.compare(mutatedSolution,solution);
                 if (best == 0) //none of then is better that the other one
                 {
@@ -133,7 +133,7 @@ public class MutationLocalSearch implements LocalSearchOperator<Solution>{
             }
         }
         while (i < rounds);
-        return solution.copy();
+        return (S) solution.copy();
     } // execute
 
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/mutation/PermutationSwapMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/mutation/PermutationSwapMutation.java
@@ -47,7 +47,7 @@ public class PermutationSwapMutation<T> implements MutationOperator<PermutationS
 
   /** Execute() method */
   @Override
-  public PermutationSolution execute(PermutationSolution solution) {
+  public PermutationSolution<T> execute(PermutationSolution<T> solution) {
     if (null == solution) {
       throw new JMetalException("Null parameter") ;
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/mutation/SimpleRandomMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/mutation/SimpleRandomMutation.java
@@ -18,8 +18,6 @@ import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
-import java.util.Random;
-
 /**
  * This class implements a random mutation operator for double solutions
  *

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/BinaryTournamentSelection.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/BinaryTournamentSelection.java
@@ -27,14 +27,14 @@ import java.util.Comparator;
  * Modified by Juanjo in 13.03.2015. A binary tournament is now a TournamenteSelection with 2 
  * tournaments
  */
-public class BinaryTournamentSelection extends TournamentSelection {
+public class BinaryTournamentSelection<S extends Solution<?>> extends TournamentSelection<S> {
     /** Constructor */
   public BinaryTournamentSelection() {
-    super(new DominanceComparator(), 2) ;
+    super(new DominanceComparator<S>(), 2) ;
   }
 
   /** Constructor */
-  public BinaryTournamentSelection(Comparator<? extends Solution> comparator) {
+  public BinaryTournamentSelection(Comparator<S> comparator) {
     super(comparator,2);
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/NaryRandomSelection.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/NaryRandomSelection.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @author Antonio J. Nebro
  * @version 1.0
  */
-public class NaryRandomSelection implements SelectionOperator<List<? extends Solution>,List<? extends Solution>> {
+public class NaryRandomSelection<S extends Solution<?>> implements SelectionOperator<List<S>,List<S>> {
   private JMetalRandom randomGenerator ;
   private int numberOfSolutionsToBeReturned ;
 
@@ -44,7 +44,7 @@ public class NaryRandomSelection implements SelectionOperator<List<? extends Sol
   }
 
   /** Execute() method */
-  public List<? extends Solution> execute(List<? extends Solution> solutionList) {
+  public List<S> execute(List<S> solutionList) {
     if (null == solutionList) {
       throw new JMetalException("The solution list is null") ;
     } else if (solutionList.isEmpty()) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/NaryTournamentSelection.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/NaryTournamentSelection.java
@@ -29,24 +29,24 @@ import java.util.List;
  * Applies a N-ary tournament selection to return the best solution between N that have been
  * chosen at random from a solution list.
  */
-public class NaryTournamentSelection implements SelectionOperator<List<Solution>, Solution> {
-  private Comparator<Solution> comparator;
+public class NaryTournamentSelection<S extends Solution<?>> implements SelectionOperator<List<S>, S> {
+  private Comparator<S> comparator;
   private int numberOfSolutionsToBeReturned ;
 
   /** Constructor */
   public NaryTournamentSelection() {
-    this(2, new DominanceComparator()) ;
+    this(2, new DominanceComparator<S>()) ;
   }
 
   /** Constructor */
-  public NaryTournamentSelection(int numberOfSolutionsToBeReturned, Comparator<Solution> comparator) {
+  public NaryTournamentSelection(int numberOfSolutionsToBeReturned, Comparator<S> comparator) {
     this.numberOfSolutionsToBeReturned = numberOfSolutionsToBeReturned ;
     this.comparator = comparator ;
   }
 
   @Override
   /** Execute() method */
-  public Solution execute(List<Solution> solutionList) {
+  public S execute(List<S> solutionList) {
     if (null == solutionList) {
       throw new JMetalException("The solution list is null") ;
     } else if (solutionList.isEmpty()) {
@@ -56,11 +56,11 @@ public class NaryTournamentSelection implements SelectionOperator<List<Solution>
           + "the number of requested solutions ("+numberOfSolutionsToBeReturned+")") ;
     }
 
-    Solution result ;
+    S result ;
     if (solutionList.size() == 1) {
       result = solutionList.get(0) ;
     } else {
-      List<Solution> selectedSolutions = SolutionListUtils.selectNRandomDifferentSolutions(
+      List<S> selectedSolutions = SolutionListUtils.selectNRandomDifferentSolutions(
           numberOfSolutionsToBeReturned, solutionList) ;
       result = SolutionListUtils.findBestSolution(selectedSolutions, comparator) ;
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/RandomSelection.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/RandomSelection.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @author Antonio J. Nebro
  * @version 1.0
  */
-public class RandomSelection implements SelectionOperator<List<Solution>, Solution> {
+public class RandomSelection<S extends Solution<?>> implements SelectionOperator<List<S>, S> {
   private JMetalRandom randomGenerator ;
   private int numberOfSolutionsToBeReturned ;
 
@@ -38,14 +38,14 @@ public class RandomSelection implements SelectionOperator<List<Solution>, Soluti
   }
 
   /** Execute() method */
-  public Solution execute(List<Solution> solutionList) {
+  public S execute(List<S> solutionList) {
     if (null == solutionList) {
       throw new JMetalException("The solution list is null") ;
     } else if (solutionList.isEmpty()) {
       throw new JMetalException("The solution list is empty") ;
     }
 
-    List<Solution> list = SolutionListUtils.selectNRandomDifferentSolutions(1, solutionList);
+    List<S> list = SolutionListUtils.selectNRandomDifferentSolutions(1, solutionList);
 
     return list.get(0) ;
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/RankingAndCrowdingSelection.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/RankingAndCrowdingSelection.java
@@ -38,8 +38,8 @@ import java.util.List;
  * a solution list. The solutions are taken by mean of its ranking and
  * crowding distance values.
  */
-public class RankingAndCrowdingSelection
-    implements SelectionOperator<List<? extends Solution>,List<? extends Solution>> {
+public class RankingAndCrowdingSelection<S extends Solution<?>>
+    implements SelectionOperator<List<S>,List<S>> {
   private int solutionsToSelect = 0 ;
 
   /** Constructor */
@@ -53,7 +53,7 @@ public class RankingAndCrowdingSelection
   }
 
   /** Execute() method */
-  public List<? extends Solution> execute(List<? extends Solution> solutionList) throws JMetalException {
+  public List<S> execute(List<S> solutionList) throws JMetalException {
     if (null == solutionList) {
       throw new JMetalException("The solution list is null");
     } else if (solutionList.isEmpty()) {
@@ -63,17 +63,17 @@ public class RankingAndCrowdingSelection
               "the solutions to selected ("+solutionsToSelect+")")  ;
     }
 
-    Ranking ranking = new DominanceRanking();
+    Ranking<S> ranking = new DominanceRanking<S>();
     ranking.computeRanking(solutionList) ;
 
-    List<Solution> resultPopulation = crowdingDistanceSelection(ranking) ;
+    List<S> resultPopulation = crowdingDistanceSelection(ranking) ;
 
     return resultPopulation;
   }
 
-  protected List<Solution> crowdingDistanceSelection(Ranking ranking) {
-    CrowdingDistance crowdingDistance = new CrowdingDistance() ;
-    List<Solution> population = new ArrayList<>(solutionsToSelect) ;
+  protected List<S> crowdingDistanceSelection(Ranking<S> ranking) {
+    CrowdingDistance<S> crowdingDistance = new CrowdingDistance<S>() ;
+    List<S> population = new ArrayList<>(solutionsToSelect) ;
     int rankingIndex = 0;
     while (population.size() < solutionsToSelect) {
       if (subfrontFillsIntoThePopulation(ranking, rankingIndex, population)) {
@@ -88,12 +88,12 @@ public class RankingAndCrowdingSelection
     return population ;
   }
 
-  protected boolean subfrontFillsIntoThePopulation(Ranking ranking, int rank, List<Solution> population) {
+  protected boolean subfrontFillsIntoThePopulation(Ranking<S> ranking, int rank, List<S> population) {
     return ranking.getSubfront(rank).size() < (solutionsToSelect - population.size()) ;
   }
 
-  protected void addRankedSolutionsToPopulation(Ranking ranking, int rank, List<Solution> population) {
-    List<Solution> front ;
+  protected void addRankedSolutionsToPopulation(Ranking<S> ranking, int rank, List<S> population) {
+    List<S> front ;
 
     front = ranking.getSubfront(rank);
 
@@ -102,10 +102,10 @@ public class RankingAndCrowdingSelection
     }
   }
 
-  protected void addLastRankedSolutionsToPopulation(Ranking ranking, int rank, List<Solution>population) {
-    List<Solution> currentRankedFront = ranking.getSubfront(rank) ;
+  protected void addLastRankedSolutionsToPopulation(Ranking<S> ranking, int rank, List<S>population) {
+    List<S> currentRankedFront = ranking.getSubfront(rank) ;
 
-    Collections.sort(currentRankedFront, new CrowdingDistanceComparator()) ;
+    Collections.sort(currentRankedFront, new CrowdingDistanceComparator<S>()) ;
 
     int i = 0 ;
     while (population.size() < solutionsToSelect) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/TournamentSelection.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/TournamentSelection.java
@@ -29,39 +29,39 @@ import java.util.List;
  *
  * Applies a n-ary tournament selection to return a solution from a list.
  */
-public class TournamentSelection implements SelectionOperator<List<? extends Solution>,Solution> {
-  private Comparator<? extends Solution> comparator;
+public class TournamentSelection<S extends Solution<?>> implements SelectionOperator<List<S>,S> {
+  private Comparator<S> comparator;
 
   private final int numberOfTournaments;
 
   /** Constructor */
   public TournamentSelection(int numberOfTournaments) {
-    this(new DominanceComparator(), numberOfTournaments) ;
+    this(new DominanceComparator<S>(), numberOfTournaments) ;
   }
 
   /** Constructor */
-  public TournamentSelection(Comparator<? extends Solution> comparator, int numberOfTournaments) {
+  public TournamentSelection(Comparator<S> comparator, int numberOfTournaments) {
     this.numberOfTournaments = numberOfTournaments;
     this.comparator = comparator ;
   }
 
   @Override
   /** Execute() method */
-  public Solution execute(List<? extends Solution> solutionList) {
+  public S execute(List<S> solutionList) {
     if (null == solutionList) {
       throw new JMetalException("The solution list is null") ;
     } else if (solutionList.isEmpty()) {
       throw new JMetalException("The solution list is empty") ;
     }
 
-    Solution result;
+    S result;
     if (solutionList.size() == 1) {
       result = solutionList.get(0);
     } else {
       result = SolutionListUtils.selectNRandomDifferentSolutions(1, solutionList).get(0);
       int count = 1; // at least 2 solutions are compared
       do {
-        Solution candidate = SolutionListUtils.selectNRandomDifferentSolutions(1, solutionList).get(0);
+        S candidate = SolutionListUtils.selectNRandomDifferentSolutions(1, solutionList).get(0);
         result = SolutionUtils.getBestSolution(result, candidate, comparator) ;
       } while (++count < this.numberOfTournaments);
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/Problem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/Problem.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
  * @version 0.1
  * @param <S> Encoding
  */
-public interface Problem<S extends Solution> extends Serializable {
+public interface Problem<S extends Solution<?>> extends Serializable {
   /* Getters */
   public int getNumberOfVariables() ;
   public int getNumberOfObjectives() ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/SetCoverage.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/SetCoverage.java
@@ -37,7 +37,7 @@ public class SetCoverage extends SimpleDescribedEntity implements QualityIndicat
     super("SC", "Set coverage") ;
   }
 
-  private Comparator<Solution> dominance;
+  private Comparator<Solution<?>> dominance;
 
   @Override public double execute(Front frontA, Front frontB) {
     if (frontA == null) {
@@ -69,7 +69,7 @@ public class SetCoverage extends SimpleDescribedEntity implements QualityIndicat
    * @param set2
    * @return The value of the set coverage
    */
-  public double setCoverage(List<? extends Solution> set1, List<? extends Solution> set2) {
+  public double setCoverage(List<? extends Solution<?>> set1, List<? extends Solution<?>> set2) {
     double result ;
     int sum = 0 ;
 
@@ -80,10 +80,10 @@ public class SetCoverage extends SimpleDescribedEntity implements QualityIndicat
         result = 1.0 ;
       }
     } else {
-      dominance = new DominanceComparator();
+      dominance = new DominanceComparator<Solution<?>>();
 
       for (int i = 0; i < set2.size(); i++) {
-        if (SolutionListUtils.isSolutionDominatedBySolutionList(set2.get(i), (List<Solution>) set1)) {
+        if (SolutionListUtils.isSolutionDominatedBySolutionList(set2.get(i), (List<Solution<?>>) set1)) {
           sum++;
         }
       }

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/util/WfgHypervolume.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/util/WfgHypervolume.java
@@ -173,7 +173,7 @@ public class WfgHypervolume {
     currentDeep++;
   }
 
-  public int getLessContributorHV(List<Solution> solutionList) {
+  public int getLessContributorHV(List<Solution<?>> solutionList) {
     WfgHypervolumeFront wholeFront = (WfgHypervolumeFront)loadFront(solutionList, -1) ;
 
     int index = 0;
@@ -191,7 +191,7 @@ public class WfgHypervolume {
         contribution = aux;
       }
 
-      HypervolumeContribution hvc = new HypervolumeContribution() ;
+      HypervolumeContribution<Solution<?>> hvc = new HypervolumeContribution<Solution<?>>() ;
       hvc.setAttribute(solutionList.get(i), aux);
       //solutionList.get(i).setCrowdingDistance(aux);
     }
@@ -199,7 +199,7 @@ public class WfgHypervolume {
     return index;
   }
 
-  private Front loadFront(List<Solution> solutionSet, int notLoadingIndex) {
+  private Front loadFront(List<Solution<?>> solutionSet, int notLoadingIndex) {
     int numberOfPoints ;
     if (notLoadingIndex >= 0 && notLoadingIndex < solutionSet.size()) {
       numberOfPoints = solutionSet.size() - 1;

--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/util/WfgHypervolumeFront.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/util/WfgHypervolumeFront.java
@@ -16,7 +16,7 @@ public class WfgHypervolumeFront extends ArrayFront {
     super();
   }
 
-  public WfgHypervolumeFront(List<? extends Solution> solutionList) {
+  public WfgHypervolumeFront(List<? extends Solution<?>> solutionList) {
     super(solutionList) ;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -9,7 +9,7 @@ import java.util.*;
 /**
  * Created by Antonio J. Nebro on 03/09/14.
  */
-public abstract class AbstractGenericSolution<T, P extends Problem> implements Solution<T> {
+public abstract class AbstractGenericSolution<T, P extends Problem<?>> implements Solution<T> {
   private double[] objectives;
   private List<T> variables;
   protected P problem ;
@@ -120,7 +120,7 @@ public abstract class AbstractGenericSolution<T, P extends Problem> implements S
     if (o == null || getClass() != o.getClass())
       return false;
 
-    AbstractGenericSolution that = (AbstractGenericSolution) o;
+    AbstractGenericSolution<?, ?> that = (AbstractGenericSolution<?, ?>) o;
 
     if (!attributes.equals(that.attributes))
       return false;

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
@@ -64,7 +64,7 @@ public class DefaultBinarySolution extends AbstractGenericSolution<BinarySet, Bi
     overallConstraintViolationDegree = solution.overallConstraintViolationDegree ;
     numberOfViolatedConstraints = solution.numberOfViolatedConstraints ;
 
-    attributes = new HashMap(solution.attributes) ;
+    attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
   private BinarySet createNewBitSet(int numberOfBits) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -2,7 +2,6 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.DoubleBinaryProblem;
 import org.uma.jmetal.solution.DoubleBinarySolution;
-import org.uma.jmetal.solution.Solution;
 
 import java.util.BitSet;
 import java.util.HashMap;
@@ -17,12 +16,12 @@ import java.util.HashMap;
  *  - the bitset is the last variable
  */
 public class DefaultDoubleBinarySolution
-    extends AbstractGenericSolution<Object, DoubleBinaryProblem>
+    extends AbstractGenericSolution<Object, DoubleBinaryProblem<?>>
     implements DoubleBinarySolution {
   private int numberOfDoubleVariables ;
 
   /** Constructor */
-  public DefaultDoubleBinarySolution(DoubleBinaryProblem problem) {
+  public DefaultDoubleBinarySolution(DoubleBinaryProblem<?> problem) {
     super(problem) ;
 
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
@@ -47,7 +46,7 @@ public class DefaultDoubleBinarySolution
     overallConstraintViolationDegree = solution.overallConstraintViolationDegree ;
     numberOfViolatedConstraints = solution.numberOfViolatedConstraints ;
 
-    attributes = new HashMap(solution.attributes) ;
+    attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
   private void initializeDoubleVariables() {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -39,7 +39,7 @@ public class DefaultDoubleSolution extends AbstractGenericSolution<Double, Doubl
 
     overallConstraintViolationDegree = solution.overallConstraintViolationDegree ;
     numberOfViolatedConstraints = solution.numberOfViolatedConstraints ;
-    attributes = new HashMap(solution.attributes) ;
+    attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -9,13 +9,13 @@ import java.util.HashMap;
  * Created by Antonio J. Nebro on 03/09/14.
  */
 public class DefaultIntegerDoubleSolution
-        extends AbstractGenericSolution<Number, IntegerDoubleProblem>
+        extends AbstractGenericSolution<Number, IntegerDoubleProblem<?>>
         implements IntegerDoubleSolution {
   private int numberOfIntegerVariables ;
   private int numberOfDoubleVariables ;
 
   /** Constructor */
-  public DefaultIntegerDoubleSolution(IntegerDoubleProblem problem) {
+  public DefaultIntegerDoubleSolution(IntegerDoubleProblem<?> problem) {
     super(problem) ;
 
     numberOfIntegerVariables = problem.getNumberOfIntegerVariables() ;
@@ -68,7 +68,7 @@ public class DefaultIntegerDoubleSolution
     overallConstraintViolationDegree = solution.overallConstraintViolationDegree ;
     numberOfViolatedConstraints = solution.numberOfViolatedConstraints ;
 
-    attributes = new HashMap(solution.attributes) ;
+    attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
@@ -11,11 +11,11 @@ import java.util.List;
  * Created by Antonio J. Nebro on 03/09/14.
  */
 public class DefaultIntegerPermutationSolution
-    extends AbstractGenericSolution<Integer, PermutationProblem>
+    extends AbstractGenericSolution<Integer, PermutationProblem<?>>
     implements PermutationSolution<Integer> {
 
   /** Constructor */
-  public DefaultIntegerPermutationSolution(PermutationProblem problem) {
+  public DefaultIntegerPermutationSolution(PermutationProblem<?> problem) {
     super(problem) ;
 
     overallConstraintViolationDegree = 0.0 ;
@@ -48,7 +48,7 @@ public class DefaultIntegerPermutationSolution
     overallConstraintViolationDegree = solution.overallConstraintViolationDegree ;
     numberOfViolatedConstraints = solution.numberOfViolatedConstraints ;
 
-    attributes = new HashMap(solution.attributes) ;
+    attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
   @Override public String getVariableValueString(int index) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -42,7 +42,7 @@ public class DefaultIntegerSolution extends AbstractGenericSolution<Integer, Int
     overallConstraintViolationDegree = solution.overallConstraintViolationDegree ;
     numberOfViolatedConstraints = solution.numberOfViolatedConstraints ;
 
-    attributes = new HashMap(solution.attributes) ;
+    attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/AdaptiveGrid.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/AdaptiveGrid.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * This class defines an adaptive grid over a list of solutions as the one used by algorithm PAES.
  */
-public class AdaptiveGrid<T extends Solution> {
+public class AdaptiveGrid<S extends Solution<?>> {
   private int bisections;
   private int numberOfObjectives;
   private int[] hypercubes;
@@ -71,7 +71,7 @@ public class AdaptiveGrid<T extends Solution> {
    *
    * @param solutionList The <code>solutionList</code> considered.
    */
-  private void updateLimits(List<T> solutionList) {
+  private void updateLimits(List<S> solutionList) {
     for (int obj = 0; obj < numberOfObjectives; obj++) {
       gridLowerLimits[obj] = Double.MAX_VALUE;
       gridUpperLimits[obj] = Double.MIN_VALUE;
@@ -79,7 +79,7 @@ public class AdaptiveGrid<T extends Solution> {
 
     //Find the max and min limits of objetives into the population
     for (int ind = 0; ind < solutionList.size(); ind++) {
-      Solution tmpIndividual = solutionList.get(ind);
+      Solution<?> tmpIndividual = solutionList.get(ind);
       for (int obj = 0; obj < numberOfObjectives; obj++) {
         if (tmpIndividual.getObjective(obj) < gridLowerLimits[obj]) {
           gridLowerLimits[obj] = tmpIndividual.getObjective(obj);
@@ -98,7 +98,7 @@ public class AdaptiveGrid<T extends Solution> {
    *
    * @param solutionList The <code>solutionList</code> considered.
    */
-  private void addSolutionSet(List<T> solutionList) {
+  private void addSolutionSet(List<S> solutionList) {
     //Calculate the location of all individuals and update the grid
     mostPopulatedHypercube = 0;
     int location;
@@ -122,7 +122,7 @@ public class AdaptiveGrid<T extends Solution> {
    *
    * @param solutionList The <code>solutionList</code>.
    */
-  public void updateGrid(List<T> solutionList) {
+  public void updateGrid(List<S> solutionList) {
     //Update lower and upper limits
     updateLimits(solutionList);
 
@@ -150,7 +150,7 @@ public class AdaptiveGrid<T extends Solution> {
    * @param solution    <code>Solution</code> considered to update the grid.
    * @param solutionSet <code>SolutionSet</code> used to update the grid.
    */
-  public void updateGrid(T solution, List<T>  solutionSet) {
+  public void updateGrid(S solution, List<S>  solutionSet) {
 
     int location = location(solution);
     if (location == -1) {
@@ -188,7 +188,7 @@ public class AdaptiveGrid<T extends Solution> {
    *
    * @param solution The <code>Solution</code>.
    */
-  public int location(T solution) {
+  public int location(S solution) {
     //Create a int [] to store the range of each objective
     int[] position = new int[numberOfObjectives];
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/AlgorithmBuilder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/AlgorithmBuilder.java
@@ -5,6 +5,6 @@ import org.uma.jmetal.algorithm.Algorithm;
 /**
  * Created by ajnebro on 3/1/15.
  */
-public interface AlgorithmBuilder {
-  public Algorithm build() ;
+public interface AlgorithmBuilder<A extends Algorithm<?>> {
+  public A build() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/AlgorithmRunner.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/AlgorithmRunner.java
@@ -40,10 +40,10 @@ public class AlgorithmRunner {
 
   /** Executor class */
   public static class Executor {
-    Algorithm algorithm ;
+    Algorithm<?> algorithm ;
     long computingTime;
 
-    public Executor(Algorithm algorithm) {
+    public Executor(Algorithm<?> algorithm) {
       this.algorithm = algorithm ;
     }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/ProblemUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/ProblemUtils.java
@@ -1,6 +1,7 @@
 package org.uma.jmetal.util;
 
 import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -14,10 +15,10 @@ public class ProblemUtils {
    * @param problemName A full qualified problem name
    * @return An instance of the problem
    */
-  public static Problem loadProblem(String problemName) {
-    Problem problem ;
+  public static <S extends Solution<?>> Problem<S> loadProblem(String problemName) {
+    Problem<S> problem ;
     try {
-      problem = (Problem)Class.forName(problemName).getConstructor().newInstance() ;
+      problem = (Problem<S>)Class.forName(problemName).getConstructor().newInstance() ;
     } catch (InstantiationException e) {
       throw new JMetalException("newInstance() cannot instantiate (abstract class)", e) ;
     } catch (IllegalAccessException e) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionListUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionListUtils.java
@@ -14,18 +14,18 @@ import java.util.*;
  */
 public class SolutionListUtils {
 
-  public static <S extends Solution> List<S> getNondominatedSolutions(List<S> solutionList) {
-    Ranking ranking = new DominanceRanking() ;
+  public static <S extends Solution<?>> List<S> getNondominatedSolutions(List<S> solutionList) {
+    Ranking<S> ranking = new DominanceRanking<S>() ;
     return ranking.computeRanking(solutionList).getSubfront(0);
   }
 
-  public int findWorstSolution(List<? extends Solution> solutionList, Comparator<Solution> comparator) {
+  public <S extends Solution<?>> int findWorstSolution(List<S> solutionList, Comparator<S> comparator) {
     if ((solutionList == null) || (solutionList.isEmpty())) {
       return -1;
     }
 
     int index = 0;
-    Solution worstKnown = solutionList.get(0), candidateSolution;
+    S worstKnown = solutionList.get(0), candidateSolution;
     int flag;
     for (int i = 1; i < solutionList.size(); i++) {
       candidateSolution = solutionList.get(i);
@@ -45,7 +45,7 @@ public class SolutionListUtils {
    * @param comparator
    * @return The index of the best solution
    */
-  public static int findIndexOfBestSolution(List<? extends Solution> solutionList, Comparator<Solution> comparator) {
+  public static <S extends Solution<?>> int findIndexOfBestSolution(List<S> solutionList, Comparator<S> comparator) {
     if (solutionList == null) {
       throw new JMetalException("The solution list is null") ;
     } else if (solutionList.isEmpty()) {
@@ -55,8 +55,8 @@ public class SolutionListUtils {
     }
 
     int index = 0;
-    Solution bestKnown = solutionList.get(0) ;
-    Solution candidateSolution ;
+    S bestKnown = solutionList.get(0) ;
+    S candidateSolution ;
 
     int flag;
     for (int i = 1; i < solutionList.size(); i++) {
@@ -77,7 +77,7 @@ public class SolutionListUtils {
    * @param comparator
    * @return The index of the best solution
    */
-  public static int findIndexOfWorstSolution(List<? extends Solution> solutionList, Comparator<Solution> comparator) {
+  public static int findIndexOfWorstSolution(List<? extends Solution<?>> solutionList, Comparator<Solution<?>> comparator) {
     if (solutionList == null) {
       throw new JMetalException("The solution list is null") ;
     } else if (solutionList.isEmpty()) {
@@ -87,8 +87,8 @@ public class SolutionListUtils {
     }
 
     int index = 0;
-    Solution worstKnown = solutionList.get(0) ;
-    Solution candidateSolution ;
+    Solution<?> worstKnown = solutionList.get(0) ;
+    Solution<?> candidateSolution ;
 
     int flag;
     for (int i = 1; i < solutionList.size(); i++) {
@@ -103,11 +103,11 @@ public class SolutionListUtils {
     return index;
   }
 
-  public static Solution findBestSolution(List<? extends Solution> solutionList, Comparator<Solution> comparator) {
+  public static <S extends Solution<?>> S findBestSolution(List<S> solutionList, Comparator<S> comparator) {
     return solutionList.get(findIndexOfBestSolution(solutionList, comparator)) ;
   }
 
-  public static <S extends Solution> double[][] writeObjectivesToMatrix(List<S> solutionList) {
+  public static <S extends Solution<?>> double[][] writeObjectivesToMatrix(List<S> solutionList) {
     if (solutionList.size() == 0) {
       return new double[0][0];
     }
@@ -134,11 +134,11 @@ public class SolutionListUtils {
    * @param minimumValue The minimum values of the objectives
    * @return the normalized list of non-dominated solutions
    */
-  public static List<Solution> getNormalizedFront(List<Solution> solutionList,
+  public static List<Solution<?>> getNormalizedFront(List<Solution<?>> solutionList,
     List<Double> maximumValue,
     List<Double> minimumValue) {
 
-    List<Solution> normalizedSolutionSet = new ArrayList<>(solutionList.size()) ;
+    List<Solution<?>> normalizedSolutionSet = new ArrayList<>(solutionList.size()) ;
 
     int numberOfObjectives = solutionList.get(0).getNumberOfObjectives() ;
     for (int i = 0; i < solutionList.size(); i++) {
@@ -159,7 +159,7 @@ public class SolutionListUtils {
    * @param solutionSet The front to invert
    * @return The inverted front
    */
-  public static <S extends Solution> List<S> getInvertedFront(List<S> solutionSet) {
+  public static <S extends Solution<?>> List<S> getInvertedFront(List<S> solutionSet) {
     List<S> invertedFront = new ArrayList<>(solutionSet.size()) ;
     int numberOfObjectives = solutionSet.get(0).getNumberOfObjectives() ;
 
@@ -179,9 +179,9 @@ public class SolutionListUtils {
     return invertedFront;
   }
 
-  public static <S extends Solution> boolean isSolutionDominatedBySolutionList(S solution, List<S> solutionSet) {
+  public static <S extends Solution<?>> boolean isSolutionDominatedBySolutionList(S solution, List<S> solutionSet) {
     boolean result = false ;
-    Comparator<Solution> dominance = new DominanceComparator() ;
+    Comparator<S> dominance = new DominanceComparator<S>() ;
 
     int i = 0 ;
 
@@ -202,7 +202,7 @@ public class SolutionListUtils {
    * @param solutionList The front to invert
    * @return The inverted front
    */
-  public static <S extends Solution> List<S> selectNRandomDifferentSolutions(
+  public static <S extends Solution<?>> List<S> selectNRandomDifferentSolutions(
       int numberOfSolutionsToBeReturned, List<S> solutionList) {
     if (null == solutionList) {
       throw new JMetalException("The solution list is null") ;
@@ -240,7 +240,7 @@ public class SolutionListUtils {
    * @param solutionSet
    * @return
    */
-  public static  <S extends Solution> double [][] distanceMatrix(List<S> solutionSet) {
+  public static  <S extends Solution<?>> double [][] distanceMatrix(List<S> solutionSet) {
      //The matrix of distances
      double [][] distance = new double [solutionSet.size()][solutionSet.size()];        
      for (int i = 0; i < solutionSet.size(); i++){

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionUtils.java
@@ -1,11 +1,9 @@
 package org.uma.jmetal.util;
 
-import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Comparator;
 import java.util.List;
 
@@ -22,8 +20,8 @@ public class SolutionUtils {
    * @param solution2
    * @return The best solution
    */
-  public static Solution getBestSolution(Solution solution1, Solution solution2, Comparator comparator) {
-    Solution result ;
+  public static <S extends Solution<?>> S getBestSolution(S solution1, S solution2, Comparator<S> comparator) {
+    S result ;
     int flag = comparator.compare(solution1, solution2);
     if (flag == -1) {
       result = solution1;
@@ -47,7 +45,7 @@ public class SolutionUtils {
    * @param secondSolution
    * @return
    */
-   static double distanceBetweenObjectives(Solution firstSolution, Solution secondSolution) {
+   static <S extends Solution<?>> double distanceBetweenObjectives(S firstSolution, S secondSolution) {
    
 	    double diff;  
 	    double distance = 0.0;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archive/Archive.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archive/Archive.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * Created by Antonio J. Nebro on 24/09/14.
  */
-public interface Archive<S extends Solution> extends Serializable{
+public interface Archive<S extends Solution<?>> extends Serializable{
   public boolean add(S solution) ;
   public S get(int index) ;
   public List<S> getSolutionList() ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archive/BoundedArchive.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archive/BoundedArchive.java
@@ -5,6 +5,6 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by Antonio J. Nebro on 24/09/14.
  */
-public interface BoundedArchive<S extends Solution> extends Archive<S> {
+public interface BoundedArchive<S extends Solution<?>> extends Archive<S> {
   public int getMaxSize() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/AbstractBoundedArchive.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/AbstractBoundedArchive.java
@@ -3,17 +3,15 @@ package org.uma.jmetal.util.archive.impl;
 import java.util.List;
 
 import org.uma.jmetal.solution.Solution;
-import org.uma.jmetal.util.SolutionListUtils;
-import org.uma.jmetal.util.archive.Archive;
 import org.uma.jmetal.util.archive.BoundedArchive;
 
-public abstract class AbstractBoundedArchive<S extends Solution> implements BoundedArchive<S> {
-	protected NonDominatedSolutionListArchive list;
+public abstract class AbstractBoundedArchive<S extends Solution<?>> implements BoundedArchive<S> {
+	protected NonDominatedSolutionListArchive<S> list;
 	protected int maxSize;
 	
 	public AbstractBoundedArchive(int maxSize) {
 		this.maxSize = maxSize;
-		this.list = new NonDominatedSolutionListArchive();
+		this.list = new NonDominatedSolutionListArchive<S>();
 	}
 	
 	@Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/AdaptiveGridArchive.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/AdaptiveGridArchive.java
@@ -23,23 +23,20 @@ package org.uma.jmetal.util.archive.impl;
 
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.AdaptiveGrid;
-import org.uma.jmetal.util.archive.BoundedArchive;
 import org.uma.jmetal.util.comparator.DominanceComparator;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * This class implements an archive (solution list) based on an adaptive grid used in PAES
  */
-public class AdaptiveGridArchive<S extends Solution> extends AbstractBoundedArchive<S> {
+public class AdaptiveGridArchive<S extends Solution<?>> extends AbstractBoundedArchive<S> {
 
   private AdaptiveGrid<S> grid;
  
   private int maxSize;
-  private Comparator<Solution> dominanceComparator;
+  private Comparator<S> dominanceComparator;
 
   /**
    * Constructor.
@@ -51,8 +48,8 @@ public class AdaptiveGridArchive<S extends Solution> extends AbstractBoundedArch
    */
   public AdaptiveGridArchive(int maxSize, int bisections, int objectives) {
     super(maxSize);
-    dominanceComparator = new DominanceComparator();
-    grid = new AdaptiveGrid(bisections, objectives);
+    dominanceComparator = new DominanceComparator<S>();
+    grid = new AdaptiveGrid<S>(bisections, objectives);
   }
 
   /**
@@ -123,7 +120,7 @@ public class AdaptiveGridArchive<S extends Solution> extends AbstractBoundedArch
     return true;
   }
 
-  public AdaptiveGrid getGrid() {
+  public AdaptiveGrid<S> getGrid() {
     return grid;
   }
   

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/CrowdingDistanceArchive.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/CrowdingDistanceArchive.java
@@ -2,29 +2,24 @@ package org.uma.jmetal.util.archive.impl;
 
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.SolutionListUtils;
-import org.uma.jmetal.util.archive.BoundedArchive;
 import org.uma.jmetal.util.comparator.CrowdingDistanceComparator;
-import org.uma.jmetal.util.comparator.DominanceComparator;
-import org.uma.jmetal.util.comparator.EqualSolutionsComparator;
 import org.uma.jmetal.util.solutionattribute.DensityEstimator;
 import org.uma.jmetal.util.solutionattribute.impl.CrowdingDistance;
 
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 
 /**
  * Created by Antonio J. Nebro on 24/09/14.
  * Modified by Juanjo on 07/04/2015
  */
-public class CrowdingDistanceArchive<S extends Solution> extends AbstractBoundedArchive<S> {
-  private Comparator<Solution> crowdingDistanceComparator;
+public class CrowdingDistanceArchive<S extends Solution<?>> extends AbstractBoundedArchive<S> {
+  private Comparator<S> crowdingDistanceComparator;
   private DensityEstimator<S> crowdingDistance ;
   
 
   public CrowdingDistanceArchive(int maxSize) {
     super(maxSize);
-	crowdingDistanceComparator = new CrowdingDistanceComparator() ;
+	crowdingDistanceComparator = new CrowdingDistanceComparator<S>() ;
     crowdingDistance = new CrowdingDistance<S>() ;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/FastHypervolumeArchive.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/FastHypervolumeArchive.java
@@ -23,25 +23,21 @@ package org.uma.jmetal.util.archive.impl;
 import org.uma.jmetal.qualityindicator.util.FastHypervolume;
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.SolutionListUtils;
-import org.uma.jmetal.util.archive.BoundedArchive;
-import org.uma.jmetal.util.comparator.DominanceComparator;
 import org.uma.jmetal.util.comparator.HypervolumeContributorComparator;
 import org.uma.jmetal.util.point.Point;
 import org.uma.jmetal.util.point.impl.ArrayPoint;
 
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 
 /**
  * This class implements a bounded archive based on the hypervolume quality indicator
  */
-public class FastHypervolumeArchive <S extends Solution> extends AbstractBoundedArchive<S> {
+public class FastHypervolumeArchive <S extends Solution<?>> extends AbstractBoundedArchive<S> {
 
   public Point referencePoint;
 
 
-  private Comparator<Solution> hvContributionComparator;
+  private Comparator<Solution<?>> hvContributionComparator;
 
   /**
    * Constructor.

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/NonDominatedSolutionListArchive.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/NonDominatedSolutionListArchive.java
@@ -34,18 +34,18 @@ import java.util.List;
 /**
  * This class implements an archive containing non-dominated solutions
  */
-public class NonDominatedSolutionListArchive<S extends Solution> implements Archive<S> {
+public class NonDominatedSolutionListArchive<S extends Solution<?>> implements Archive<S> {
   private List<S> solutionList;
-  private Comparator<Solution> dominanceComparator;
-  private Comparator<Solution> equalSolutions = new EqualSolutionsComparator();
+  private Comparator<S> dominanceComparator;
+  private Comparator<S> equalSolutions = new EqualSolutionsComparator<S>();
 
   /** Constructor */
   public NonDominatedSolutionListArchive() {
-    this(new DominanceComparator()) ;
+    this(new DominanceComparator<S>()) ;
   }
 
   /** Constructor */
-  public NonDominatedSolutionListArchive(DominanceComparator comparator) {
+  public NonDominatedSolutionListArchive(DominanceComparator<S> comparator) {
     dominanceComparator = comparator ;
    
     solutionList = new ArrayList<>() ;
@@ -71,7 +71,7 @@ public class NonDominatedSolutionListArchive<S extends Solution> implements Arch
       
       boolean isContained = false;
       while (((!isDominated) && (!isContained)) && (iterator.hasNext())) {
-        Solution listIndividual = iterator.next();
+        S listIndividual = iterator.next();
         int flag = dominanceComparator.compare(solution, listIndividual);
         if (flag == -1) {
           iterator.remove();

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/ConstraintViolationComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/ConstraintViolationComparator.java
@@ -4,6 +4,6 @@ import org.uma.jmetal.solution.Solution;
 
 import java.util.Comparator;
 
-public interface ConstraintViolationComparator extends Comparator<Solution<?>> {
-  public int compare(Solution<?> solution1, Solution<?> solution2);
+public interface ConstraintViolationComparator<S extends Solution<?>> extends Comparator<S> {
+  public int compare(S solution1, S solution2);
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/ConstraintViolationComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/ConstraintViolationComparator.java
@@ -4,6 +4,6 @@ import org.uma.jmetal.solution.Solution;
 
 import java.util.Comparator;
 
-public interface ConstraintViolationComparator extends Comparator<Solution> {
-  public int compare(Solution solution1, Solution solution2);
+public interface ConstraintViolationComparator extends Comparator<Solution<?>> {
+  public int compare(Solution<?> solution1, Solution<?> solution2);
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/CrowdingDistanceComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/CrowdingDistanceComparator.java
@@ -25,8 +25,8 @@ import java.util.Comparator;
  * Compares two solutions according to the crowding distance attribute. The higher
  * the distance the better
  */
-public class CrowdingDistanceComparator implements Comparator<Solution> {
-  private final CrowdingDistance crowdingDistance = new CrowdingDistance() ;
+public class CrowdingDistanceComparator<S extends Solution<?>> implements Comparator<S> {
+  private final CrowdingDistance<S> crowdingDistance = new CrowdingDistance<S>() ;
 
   /**
    * Compare two solutions.
@@ -37,7 +37,7 @@ public class CrowdingDistanceComparator implements Comparator<Solution> {
    * respectively.
    */
   @Override
-  public int compare(Solution solution1, Solution solution2) {
+  public int compare(S solution1, S solution2) {
     int result ;
     if (solution1 == null) {
       if (solution2 == null) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/DominanceComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/DominanceComparator.java
@@ -29,26 +29,26 @@ import java.util.Comparator;
  * an optional epsilon value (i.e, implements an epsilon dominance comparator)
  */
 public class DominanceComparator<S extends Solution<?>> implements Comparator<S> {
-  private ConstraintViolationComparator constraintViolationComparator;
+  private ConstraintViolationComparator<S> constraintViolationComparator;
   private double epsilon = 0.0 ;
 
   /** Constructor */
   public DominanceComparator() {
-    this(new OverallConstraintViolationComparator(), 0.0) ;
+    this(new OverallConstraintViolationComparator<S>(), 0.0) ;
   }
 
   /** Constructor */
   public DominanceComparator(double epsilon) {
-    this(new OverallConstraintViolationComparator(), epsilon) ;
+    this(new OverallConstraintViolationComparator<S>(), epsilon) ;
   }
 
   /** Constructor */
-  public DominanceComparator(ConstraintViolationComparator constraintComparator) {
+  public DominanceComparator(ConstraintViolationComparator<S> constraintComparator) {
     this(constraintComparator, 0.0) ;
   }
 
   /** Constructor */
-  public DominanceComparator(ConstraintViolationComparator constraintComparator, double epsilon) {
+  public DominanceComparator(ConstraintViolationComparator<S> constraintComparator, double epsilon) {
     constraintViolationComparator = constraintComparator ;
     this.epsilon = epsilon ;
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/DominanceComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/DominanceComparator.java
@@ -28,7 +28,7 @@ import java.util.Comparator;
  * This class implements a solution comparator taking into account the violation constraints and
  * an optional epsilon value (i.e, implements an epsilon dominance comparator)
  */
-public class DominanceComparator implements Comparator<Solution> {
+public class DominanceComparator<S extends Solution<?>> implements Comparator<S> {
   private ConstraintViolationComparator constraintViolationComparator;
   private double epsilon = 0.0 ;
 
@@ -62,7 +62,7 @@ public class DominanceComparator implements Comparator<Solution> {
    * non-dominated, or solution1  is dominated by solution2, respectively.
    */
   @Override
-  public int compare(Solution solution1, Solution solution2) {
+  public int compare(S solution1, S solution2) {
     if (solution1 == null) {
       throw new JMetalException("Solution1 is null") ;
     } else if (solution2 == null) {
@@ -81,7 +81,7 @@ public class DominanceComparator implements Comparator<Solution> {
     return result ;
   }
 
-  private int dominanceTest(Solution solution1, Solution solution2) {
+  private int dominanceTest(Solution<?> solution1, Solution<?> solution2) {
     int result ;
     boolean solution1Dominates = false ;
     boolean solution2Dominates = false ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/EqualSolutionsComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/EqualSolutionsComparator.java
@@ -31,7 +31,7 @@ import java.util.Comparator;
  * equal or not. A dominance test is applied to decide about what solution
  * is the best.
  */
-public class EqualSolutionsComparator implements Comparator<Solution> {
+public class EqualSolutionsComparator<S extends Solution<?>> implements Comparator<S> {
 
   /**
    * Compares two solutions.
@@ -43,7 +43,7 @@ public class EqualSolutionsComparator implements Comparator<Solution> {
    * respectively.
    */
   @Override
-  public int compare(Solution object1, Solution object2) {
+  public int compare(S object1, S object2) {
     if (object1 == null) {
       return 1;
     } else if (object2 == null) {
@@ -57,8 +57,8 @@ public class EqualSolutionsComparator implements Comparator<Solution> {
     dominate1 = 0;
     dominate2 = 0;
 
-    Solution solution1 = (Solution) object1;
-    Solution solution2 = (Solution) object2;
+    Solution<?> solution1 = (Solution<?>) object1;
+    Solution<?> solution2 = (Solution<?>) object2;
 
     int flag;
     double value1, value2;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/FitnessComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/FitnessComparator.java
@@ -32,8 +32,8 @@ import java.util.Comparator;
  * <code>Solution</code> objects) based on the fitness value returned by the
  * method <code>getFitness</code>.
  */
-public class FitnessComparator<S extends Solution> implements Comparator<S> {
-  private Fitness<S> solutionFitness = new Fitness() ;
+public class FitnessComparator<S extends Solution<?>> implements Comparator<S> {
+  private Fitness<S> solutionFitness = new Fitness<S>() ;
 
   /**
    * Compares two solutions.

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/HypervolumeContributorComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/HypervolumeContributorComparator.java
@@ -25,8 +25,8 @@ import java.util.Comparator;
  * Compares two solutions according to the crowding distance attribute. The higher
  * the distance the better
  */
-public class HypervolumeContributorComparator implements Comparator<Solution> {
-  private final HypervolumeContribution hvContribution = new HypervolumeContribution() ;
+public class HypervolumeContributorComparator implements Comparator<Solution<?>> {
+  private final HypervolumeContribution<Solution<?>> hvContribution = new HypervolumeContribution<Solution<?>>() ;
 
   /**
    * Compare two solutions.
@@ -37,7 +37,7 @@ public class HypervolumeContributorComparator implements Comparator<Solution> {
    * respectively.
    */
   @Override
-  public int compare(Solution solution1, Solution solution2) {
+  public int compare(Solution<?> solution1, Solution<?> solution2) {
     int result ;
     if (solution1 == null) {
       if (solution2 == null) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/ObjectiveComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/ObjectiveComparator.java
@@ -24,7 +24,7 @@ import java.util.Comparator;
  *
  * This class implements a comparator based on a given objective
  */
-public class ObjectiveComparator implements Comparator<Solution> {
+public class ObjectiveComparator<S extends Solution<?>> implements Comparator<S> {
   public enum Ordering {ASCENDING, DESCENDING} ;
   private int objectiveId;
 
@@ -59,7 +59,7 @@ public class ObjectiveComparator implements Comparator<Solution> {
    * respectively, according to the established order
    */
   @Override
-  public int compare(Solution solution1, Solution solution2) {
+  public int compare(S solution1, S solution2) {
     int result ;
     if (solution1 == null) {
       if (solution2 == null) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/RankingAndCrowdingDistanceComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/RankingAndCrowdingDistanceComparator.java
@@ -23,9 +23,9 @@ import java.util.Comparator;
  * This class implements a comparator based on the rank of the solutions; if the rank is the same
  * then the crowding distance is used.
  */
-public class RankingAndCrowdingDistanceComparator implements Comparator<Solution> {
-  private final Comparator<Solution> rankComparator = new RankingComparator();
-  private final Comparator<Solution> crowdingDistanceComparator = new CrowdingDistanceComparator() ;
+public class RankingAndCrowdingDistanceComparator<S extends Solution<?>> implements Comparator<S> {
+  private final Comparator<S> rankComparator = new RankingComparator<S>();
+  private final Comparator<S> crowdingDistanceComparator = new CrowdingDistanceComparator<S>() ;
 
   /**
    * Compares two solutions.
@@ -36,7 +36,7 @@ public class RankingAndCrowdingDistanceComparator implements Comparator<Solution
    * respectively.
    */
   @Override
-  public int compare(Solution solution1, Solution solution2) {
+  public int compare(S solution1, S solution2) {
     int result = rankComparator.compare(solution1, solution2) ;
     if (result == 0) {
       result = crowdingDistanceComparator.compare(solution1, solution2);

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/RankingComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/RankingComparator.java
@@ -25,8 +25,8 @@ import java.util.Comparator;
  *
  * This class implements a comparator based on the rank of the solutions.
  */
-public class RankingComparator implements Comparator<Solution> {
-  private Ranking ranking = new DominanceRanking() ;
+public class RankingComparator<S extends Solution<?>> implements Comparator<S> {
+  private Ranking<S> ranking = new DominanceRanking<S>() ;
 
   /**
    * Compares two solutions according to the ranking attribute. The lower the ranking the better
@@ -37,7 +37,7 @@ public class RankingComparator implements Comparator<Solution> {
    * respectively.
    */
   @Override
-  public int compare(Solution solution1, Solution solution2) {
+  public int compare(S solution1, S solution2) {
     int result ;
     if (solution1 == null) {
       if (solution2 == null) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/StrengthFitnessComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/StrengthFitnessComparator.java
@@ -5,11 +5,11 @@ import java.util.Comparator;
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.solutionattribute.impl.StrengthRawFitness;
 
-public class StrengthFitnessComparator implements Comparator<Solution>{
+public class StrengthFitnessComparator implements Comparator<Solution<?>>{
 	private final StrengthRawFitness fitnessValue = new StrengthRawFitness();
 
 	@Override
-	public int compare(Solution solution1, Solution solution2) {
+	public int compare(Solution<?> solution1, Solution<?> solution2) {
 		int result ;
 	    if (solution1 == null) {
 	      if (solution2 == null) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/StrengthFitnessComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/StrengthFitnessComparator.java
@@ -5,11 +5,11 @@ import java.util.Comparator;
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.solutionattribute.impl.StrengthRawFitness;
 
-public class StrengthFitnessComparator implements Comparator<Solution<?>>{
-	private final StrengthRawFitness fitnessValue = new StrengthRawFitness();
+public class StrengthFitnessComparator<S extends Solution<?>> implements Comparator<S>{
+	private final StrengthRawFitness<S> fitnessValue = new StrengthRawFitness<S>();
 
 	@Override
-	public int compare(Solution<?> solution1, Solution<?> solution2) {
+	public int compare(S solution1, S solution2) {
 		int result ;
 	    if (solution1 == null) {
 	      if (solution2 == null) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/impl/OverallConstraintViolationComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/impl/OverallConstraintViolationComparator.java
@@ -37,7 +37,7 @@ public class OverallConstraintViolationComparator implements ConstraintViolation
    * @return -1, or 0, or 1 if o1 is less than, equal, or greater than o2,
    * respectively.
    */
-  public int compare(Solution solution1, Solution solution2) {
+  public int compare(Solution<?> solution1, Solution<?> solution2) {
     double violationDegreeSolution1 ;
     double violationDegreeSolution2;
     violationDegreeSolution1 =  solution1.getOverallConstraintViolationDegree();

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/impl/OverallConstraintViolationComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/impl/OverallConstraintViolationComparator.java
@@ -28,7 +28,7 @@ import org.uma.jmetal.util.comparator.ConstraintViolationComparator;
  * This class implements a <code>Comparator</code> (a method for comparing <code>Solution</code> objects)
  * based on the overall constraint violation of the solutions, as done in NSGA-II.
  */
-public class OverallConstraintViolationComparator implements ConstraintViolationComparator {
+public class OverallConstraintViolationComparator<S extends Solution<?>> implements ConstraintViolationComparator<S> {
   /**
    * Compares two solutions.
    *
@@ -37,7 +37,7 @@ public class OverallConstraintViolationComparator implements ConstraintViolation
    * @return -1, or 0, or 1 if o1 is less than, equal, or greater than o2,
    * respectively.
    */
-  public int compare(Solution<?> solution1, Solution<?> solution2) {
+  public int compare(S solution1, S solution2) {
     double violationDegreeSolution1 ;
     double violationDegreeSolution2;
     violationDegreeSolution1 =  solution1.getOverallConstraintViolationDegree();

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/impl/ViolationThresholdComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/impl/ViolationThresholdComparator.java
@@ -26,8 +26,8 @@ import org.uma.jmetal.util.comparator.ConstraintViolationComparator;
 import java.util.List;
 
 // This class implements the ViolationThreshold Comparator
-public class ViolationThresholdComparator<S extends Solution> implements
-    ConstraintViolationComparator {
+public class ViolationThresholdComparator<S extends Solution<?>> implements
+    ConstraintViolationComparator<S> {
 
   private double threshold = 0.0;
 
@@ -40,7 +40,7 @@ public class ViolationThresholdComparator<S extends Solution> implements
    * respectively.
    */
   @Override
-  public int compare(Solution solution1, Solution solution2) {
+  public int compare(S solution1, S solution2) {
     double overall1, overall2;
     overall1 = solution1.getNumberOfViolatedConstraints() *
         solution1.getOverallConstraintViolationDegree();
@@ -68,7 +68,7 @@ public class ViolationThresholdComparator<S extends Solution> implements
    * Returns true if solutions s1 and/or s2 have an overall constraint
    * violation with value less than 0
    */
-  public boolean needToCompare(Solution solution1, Solution solution2) {
+  public boolean needToCompare(S solution1, S solution2) {
     boolean needToCompare;
     double overall1, overall2;
     overall1 = Math.abs(solution1.getNumberOfViolatedConstraints() *

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/SolutionListEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/SolutionListEvaluator.java
@@ -32,7 +32,7 @@ import java.util.List;
  * Created by Antonio J. Nebro on 30/05/14.
  */
 
-public interface SolutionListEvaluator<S extends Solution> extends Serializable {
-  public List<S> evaluate(List<S> solutionSet, Problem problem) ;
+public interface SolutionListEvaluator<S extends Solution<?>> extends Serializable {
+  public List<S> evaluate(List<S> solutionSet, Problem<S> problem) ;
   public void shutdown() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/MultithreadedSolutionListEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/MultithreadedSolutionListEvaluator.java
@@ -32,13 +32,13 @@ import java.util.List;
  * Created by Antonio J. Nebro on 30/05/14.
  */
 public class MultithreadedSolutionListEvaluator<S extends Solution<?>> implements SolutionListEvaluator<S> {
-  private MultithreadedEvaluator evaluator;
+  private MultithreadedEvaluator<S> evaluator;
   private Problem<S> problem;
   private int numberOfThreads ;
 
   public MultithreadedSolutionListEvaluator(int numberOfThreads, Problem<S> problem) {
   	this.numberOfThreads = numberOfThreads ;
-    evaluator = new MultithreadedEvaluator(numberOfThreads)  ;
+    evaluator = new MultithreadedEvaluator<S>(numberOfThreads)  ;
     this.problem = problem ;
     evaluator.start(problem) ;
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/MultithreadedSolutionListEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/MultithreadedSolutionListEvaluator.java
@@ -31,12 +31,12 @@ import java.util.List;
 /**
  * Created by Antonio J. Nebro on 30/05/14.
  */
-public class MultithreadedSolutionListEvaluator<S extends Solution> implements SolutionListEvaluator<S> {
+public class MultithreadedSolutionListEvaluator<S extends Solution<?>> implements SolutionListEvaluator<S> {
   private MultithreadedEvaluator evaluator;
-  private Problem problem;
+  private Problem<S> problem;
   private int numberOfThreads ;
 
-  public MultithreadedSolutionListEvaluator(int numberOfThreads, Problem problem) {
+  public MultithreadedSolutionListEvaluator(int numberOfThreads, Problem<S> problem) {
   	this.numberOfThreads = numberOfThreads ;
     evaluator = new MultithreadedEvaluator(numberOfThreads)  ;
     this.problem = problem ;
@@ -44,7 +44,7 @@ public class MultithreadedSolutionListEvaluator<S extends Solution> implements S
   }
 
   @Override
-  public List<S> evaluate(List<S> SolutionList, Problem problem) {
+  public List<S> evaluate(List<S> SolutionList, Problem<S> problem) {
     for (int i = 0 ; i < SolutionList.size(); i++) {
       evaluator.addTask(new Object[] {SolutionList.get(i)});
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/SequentialSolutionListEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/SequentialSolutionListEvaluator.java
@@ -35,15 +35,15 @@ import java.util.logging.Level;
 /**
  * Created by Antonio J. Nebro on 30/05/14.
  */
-public class SequentialSolutionListEvaluator<S extends Solution> implements SolutionListEvaluator<S> {
+public class SequentialSolutionListEvaluator<S extends Solution<?>> implements SolutionListEvaluator<S> {
 
   @Override
-  public List<S> evaluate(List<S> solutionList, Problem problem) throws JMetalException {
+  public List<S> evaluate(List<S> solutionList, Problem<S> problem) throws JMetalException {
     try {
       if (problem instanceof ConstrainedProblem) {
         for (int i = 0 ; i < solutionList.size(); i++) {
           problem.evaluate(solutionList.get(i)) ;
-          ((ConstrainedProblem)problem).evaluateConstraints(solutionList.get(i)) ;
+          ((ConstrainedProblem<S>)problem).evaluateConstraints(solutionList.get(i)) ;
         }
       } else {
         for (int i = 0 ; i < solutionList.size(); i++) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentConfiguration.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentConfiguration.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class ExperimentConfiguration<S extends Solution<?>> {
 	private String experimentName;
-	private List<Algorithm<S>> algorithmList;
+	private List<Algorithm<?>> algorithmList;
 	private List<Problem<S>> problemList;
 	private String experimentBaseDirectory;
 
@@ -58,7 +58,7 @@ public class ExperimentConfiguration<S extends Solution<?>> {
     return experimentName;
   }
 
-  public List<Algorithm<S>> getAlgorithmList() {
+  public List<Algorithm<?>> getAlgorithmList() {
     return algorithmList;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentConfiguration.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentConfiguration.java
@@ -23,6 +23,7 @@ package org.uma.jmetal.util.experiment;
 
 import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
 
 import java.util.List;
 
@@ -31,10 +32,10 @@ import java.util.List;
  * 
  * Class for describing the configuration of a jMetal experiment
  */
-public class ExperimentConfiguration {
+public class ExperimentConfiguration<S extends Solution<?>> {
 	private String experimentName;
-	private List<Algorithm> algorithmList;
-	private List<Problem> problemList;
+	private List<Algorithm<S>> algorithmList;
+	private List<Problem<S>> problemList;
 	private String experimentBaseDirectory;
 
 	private String outputParetoFrontFileName;
@@ -42,7 +43,7 @@ public class ExperimentConfiguration {
 	private int independentRuns;
 
 	/** Constructor */
-	public ExperimentConfiguration(ExperimentConfigurationBuilder builder) {
+	public ExperimentConfiguration(ExperimentConfigurationBuilder<S> builder) {
 		experimentName = builder.getExperimentName() ;
     this.experimentBaseDirectory = builder.getExperimentBaseDirectory() ;
     this.algorithmList = builder.getAlgorithmList() ;
@@ -57,11 +58,11 @@ public class ExperimentConfiguration {
     return experimentName;
   }
 
-  public List<Algorithm> getAlgorithmList() {
+  public List<Algorithm<S>> getAlgorithmList() {
     return algorithmList;
   }
 
-  public List<Problem> getProblemList() {
+  public List<Problem<S>> getProblemList() {
     return problemList;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentConfigurationBuilder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentConfigurationBuilder.java
@@ -23,6 +23,7 @@ package org.uma.jmetal.util.experiment;
 
 import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,10 +33,10 @@ import java.util.List;
  *
  * Class for describing the configuration of a jMetal experiment
  */
-public class ExperimentConfigurationBuilder {
+public class ExperimentConfigurationBuilder<S extends Solution<?>> {
   private final String experimentName ;
-  private List<Algorithm> algorithmList;
-  private List<Problem> problemList;
+  private List<Algorithm<S>> algorithmList;
+  private List<Problem<S>> problemList;
   private String experimentBaseDirectory;
   private String outputParetoFrontFileName;
   private String outputParetoSetFileName;
@@ -45,44 +46,44 @@ public class ExperimentConfigurationBuilder {
     this.experimentName = experimentName ;
   }
 
-  public ExperimentConfigurationBuilder setAlgorithmList(List<Algorithm> algorithmList) {
+  public ExperimentConfigurationBuilder<S> setAlgorithmList(List<Algorithm<S>> algorithmList) {
     this.algorithmList = new ArrayList<>(algorithmList) ;
 
     return this ;
   }
 
-  public ExperimentConfigurationBuilder setProblemList(List<Problem> problemList) {
+  public ExperimentConfigurationBuilder<S> setProblemList(List<Problem<S>> problemList) {
     this.problemList = new ArrayList<>(problemList) ;
 
     return this ;
   }
 
-  public ExperimentConfigurationBuilder setExperimentBaseDirectory(String experimentBaseDirectory) {
+  public ExperimentConfigurationBuilder<S> setExperimentBaseDirectory(String experimentBaseDirectory) {
     this.experimentBaseDirectory = experimentBaseDirectory+"/"+experimentName ;
 
     return this ;
   }
 
-  public ExperimentConfigurationBuilder setOutputParetoFrontFileName(String outputParetoFrontFileName) {
+  public ExperimentConfigurationBuilder<S> setOutputParetoFrontFileName(String outputParetoFrontFileName) {
     this.outputParetoFrontFileName = outputParetoFrontFileName ;
 
     return this ;
   }
 
-  public ExperimentConfigurationBuilder setOutputParetoSetFileName(String outputParetoSetFileName) {
+  public ExperimentConfigurationBuilder<S> setOutputParetoSetFileName(String outputParetoSetFileName) {
     this.outputParetoSetFileName = outputParetoSetFileName ;
 
     return this ;
   }
 
-  public ExperimentConfigurationBuilder setIndependentRuns(int independentRuns) {
+  public ExperimentConfigurationBuilder<S> setIndependentRuns(int independentRuns) {
     this.independentRuns = independentRuns ;
 
     return this ;
   }
 
-  public ExperimentConfiguration build() {
-    return new ExperimentConfiguration(this);
+  public ExperimentConfiguration<S> build() {
+    return new ExperimentConfiguration<S>(this);
   }
 
   /* Getters */
@@ -90,11 +91,11 @@ public class ExperimentConfigurationBuilder {
     return experimentName;
   }
 
-  public List<Algorithm> getAlgorithmList() {
+  public List<Algorithm<S>> getAlgorithmList() {
     return algorithmList;
   }
 
-  public List<Problem> getProblemList() {
+  public List<Problem<S>> getProblemList() {
     return problemList;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentConfigurationBuilder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentConfigurationBuilder.java
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public class ExperimentConfigurationBuilder<S extends Solution<?>> {
   private final String experimentName ;
-  private List<Algorithm<S>> algorithmList;
+  private List<Algorithm<?>> algorithmList;
   private List<Problem<S>> problemList;
   private String experimentBaseDirectory;
   private String outputParetoFrontFileName;
@@ -46,7 +46,7 @@ public class ExperimentConfigurationBuilder<S extends Solution<?>> {
     this.experimentName = experimentName ;
   }
 
-  public ExperimentConfigurationBuilder<S> setAlgorithmList(List<Algorithm<S>> algorithmList) {
+  public ExperimentConfigurationBuilder<S> setAlgorithmList(List<? extends Algorithm<?>> algorithmList) {
     this.algorithmList = new ArrayList<>(algorithmList) ;
 
     return this ;
@@ -91,7 +91,7 @@ public class ExperimentConfigurationBuilder<S extends Solution<?>> {
     return experimentName;
   }
 
-  public List<Algorithm<S>> getAlgorithmList() {
+  public List<Algorithm<?>> getAlgorithmList() {
     return algorithmList;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentRunner.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentRunner.java
@@ -20,13 +20,14 @@
 
 package org.uma.jmetal.util.experiment;
 
+import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalException;
 
 import java.io.IOException;
 
 public class ExperimentRunner {
   public static void main(String[] args) throws JMetalException, IOException {
-    ExperimentConfiguration configuration = new ExperimentConfigurationBuilder("Experiment")
+    ExperimentConfiguration<?> configuration = new ExperimentConfigurationBuilder<Solution<?>>("Experiment")
       //.setAlgorithmList(Arrays.asList("NSGAII", "SMPSO", "MOCell", "GDE3"))
       //.setProblemList(Arrays.asList("ZDT1", "ZDT2", "ZDT3", "ZDT4", "ZDT6"))
       .setExperimentBaseDirectory("/Users/antelverde/Softw/jMetal/jMetalGitHub/pruebas")

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentalStudy.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentalStudy.java
@@ -19,7 +19,7 @@ public class ExperimentalStudy {
   public static class Builder {
     private LinkedList<ExperimentComponent> resultObjectList ;
 
-    public Builder(ExperimentConfiguration experimentData) {
+    public Builder(ExperimentConfiguration<?> experimentData) {
       this.resultObjectList = new LinkedList<>() ;
   	}
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/impl/AlgorithmExecution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/impl/AlgorithmExecution.java
@@ -32,10 +32,10 @@ import java.io.File;
  * Created by Antonio J. Nebro on 18/07/14.
  */
 public class AlgorithmExecution implements ExperimentComponent {
-  private ExperimentConfiguration configuration ;
+  private ExperimentConfiguration<?> configuration ;
 
   /** Constructor */
-  public AlgorithmExecution(ExperimentConfiguration configuration) {
+  public AlgorithmExecution(ExperimentConfiguration<?> configuration) {
     this.configuration = configuration ;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/extremevalues/impl/SolutionListExtremeValues.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/extremevalues/impl/SolutionListExtremeValues.java
@@ -9,13 +9,13 @@ import java.util.List;
 /**
  * Created by ajnebro on 23/4/15.
  */
-public class SolutionListExtremeValues implements ExtremeValuesFinder <List<Solution>, List<Double>> {
+public class SolutionListExtremeValues implements ExtremeValuesFinder <List<Solution<?>>, List<Double>> {
 
-  @Override public List<Double> findLowestValues(List<Solution> solutionList) {
+  @Override public List<Double> findLowestValues(List<Solution<?>> solutionList) {
 	  return new FrontExtremeValues().findLowestValues(new ArrayFront(solutionList));
   }
 
-  @Override public List<Double> findHighestValues(List<Solution> solutionList) {
+  @Override public List<Double> findHighestValues(List<Solution<?>> solutionList) {
 	  return new FrontExtremeValues().findHighestValues(new ArrayFront(solutionList));
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/fileoutput/SolutionSetOutput.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/fileoutput/SolutionSetOutput.java
@@ -31,7 +31,6 @@ import java.util.List;
 /**
  * Created by Antonio J. Nebro on 31/05/14.
  */
-@SuppressWarnings("ALL")
 public class SolutionSetOutput {
 
   public static class Printer {
@@ -40,15 +39,15 @@ public class SolutionSetOutput {
     private String varFileName = "VAR";
     private String funFileName = "FUN";
     private String separator = "\t";
-    private List<Solution> solutionSet;
+    private List<? extends Solution<?>> solutionSet;
     private boolean selectFeasibleSolutions;
 
-    public Printer(List<? extends Solution> solutionSet)  {
+    public Printer(List<? extends Solution<?>> solutionSet)  {
       varFileContext = new DefaultFileOutputContext(varFileName);
       funFileContext = new DefaultFileOutputContext(funFileName);
       varFileContext.setSeparator(separator);
       funFileContext.setSeparator(separator);
-      this.solutionSet = (List<Solution>) solutionSet;
+      this.solutionSet = solutionSet;
       selectFeasibleSolutions = false;
     }
 
@@ -83,7 +82,7 @@ public class SolutionSetOutput {
     }
   }
 
-  static public void printVariablesToFile(FileOutputContext context, List<Solution> solutionSet) {
+  static public void printVariablesToFile(FileOutputContext context, List<? extends Solution<?>> solutionSet) {
     BufferedWriter bufferedWriter = context.getFileWriter();
 
     int numberOfVariables = solutionSet.get(0).getNumberOfVariables();
@@ -100,7 +99,7 @@ public class SolutionSetOutput {
     }
   }
 
-  static public void printObjectivesToFile(FileOutputContext context, List<Solution> solutionSet) {
+  static public void printObjectivesToFile(FileOutputContext context, List<? extends Solution<?>> solutionSet) {
     BufferedWriter bufferedWriter = context.getFileWriter();
 
     int numberOfObjectives = solutionSet.get(0).getNumberOfObjectives();
@@ -120,11 +119,11 @@ public class SolutionSetOutput {
   /*
    * Wrappers for printing with default configuration
    */
-  public static void printObjectivesToFile(List<Solution> solutionSet, String fileName) throws IOException {
+  public static void printObjectivesToFile(List<? extends Solution<?>> solutionSet, String fileName) throws IOException {
     printObjectivesToFile(new DefaultFileOutputContext(fileName), solutionSet);
   }
 
-  public static void printVariablesToFile(List<Solution> solutionSet, String fileName) throws IOException {
+  public static void printVariablesToFile(List<? extends Solution<?>> solutionSet, String fileName) throws IOException {
     printVariablesToFile(new DefaultFileOutputContext(fileName), solutionSet);
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/front/imp/ArrayFront.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/front/imp/ArrayFront.java
@@ -42,7 +42,7 @@ public class ArrayFront implements Front {
   }
 
   /** Constructor */
-  public ArrayFront(List<? extends Solution> solutionList) {
+  public ArrayFront(List<? extends Solution<?>> solutionList) {
     if (solutionList == null) {
       throw new JMetalException("The list of solution is null") ;
     } else if (solutionList.size() == 0) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/Neighborhood.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/Neighborhood.java
@@ -7,6 +7,6 @@ import java.util.List;
 /**
  * Created by ajnebro on 20/5/15.
  */
-public interface Neighborhood<S extends Solution> {
+public interface Neighborhood<S extends Solution<?>> {
   public List<S> getNeighbors(List<S> solutionList, int solutionIndex) ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/C9.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/C9.java
@@ -27,7 +27,7 @@ import org.uma.jmetal.solution.Solution;
  * Class representing neighborhoods for a <code>Solution</code> into a
  * <code>SolutionSet</code>.
  */
-public class C9<S extends Solution> extends TwoDimensionalMesh<S> {
+public class C9<S extends Solution<?>> extends TwoDimensionalMesh<S> {
 
   // 8 possible movements north, south, east, west, northeast, northwest,southeast, southwest
   // each movement is represented by an array of two positions, first component represents the

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/L5.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/L5.java
@@ -9,7 +9,7 @@ import org.uma.jmetal.solution.Solution;
  * structured as a bi-dimensional square mesh. The neighbors are those solutions that are in the positions
  * North, South, East and West
  */
-public class L5<S extends Solution> extends TwoDimensionalMesh<S> {
+public class L5<S extends Solution<?>> extends TwoDimensionalMesh<S> {
   private static final int [] north      = {-1,  0};
   private static final int [] south      = { 1 , 0};
   private static final int [] east       = { 0 , 1};

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/TwoDimensionalMesh.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/TwoDimensionalMesh.java
@@ -14,7 +14,7 @@ import java.util.List;
  * structured as a bi-dimensional square mesh. The neighbors are those solutions that are in the positions
  * North, South, East and West
  */
-public class TwoDimensionalMesh<S extends Solution> implements Neighborhood<S> {
+public class TwoDimensionalMesh<S extends Solution<?>> implements Neighborhood<S> {
   private int rows ;
   private int columns ;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/parallel/impl/MultithreadedEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/parallel/impl/MultithreadedEvaluator.java
@@ -36,8 +36,8 @@ import java.util.logging.Level;
  * @author Antonio J. Nebro
  *         Class for evaluating solutions in parallel using threads
  */
-public class MultithreadedEvaluator implements SynchronousParallelTaskExecutor {
-  private Problem problem;
+public class MultithreadedEvaluator<S extends Solution<?>> implements SynchronousParallelTaskExecutor {
+  private Problem<S> problem;
   private Collection<EvaluationTask> taskList;
   private int numberOfThreads;
   private ExecutorService executor;
@@ -67,7 +67,7 @@ public class MultithreadedEvaluator implements SynchronousParallelTaskExecutor {
    * @param problem problem to solve
    */
   public void start(Object problem) {
-    this.problem = (Problem) problem;
+    this.problem = (Problem<S>) problem;
 
     executor = Executors.newFixedThreadPool(numberOfThreads);
     JMetalLogger.logger.info("Cores: " + numberOfThreads);
@@ -78,7 +78,7 @@ public class MultithreadedEvaluator implements SynchronousParallelTaskExecutor {
    * Adds a solution to be evaluated to a list of tasks
    */
   public void addTask(Object[] taskParameters) {
-    Solution<?> solution = (Solution<?>) taskParameters[0];
+    S solution = (S) taskParameters[0];
     if (taskList == null) {
       taskList = new ArrayList<EvaluationTask>();
     }
@@ -128,8 +128,8 @@ public class MultithreadedEvaluator implements SynchronousParallelTaskExecutor {
    */
 
   private class EvaluationTask implements Callable<Object> {
-    private Problem problem;
-    private Solution solution;
+    private Problem<S> problem;
+    private S solution;
 
     /**
      * Constructor
@@ -137,12 +137,12 @@ public class MultithreadedEvaluator implements SynchronousParallelTaskExecutor {
      * @param problem  Problem to solve
      * @param solution Solution to evaluate
      */
-    public EvaluationTask(Problem problem, Solution solution) {
+    public EvaluationTask(Problem<S> problem, S solution) {
       this.problem = problem;
       this.solution = solution;
     }
 
-    public Solution call() throws Exception {
+    public S call() throws Exception {
       problem.evaluate(solution);
 
       return solution;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/parallel/impl/MultithreadedExperimentExecutor.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/parallel/impl/MultithreadedExperimentExecutor.java
@@ -72,7 +72,7 @@ public class MultithreadedExperimentExecutor implements SynchronousParallelTaskE
     String algorithm = (String) taskParameters[0];
     String problem = (String) taskParameters[1];
     Integer id = (Integer) taskParameters[2];
-    ExperimentConfiguration experimentData = (ExperimentConfiguration) taskParameters[3] ;
+    ExperimentConfiguration<?> experimentData = (ExperimentConfiguration<?>) taskParameters[3] ;
     taskList.add(new EvaluationTask(algorithm, problem, id, experimentData));
   }
 
@@ -109,10 +109,10 @@ public class MultithreadedExperimentExecutor implements SynchronousParallelTaskE
     private String problemName;
     private String algorithmName;
     private int id;
-    private ExperimentConfiguration experimentData ;
+    private ExperimentConfiguration<?> experimentData ;
 
     /** Constructor */
-    public EvaluationTask(String algorithm, String problem, int id, ExperimentConfiguration experimentData) {
+    public EvaluationTask(String algorithm, String problem, int id, ExperimentConfiguration<?> experimentData) {
       JMetalLogger.logger.info(
         " Task: " + algorithmName + ", problem: " + problemName + ", run: " + id);
       problemName = problem;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/point/impl/ArrayPoint.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/point/impl/ArrayPoint.java
@@ -65,7 +65,7 @@ public class ArrayPoint implements Point {
    *
    * @param solution
    */
-  public ArrayPoint(Solution solution) {
+  public ArrayPoint(Solution<?> solution) {
     if (solution == null) {
       throw new JMetalException("The solution is null") ;
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/DensityEstimator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/DensityEstimator.java
@@ -29,7 +29,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro
  */
-public interface DensityEstimator<S extends Solution> extends SolutionAttribute<S, Double>{
+public interface DensityEstimator<S extends Solution<?>> extends SolutionAttribute<S, Double>{
   public void computeDensityEstimator(List<S> solutionSet) ;
 }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/Ranking.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/Ranking.java
@@ -29,8 +29,8 @@ import java.util.List;
  *
  * @author Antonio J. Nebro
  */
-public interface Ranking<S extends Solution> extends SolutionAttribute<S, Integer>{
-  public Ranking computeRanking(List<S> solutionList) ;
+public interface Ranking<S extends Solution<?>> extends SolutionAttribute<S, Integer>{
+  public Ranking<S> computeRanking(List<S> solutionList) ;
   public List<S> getSubfront(int rank) ;
   public int getNumberOfSubfronts() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/SolutionAttribute.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/SolutionAttribute.java
@@ -5,7 +5,7 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by Antonio J. Nebro on 03/10/14.
  */
-public interface SolutionAttribute <S extends Solution, V> {
+public interface SolutionAttribute <S extends Solution<?>, V> {
   public void setAttribute(S solution, V value) ;
   public V getAttribute(S solution) ;
   public Object getAttributeID() ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/CrowdingDistance.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/CrowdingDistance.java
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * This class implements some utilities for calculating distances
  */
-public class CrowdingDistance<S extends Solution>
+public class CrowdingDistance<S extends Solution<?>>
     extends GenericSolutionAttribute<S, Double> implements DensityEstimator<S>{
 
   /**

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/CrowdingDistance.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/CrowdingDistance.java
@@ -63,8 +63,8 @@ public class CrowdingDistance<S extends Solution<?>>
     }
 
     //Use a new SolutionSet to avoid altering the original solutionSet
-    List<Solution<?>> front = new ArrayList<>(size);
-    for (Solution<?> solution : solutionList) {
+    List<S> front = new ArrayList<>(size);
+    for (S solution : solutionList) {
       front.add(solution);
     }
 
@@ -80,7 +80,7 @@ public class CrowdingDistance<S extends Solution<?>>
 
     for (int i = 0; i < numberOfObjectives; i++) {
       // Sort the population by Obj n
-      Collections.sort(front, new ObjectiveComparator(i)) ;
+      Collections.sort(front, new ObjectiveComparator<S>(i)) ;
       objetiveMinn = front.get(0).getObjective(i);
       objetiveMaxn = front.get(front.size() - 1).getObjective(i);
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/DistanceToSolutionListAttribute.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/DistanceToSolutionListAttribute.java
@@ -5,5 +5,5 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by cbarba on 24/3/15.
  */
-public class DistanceToSolutionListAttribute extends GenericSolutionAttribute<Solution,Double> {
+public class DistanceToSolutionListAttribute extends GenericSolutionAttribute<Solution<?>,Double> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/DominanceRanking.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/DominanceRanking.java
@@ -38,11 +38,11 @@ import java.util.*;
  * solutions, subset 1 contains the non-dominated solutions after removing those
  * belonging to subset 0, and so on.
  */
-public class DominanceRanking <S extends Solution>
+public class DominanceRanking <S extends Solution<?>>
     extends GenericSolutionAttribute<S, Integer> implements Ranking<S> {
 
-  private static final Comparator<Solution> DOMINANCE_COMPARATOR = new DominanceComparator();
-  private static final Comparator<Solution> CONSTRAINT_VIOLATION_COMPARATOR =
+  private static final Comparator<Solution<?>> DOMINANCE_COMPARATOR = new DominanceComparator();
+  private static final Comparator<Solution<?>> CONSTRAINT_VIOLATION_COMPARATOR =
     new OverallConstraintViolationComparator();
 
   private List<ArrayList<S>> rankedSubpopulations;
@@ -55,7 +55,7 @@ public class DominanceRanking <S extends Solution>
   }
 
   @Override
-  public Ranking computeRanking(List<S> solutionSet) {
+  public Ranking<S> computeRanking(List<S> solutionSet) {
     List<S> population = solutionSet;
 
     // dominateMe[i] contains the number of solutions dominating i

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/DominanceRanking.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/DominanceRanking.java
@@ -41,9 +41,9 @@ import java.util.*;
 public class DominanceRanking <S extends Solution<?>>
     extends GenericSolutionAttribute<S, Integer> implements Ranking<S> {
 
-  private static final Comparator<Solution<?>> DOMINANCE_COMPARATOR = new DominanceComparator();
+  private static final Comparator<Solution<?>> DOMINANCE_COMPARATOR = new DominanceComparator<Solution<?>>();
   private static final Comparator<Solution<?>> CONSTRAINT_VIOLATION_COMPARATOR =
-    new OverallConstraintViolationComparator();
+    new OverallConstraintViolationComparator<Solution<?>>();
 
   private List<ArrayList<S>> rankedSubpopulations;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/Fitness.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/Fitness.java
@@ -24,5 +24,5 @@ import org.uma.jmetal.solution.Solution;
 
 /**
  */
-public class Fitness<S extends Solution> extends GenericSolutionAttribute<S, Double> {
+public class Fitness<S extends Solution<?>> extends GenericSolutionAttribute<S, Double> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/GenericSolutionAttribute.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/GenericSolutionAttribute.java
@@ -25,10 +25,10 @@ import org.uma.jmetal.util.solutionattribute.SolutionAttribute;
 
 /**
  */
-public class GenericSolutionAttribute <S extends Solution, V> implements SolutionAttribute<S, V>{
+public class GenericSolutionAttribute <S extends Solution<?>, V> implements SolutionAttribute<S, V>{
 
   @Override
-  public V getAttribute(Solution solution) {
+  public V getAttribute(S solution) {
     return (V)solution.getAttribute(getAttributeID());
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/HypervolumeContribution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/HypervolumeContribution.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 /**
  */
-public class HypervolumeContribution<S extends Solution>
+public class HypervolumeContribution<S extends Solution<?>>
     extends GenericSolutionAttribute<S, Double> implements DensityEstimator<S> {
   private FastHypervolume fastHV ;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/LocationAttribute.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/LocationAttribute.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.uma.jmetal.solution.Solution;
 
 
-public class LocationAttribute <S extends Solution>
+public class LocationAttribute <S extends Solution<?>>
 extends GenericSolutionAttribute<S, Integer> {
 	    
 	 public LocationAttribute() {}

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/MarkAttribute.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/MarkAttribute.java
@@ -5,5 +5,5 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by cbarba on 24/3/15.
  */
-public class MarkAttribute extends GenericSolutionAttribute<Solution,Boolean> {
+public class MarkAttribute extends GenericSolutionAttribute<Solution<?>,Boolean> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/StrengthRawFitness.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/StrengthRawFitness.java
@@ -9,9 +9,9 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-public class StrengthRawFitness <S extends Solution>
+public class StrengthRawFitness <S extends Solution<?>>
     extends GenericSolutionAttribute<S, Double> implements DensityEstimator<S>{
-  private static final Comparator<Solution> DOMINANCE_COMPARATOR = new DominanceComparator();
+  private static final Comparator<Solution<?>> DOMINANCE_COMPARATOR = new DominanceComparator<Solution<?>>();
 
   @Override
   public void computeDensityEstimator(List<S> solutionSet) {

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/crossover/NullCrossoverTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/crossover/NullCrossoverTest.java
@@ -21,13 +21,13 @@ public class NullCrossoverTest {
 
   @Test
   public void shouldExecuteReturnTwoDifferentObjectsWhichAreEquals() {
-    Problem problem = new MockProblem() ;
+    Problem<DoubleSolution> problem = new MockProblem() ;
     List<DoubleSolution> parents = new ArrayList<>(2) ;
     parents.add((DoubleSolution) problem.createSolution()) ;
     parents.add((DoubleSolution) problem.createSolution()) ;
 
-    CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> crossover;
-    crossover = new NullCrossover<List<DoubleSolution>, List<DoubleSolution>>() ;
+    CrossoverOperator<DoubleSolution> crossover;
+    crossover = new NullCrossover<DoubleSolution>() ;
 
     List<DoubleSolution> offspring = crossover.execute(parents);
     assertNotSame(parents.get(0), offspring.get(0)) ;

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/BinaryTournamentSelectionTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/BinaryTournamentSelectionTest.java
@@ -15,7 +15,6 @@ package org.uma.jmetal.operator.impl.selection;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -45,31 +44,26 @@ import static org.mockito.Mockito.*;
 public class BinaryTournamentSelectionTest {
   private static final int POPULATION_SIZE = 20 ;
 
-  private BinaryTournamentSelection selection ;
-
-  @Mock private Problem problem ;
-  private List<Solution> population ;
-
-  @Before
-  public void startup() {
-    selection = new BinaryTournamentSelection() ;
-  }
+  @Mock private Problem<Solution<Object>> problem ;
+  private List<Solution<Object>> population ;
 
   @Test (expected = JMetalException.class)
   public void shouldExecuteRaiseAnExceptionIfTheListOfSolutionsIsNull() {
     population = null ;
+    BinaryTournamentSelection<Solution<Object>> selection = new BinaryTournamentSelection<Solution<Object>>() ;
     selection.execute(population) ;
   }
 
   @Test (expected = JMetalException.class)
   public void shouldExecuteRaiseAnExceptionIfTheListOfSolutionsIsEmpty() {
     population = new ArrayList<>(0) ;
+    BinaryTournamentSelection<Solution<Object>> selection = new BinaryTournamentSelection<Solution<Object>>() ;
     selection.execute(population) ;
   }
 
   @Test
   public void shouldExecuteReturnAValidSolutionIsWithCorrectParameters() {
-    Solution solution = mock(Solution.class) ;
+	  Solution<Object> solution = mock(Solution.class) ;
 
     Mockito.when(problem.createSolution()).thenReturn(solution) ;
 
@@ -77,23 +71,25 @@ public class BinaryTournamentSelectionTest {
     for (int i = 0 ; i < POPULATION_SIZE; i++) {
       population.add(problem.createSolution());
     }
+    BinaryTournamentSelection<Solution<Object>> selection = new BinaryTournamentSelection<Solution<Object>>() ;
     assertNotNull(selection.execute(population));
     verify(problem, times(POPULATION_SIZE)).createSolution();
   }
 
   @Test
   public void shouldExecuteReturnTheSameSolutionIfTheListContainsOneSolution() {
-    Solution solution = mock(Solution.class) ;
+	  Solution<Object> solution = mock(Solution.class) ;
 
     population = new ArrayList<>(1) ;
     population.add(solution) ;
+    BinaryTournamentSelection<Solution<Object>> selection = new BinaryTournamentSelection<Solution<Object>>() ;
     assertSame(solution, selection.execute(population));
   }
 
   @Test
   public void shouldExecuteReturnTwoSolutionsIfTheListContainsTwoSolutions() {
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<Object> solution1 = mock(Solution.class) ;
+    Solution<Object> solution2 = mock(Solution.class) ;
 
     population = Arrays.asList(solution1, solution2) ;
     assertEquals(2, population.size());
@@ -117,7 +113,7 @@ public class BinaryTournamentSelectionTest {
 
     List<DoubleSolution> population = Arrays.<DoubleSolution>asList(solution1, solution2);
 
-    selection = new BinaryTournamentSelection(comparator) ;
+    BinaryTournamentSelection<DoubleSolution> selection = new BinaryTournamentSelection<DoubleSolution>(comparator) ;
     DoubleSolution result = (DoubleSolution) selection.execute(population);
 
     assertThat(result, Matchers.either(Matchers.is(solution1)).or(Matchers.is(solution2))) ;
@@ -126,7 +122,6 @@ public class BinaryTournamentSelectionTest {
 
   @After
   public void tearDown() {
-    selection = null ;
     population = null ;
     problem = null ;
   }

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/NaryRandomSelectionTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/NaryRandomSelectionTest.java
@@ -40,14 +40,12 @@ public class NaryRandomSelectionTest {
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
-  private NaryRandomSelection selection ;
-
   @Test
   public void shouldExecuteRaiseAnExceptionIfTheSolutionListIsNull() {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is null"));
 
-    selection = new NaryRandomSelection() ;
+    NaryRandomSelection<Solution<?>> selection = new NaryRandomSelection<Solution<?>>() ;
     selection.execute(null) ;
   }
 
@@ -56,7 +54,7 @@ public class NaryRandomSelectionTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is empty"));
 
-    selection = new NaryRandomSelection() ;
+    NaryRandomSelection<DoubleSolution> selection = new NaryRandomSelection<DoubleSolution>() ;
     List<DoubleSolution> list = new ArrayList<>() ;
 
     selection.execute(list) ;
@@ -64,7 +62,7 @@ public class NaryRandomSelectionTest {
 
   @Test
   public void shouldDefaultConstructorReturnASingleSolution() {
-    selection = new NaryRandomSelection() ;
+    NaryRandomSelection<Solution<?>> selection = new NaryRandomSelection<Solution<?>>() ;
 
     int result = (int)ReflectionTestUtils.getField(selection, "numberOfSolutionsToBeReturned");
     int expectedResult = 1 ;
@@ -74,7 +72,7 @@ public class NaryRandomSelectionTest {
   @Test
   public void shouldNonDefaultConstructorReturnTheCorrectNumberOfSolutions() {
     int solutionsToBeReturned = 4 ;
-    selection = new NaryRandomSelection(solutionsToBeReturned) ;
+    NaryRandomSelection<Solution<?>> selection = new NaryRandomSelection<Solution<?>>(solutionsToBeReturned) ;
 
     int result = (int)ReflectionTestUtils.getField(selection, "numberOfSolutionsToBeReturned");
     assertEquals(solutionsToBeReturned, result) ;
@@ -86,8 +84,8 @@ public class NaryRandomSelectionTest {
     exception.expectMessage(containsString("The solution list size (1) is less than " +
     "the number of requested solutions (2)"));
 
-    selection = new NaryRandomSelection(2) ;
-    List<Solution> list = new ArrayList<>(1) ;
+    NaryRandomSelection<Solution<?>> selection = new NaryRandomSelection<Solution<?>>(2) ;
+    List<Solution<?>> list = new ArrayList<>(1) ;
     list.add(mock(Solution.class)) ;
 
     selection.execute(list) ;
@@ -99,8 +97,8 @@ public class NaryRandomSelectionTest {
     exception.expectMessage(containsString("The solution list size (2) is less than " +
         "the number of requested solutions (4)"));
 
-    selection = new NaryRandomSelection(4) ;
-    List<Solution> list = new ArrayList<>(2) ;
+    NaryRandomSelection<Solution<?>> selection = new NaryRandomSelection<Solution<?>>(4) ;
+    List<Solution<?>> list = new ArrayList<>(2) ;
     list.add(mock(Solution.class)) ;
     list.add(mock(Solution.class)) ;
 
@@ -109,7 +107,7 @@ public class NaryRandomSelectionTest {
 
   @Test
   public void shouldExecuteReturnTheSolutionInTheListIfTheListContainsASolution() {
-    selection = new NaryRandomSelection(1) ;
+    NaryRandomSelection<IntegerSolution> selection = new NaryRandomSelection<IntegerSolution>(1) ;
     List<IntegerSolution> list = new ArrayList<>(2) ;
     IntegerSolution solution = mock(IntegerSolution.class) ;
     list.add(solution) ;
@@ -120,7 +118,7 @@ public class NaryRandomSelectionTest {
 
   @Test
   public void shouldExecuteReturnTheSolutionSInTheListIfTheListContainsTwoSolutions() {
-    selection = new NaryRandomSelection(2) ;
+    NaryRandomSelection<BinarySolution> selection = new NaryRandomSelection<BinarySolution>(2) ;
     List<BinarySolution> list = new ArrayList<>(2) ;
     BinarySolution solution1 = mock(BinarySolution.class) ;
     BinarySolution solution2 = mock(BinarySolution.class) ;
@@ -139,7 +137,7 @@ public class NaryRandomSelectionTest {
     int listSize = 20 ;
     int solutionsToBeReturned = 4 ;
 
-    selection = new NaryRandomSelection(solutionsToBeReturned) ;
+    NaryRandomSelection<BinarySolution> selection = new NaryRandomSelection<BinarySolution>(solutionsToBeReturned) ;
     List<BinarySolution> list = new ArrayList<>(listSize) ;
     for (int i = 0; i < listSize; i++) {
       list.add(mock(BinarySolution.class));
@@ -164,7 +162,7 @@ public class NaryRandomSelectionTest {
       list.add(solution[i]);
     }
 
-    selection = new NaryRandomSelection(solutionsToBeReturned) ;
+    NaryRandomSelection<IntegerSolution> selection = new NaryRandomSelection<IntegerSolution>(solutionsToBeReturned) ;
 
     List<IntegerSolution> result = (List<IntegerSolution>) selection.execute(list);
     assertTrue(result.contains(solution[0]));

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/NaryTournamentSelectionTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/NaryTournamentSelectionTest.java
@@ -40,15 +40,15 @@ import static org.mockito.Mockito.*;
 public class NaryTournamentSelectionTest {
   private static final int POPULATION_SIZE = 20 ;
 
-  private NaryTournamentSelection selection ;
-  private List<Solution> population ;
+  private NaryTournamentSelection<?> selection ;
+  private List<Solution<?>> population ;
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void shouldDefaultConstructorSetTheNumberOfSolutionsToBeReturnedEqualsToTwo() {
-    selection = new NaryTournamentSelection() ;
+    selection = new NaryTournamentSelection<Solution<?>>() ;
 
     assertEquals(2, ReflectionTestUtils.getField(selection, "numberOfSolutionsToBeReturned"));
   }
@@ -58,14 +58,14 @@ public class NaryTournamentSelectionTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is null"));
 
-    selection = new NaryTournamentSelection() ;
+    selection = new NaryTournamentSelection<Solution<?>>() ;
     population = null ;
     selection.execute(population) ;
   }
 
   @Test (expected = JMetalException.class)
   public void shouldExecuteRaiseAnExceptionIfTheListOfSolutionsIsEmpty() {
-    selection = new NaryTournamentSelection() ;
+    selection = new NaryTournamentSelection<Solution<?>>() ;
 
     population = new ArrayList<>(0) ;
 
@@ -74,10 +74,10 @@ public class NaryTournamentSelectionTest {
 
   @Test
   public void shouldExecuteReturnAValidSolutionIsWithCorrectParameters() {
-    selection = new NaryTournamentSelection() ;
-    Solution solution = mock(Solution.class) ;
+    selection = new NaryTournamentSelection<Solution<?>>() ;
+    Solution<Object> solution = mock(Solution.class) ;
 
-    Problem problem = mock(Problem.class) ;
+    Problem<Solution<Object>> problem = mock(Problem.class) ;
 
     Mockito.when(problem.createSolution()).thenReturn(solution) ;
 
@@ -91,8 +91,8 @@ public class NaryTournamentSelectionTest {
 
   @Test
   public void shouldExecuteReturnTheSameSolutionIfTheListContainsOneSolution() {
-    selection = new NaryTournamentSelection(1, mock(Comparator.class)) ;
-    Solution solution = mock(Solution.class) ;
+    selection = new NaryTournamentSelection<Solution<?>>(1, mock(Comparator.class)) ;
+    Solution<?> solution = mock(Solution.class) ;
 
     population = new ArrayList<>(1) ;
     population.add(solution) ;
@@ -101,10 +101,10 @@ public class NaryTournamentSelectionTest {
 
   @Test
   public void shouldExecuteReturnTwoSolutionsIfTheListContainsTwoSolutions() {
-    selection = new NaryTournamentSelection(2, mock(Comparator.class)) ;
+    selection = new NaryTournamentSelection<Solution<?>>(2, mock(Comparator.class)) ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     population = Arrays.asList(solution1, solution2) ;
     assertEquals(2, population.size());
@@ -116,8 +116,8 @@ public class NaryTournamentSelectionTest {
     exception.expectMessage(containsString("The solution list size (1) is less than " +
         "the number of requested solutions (4)"));
 
-    selection = new NaryTournamentSelection(4, mock(Comparator.class)) ;
-    List<Solution> list = new ArrayList<>(1) ;
+    selection = new NaryTournamentSelection<Solution<?>>(4, mock(Comparator.class)) ;
+    List<Solution<?>> list = new ArrayList<>(1) ;
     list.add(mock(Solution.class)) ;
 
     selection.execute(list) ;

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/RankingAndCrowdingSelectionTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/RankingAndCrowdingSelectionTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.uma.jmetal.solution.DoubleSolution;
+import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalException;
 
 import java.util.ArrayList;
@@ -34,14 +35,12 @@ public class RankingAndCrowdingSelectionTest {
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
-  private RankingAndCrowdingSelection selection ;
-
   @Test
   public void shouldExecuteRaiseAnExceptionIfTheSolutionListIsNull() {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is null"));
 
-    selection = new RankingAndCrowdingSelection(4) ;
+    RankingAndCrowdingSelection<Solution<?>> selection = new RankingAndCrowdingSelection<Solution<?>>(4) ;
     selection.execute(null) ;
   }
 
@@ -50,7 +49,7 @@ public class RankingAndCrowdingSelectionTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is empty"));
 
-    selection = new RankingAndCrowdingSelection(4) ;
+    RankingAndCrowdingSelection<DoubleSolution> selection = new RankingAndCrowdingSelection<DoubleSolution>(4) ;
     List<DoubleSolution> list = new ArrayList<>() ;
 
     selection.execute(list) ;
@@ -58,7 +57,7 @@ public class RankingAndCrowdingSelectionTest {
 
   @Test
   public void shouldDefaultConstructorReturnASingleSolution() {
-    selection = new RankingAndCrowdingSelection(1) ;
+    RankingAndCrowdingSelection<Solution<?>> selection = new RankingAndCrowdingSelection<Solution<?>>(1) ;
 
     int result = (int) ReflectionTestUtils.getField(selection, "solutionsToSelect");
     int expectedResult = 1 ;
@@ -68,7 +67,7 @@ public class RankingAndCrowdingSelectionTest {
   @Test
   public void shouldNonDefaultConstructorReturnTheCorrectNumberOfSolutions() {
     int solutionsToSelect = 4 ;
-    selection = new RankingAndCrowdingSelection(solutionsToSelect) ;
+    RankingAndCrowdingSelection<Solution<?>> selection = new RankingAndCrowdingSelection<Solution<?>>(solutionsToSelect) ;
 
     int result = (int)ReflectionTestUtils.getField(selection, "solutionsToSelect");
     assertEquals(solutionsToSelect, result) ;

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/TournamentSelectionTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/TournamentSelectionTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
  * Created by ajnebro on 3/5/15.
  */
 public class TournamentSelectionTest {
-  private TournamentSelection selection ;
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -32,7 +31,7 @@ public class TournamentSelectionTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is null"));
 
-    selection = new TournamentSelection(4) ;
+    TournamentSelection<Solution<?>> selection = new TournamentSelection<Solution<?>>(4) ;
     selection.execute(null) ;
   }
 
@@ -41,7 +40,7 @@ public class TournamentSelectionTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is empty"));
 
-    selection = new TournamentSelection(4) ;
+    TournamentSelection<DoubleSolution> selection = new TournamentSelection<DoubleSolution>(4) ;
     List<DoubleSolution> list = new ArrayList<>() ;
 
     selection.execute(list) ;
@@ -49,7 +48,7 @@ public class TournamentSelectionTest {
 
   @Test
   public void shouldConstructorAssignTheCorrectValueToTheNumberOfTournaments() {
-    selection = new TournamentSelection(5) ;
+    TournamentSelection<Solution<?>> selection = new TournamentSelection<Solution<?>>(5) ;
 
     int result = (int) ReflectionTestUtils.getField(selection, "numberOfTournaments");
     int expectedResult = 5 ;
@@ -58,11 +57,11 @@ public class TournamentSelectionTest {
 
   @Test
   public void shouldConstructorAssignTheCorrectValueSToTheNumberOfTournamentsAndTheComparator() {
-    Comparator comparator = mock(Comparator.class) ;
-    selection = new TournamentSelection(comparator, 7) ;
+    Comparator<Solution<?>> comparator = mock(Comparator.class) ;
+    TournamentSelection<Solution<?>> selection = new TournamentSelection<Solution<?>>(comparator, 7) ;
 
     int result = (int) ReflectionTestUtils.getField(selection, "numberOfTournaments");
-    Comparator comp = (Comparator) ReflectionTestUtils.getField(selection, "comparator");
+    Object comp = ReflectionTestUtils.getField(selection, "comparator");
 
     int expectedResult = 7 ;
     assertEquals(expectedResult, result) ;
@@ -71,10 +70,10 @@ public class TournamentSelectionTest {
 
   @Test
   public void shouldExecuteReturnAnElementIfTheListHasOneElement() {
-    List<Solution> population = new ArrayList<>(1);
+    List<Solution<?>> population = new ArrayList<>(1);
 
-    Comparator comparator = mock(Comparator.class) ;
-    selection = new TournamentSelection(comparator, 2) ;
+    Comparator<Solution<?>> comparator = mock(Comparator.class) ;
+    TournamentSelection<Solution<?>> selection = new TournamentSelection<Solution<?>>(comparator, 2) ;
 
     BinarySolution solution = mock(BinarySolution.class) ;
     population.add(solution) ;

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/SolutionListUtilsTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/SolutionListUtilsTest.java
@@ -16,6 +16,7 @@ package org.uma.jmetal.util;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Matchers;
 import org.uma.jmetal.solution.BinarySolution;
 import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.solution.IntegerSolution;
@@ -27,7 +28,6 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.*;
 
 /**
@@ -44,7 +44,7 @@ public class SolutionListUtilsTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is null"));
 
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<Solution<?>> comparator = mock(Comparator.class) ;
 
     SolutionListUtils.findBestSolution(null, comparator) ;
   }
@@ -54,7 +54,7 @@ public class SolutionListUtilsTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is empty"));
 
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<DoubleSolution> comparator = mock(Comparator.class) ;
     List<DoubleSolution> list = new ArrayList<>() ;
 
     SolutionListUtils.findBestSolution(list, comparator) ;
@@ -73,7 +73,7 @@ public class SolutionListUtilsTest {
 
   @Test
   public void shouldFindBestSolutionReturnTheSolutionInTheListWhenItContainsOneSolution() {
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<IntegerSolution> comparator = mock(Comparator.class) ;
     List<IntegerSolution> list = new ArrayList<>() ;
     IntegerSolution solution = mock(IntegerSolution.class) ;
     list.add(solution) ;
@@ -83,29 +83,29 @@ public class SolutionListUtilsTest {
 
   @Test
   public void shouldFindBestSolutionReturnTheSecondSolutionInTheListIfIsTheBestOufOfTwoSolutions() {
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<IntegerSolution> comparator = mock(Comparator.class) ;
     List<IntegerSolution> list = new ArrayList<>() ;
     IntegerSolution solution1 = mock(IntegerSolution.class) ;
     list.add(solution1) ;
     IntegerSolution solution2 = mock(IntegerSolution.class) ;
     list.add(solution2) ;
 
-    when(comparator.compare(anyObject(), anyObject())).thenReturn(1) ;
+    when(comparator.compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject())).thenReturn(1) ;
 
     assertSame(solution2, SolutionListUtils.findBestSolution(list, comparator)) ;
   }
 
   @Test
   public void shouldFindBestSolutionReturnTheLastOneIfThisIsTheBestSolutionInALastInAListWithFiveSolutions() {
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<IntegerSolution> comparator = mock(Comparator.class) ;
     List<IntegerSolution> list = new ArrayList<>() ;
     for (int i = 0 ; i < 5; i++) {
       list.add(mock(IntegerSolution.class)) ;
     }
 
-    when(comparator.compare(anyObject(), anyObject())).thenReturn(1, 0, 0, 1) ;
+    when(comparator.compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject())).thenReturn(1, 0, 0, 1) ;
     assertSame(list.get(4), SolutionListUtils.findBestSolution(list, comparator));
-    verify(comparator, times(4)).compare(anyObject(), anyObject()) ;
+    verify(comparator, times(4)).compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject()) ;
   }
 
   /***** Unit tests to method findIndexOfBestSolution ****/
@@ -114,7 +114,7 @@ public class SolutionListUtilsTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is null"));
 
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<Solution<?>> comparator = mock(Comparator.class) ;
 
     SolutionListUtils.findIndexOfBestSolution(null, comparator) ;
   }
@@ -124,7 +124,7 @@ public class SolutionListUtilsTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is empty"));
 
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<DoubleSolution> comparator = mock(Comparator.class) ;
     List<DoubleSolution> list = new ArrayList<>() ;
 
     SolutionListUtils.findIndexOfBestSolution(list, comparator) ;
@@ -143,7 +143,7 @@ public class SolutionListUtilsTest {
 
   @Test
   public void shouldFindIndexOfBestSolutionReturnZeroIfTheListWhenItContainsOneSolution() {
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<IntegerSolution> comparator = mock(Comparator.class) ;
     List<IntegerSolution> list = new ArrayList<>() ;
     IntegerSolution solution = mock(IntegerSolution.class) ;
     list.add(solution) ;
@@ -153,43 +153,43 @@ public class SolutionListUtilsTest {
 
   @Test
   public void shouldFindIndexOfBestSolutionReturnZeroIfTheFirstSolutionItTheBestOutOfTwoSolutionsInTheList() {
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<IntegerSolution> comparator = mock(Comparator.class) ;
     List<IntegerSolution> list = new ArrayList<>() ;
     IntegerSolution solution1 = mock(IntegerSolution.class) ;
     list.add(solution1) ;
     IntegerSolution solution2 = mock(IntegerSolution.class) ;
     list.add(solution2) ;
 
-    when(comparator.compare(anyObject(), anyObject())).thenReturn(0) ;
+    when(comparator.compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject())).thenReturn(0) ;
     assertEquals(0, SolutionListUtils.findIndexOfBestSolution(list, comparator));
-    verify(comparator).compare(anyObject(), anyObject()) ;
+    verify(comparator).compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject()) ;
   }
 
   @Test
   public void shouldFindIndexOfBestSolutionReturnOneIfTheSecondSolutionItTheBestOutOfTwoSolutionInTheList() {
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<IntegerSolution> comparator = mock(Comparator.class) ;
     List<IntegerSolution> list = new ArrayList<>() ;
     IntegerSolution solution1 = mock(IntegerSolution.class) ;
     list.add(solution1) ;
     IntegerSolution solution2 = mock(IntegerSolution.class) ;
     list.add(solution2) ;
 
-    when(comparator.compare(anyObject(), anyObject())).thenReturn(1) ;
+    when(comparator.compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject())).thenReturn(1) ;
     assertEquals(1, SolutionListUtils.findIndexOfBestSolution(list, comparator));
-    verify(comparator).compare(anyObject(), anyObject()) ;
+    verify(comparator).compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject()) ;
   }
 
   @Test
   public void shouldFindIndexOfBestSolutionReturn4IfTheBestSolutionIsTheLastInAListWithFiveSolutions() {
-    Comparator comparator = mock(Comparator.class) ;
+    Comparator<IntegerSolution> comparator = mock(Comparator.class) ;
     List<IntegerSolution> list = new ArrayList<>() ;
     for (int i = 0 ; i < 5; i++) {
       list.add(mock(IntegerSolution.class)) ;
     }
 
-    when(comparator.compare(anyObject(), anyObject())).thenReturn(1,0,0,1) ;
+    when(comparator.compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject())).thenReturn(1,0,0,1) ;
     assertEquals(4, SolutionListUtils.findIndexOfBestSolution(list, comparator));
-    verify(comparator, times(4)).compare(anyObject(), anyObject()) ;
+    verify(comparator, times(4)).compare(Matchers.<IntegerSolution> anyObject(), Matchers.<IntegerSolution> anyObject()) ;
   }
 
   /***** Unit tests to method selectNRandomDifferentSolutions ****/
@@ -213,7 +213,7 @@ public class SolutionListUtilsTest {
 
   @Test
   public void shouldSelectNRandomDifferentSolutionsReturnASingleSolution() {
-    List<Solution> list = new ArrayList<>() ;
+    List<Solution<?>> list = new ArrayList<>() ;
     list.add(mock(Solution.class)) ;
 
     assertEquals(1, list.size()) ;
@@ -225,7 +225,7 @@ public class SolutionListUtilsTest {
     exception.expectMessage(containsString("The solution list size (1) is less than " +
         "the number of requested solutions (2)"));
 
-    List<Solution> list = new ArrayList<>(1) ;
+    List<Solution<?>> list = new ArrayList<>(1) ;
     list.add(mock(Solution.class)) ;
 
     SolutionListUtils.selectNRandomDifferentSolutions(2, list) ;
@@ -237,7 +237,7 @@ public class SolutionListUtilsTest {
     exception.expectMessage(containsString("The solution list size (2) is less than " +
         "the number of requested solutions (4)"));
 
-    List<Solution> list = new ArrayList<>(2) ;
+    List<Solution<?>> list = new ArrayList<>(2) ;
     list.add(mock(Solution.class)) ;
     list.add(mock(Solution.class)) ;
 

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/CrowdingDistanceComparatorTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/CrowdingDistanceComparatorTest.java
@@ -30,20 +30,20 @@ import static org.mockito.Mockito.*;
  * @version 1.0
  */
 public class CrowdingDistanceComparatorTest {
-  private CrowdingDistanceComparator comparator ;
+  private CrowdingDistanceComparator<Solution<?>> comparator ;
 
   @Before public void setup() {
-    comparator = new CrowdingDistanceComparator() ;
+    comparator = new CrowdingDistanceComparator<Solution<?>>() ;
   }
 
   @Test public void shouldCompareReturnOneIfTheFirstSolutionIsNull() {
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     assertEquals(1, comparator.compare(null, solution2)) ;
   }
 
   @Test public void shouldCompareReturnMinusOneIfTheSecondSolutionIsNull() {
-    Solution solution1 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
 
     assertEquals(-1, comparator.compare(solution1, null)) ;
   }
@@ -53,20 +53,20 @@ public class CrowdingDistanceComparatorTest {
   }
 
   @Test public void shouldCompareReturnZeroIfBothSolutionsHaveNoCrowdingDistanceAttribute() {
-    CrowdingDistance distance = mock(CrowdingDistance.class) ;
+    CrowdingDistance<Solution<?>> distance = mock(CrowdingDistance.class) ;
     when(distance.getAttribute(any(Solution.class))).thenReturn(null, null) ;
 
     ReflectionTestUtils.setField(comparator, "crowdingDistance", distance);
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     assertEquals(0, comparator.compare(solution1, solution2));
     verify(distance, times(2)).getAttribute(any(Solution.class)) ;
   }
 
   @Test public void shouldCompareReturnZeroIfBothSolutionsHaveTheSameDistance() {
-    CrowdingDistance distance = mock(CrowdingDistance.class) ;
+    CrowdingDistance<Solution<?>> distance = mock(CrowdingDistance.class) ;
     when(distance.getAttribute(any(DoubleSolution.class))).thenReturn(2.0, 2.0, 2.0, 2.0) ;
 
     ReflectionTestUtils.setField(comparator, "crowdingDistance", distance);
@@ -79,7 +79,7 @@ public class CrowdingDistanceComparatorTest {
   }
 
   @Test public void shouldCompareReturnOneIfSolutionAHasLessDistance() {
-    CrowdingDistance distance = mock(CrowdingDistance.class) ;
+    CrowdingDistance<Solution<?>> distance = mock(CrowdingDistance.class) ;
     when(distance.getAttribute(any(BinarySolution.class))).thenReturn(0.0, 0.0, 2.0, 2.0) ;
 
     ReflectionTestUtils.setField(comparator, "crowdingDistance", distance);
@@ -92,7 +92,7 @@ public class CrowdingDistanceComparatorTest {
   }
 
   @Test public void shouldCompareReturnMinusOneIfSolutionBHasHigherDistance() {
-    CrowdingDistance distance = mock(CrowdingDistance.class) ;
+    CrowdingDistance<Solution<?>> distance = mock(CrowdingDistance.class) ;
     when(distance.getAttribute(any(BinarySolution.class))).thenReturn(3.0, 3.0, 2.0, 2.0) ;
 
     ReflectionTestUtils.setField(comparator, "crowdingDistance", distance);

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/DominanceComparatorTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/DominanceComparatorTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
  * @version 1.0
  */
 public class DominanceComparatorTest {
-  private DominanceComparator comparator ;
+  private DominanceComparator<Solution<?>> comparator ;
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -38,9 +38,9 @@ public class DominanceComparatorTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("Solution1 is null"));
 
-    comparator = new DominanceComparator() ;
+    comparator = new DominanceComparator<Solution<?>>() ;
 
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     comparator.compare(null, solution2) ;
   }
@@ -49,9 +49,9 @@ public class DominanceComparatorTest {
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("Solution2 is null"));
 
-    comparator = new DominanceComparator(0) ;
+    comparator = new DominanceComparator<Solution<?>>(0) ;
 
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     comparator.compare(solution2, null) ;
   }
@@ -61,10 +61,10 @@ public class DominanceComparatorTest {
     exception.expectMessage(containsString("Cannot compare because solution1 has 4 objectives "
         + "and solution2 has 2"));
 
-    comparator = new DominanceComparator() ;
+    comparator = new DominanceComparator<Solution<?>>() ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     when(solution1.getNumberOfObjectives()).thenReturn(4) ;
     when(solution2.getNumberOfObjectives()).thenReturn(2) ;
@@ -73,13 +73,13 @@ public class DominanceComparatorTest {
   }
 
   @Test public void shouldCompareReturnTheValueReturnedByTheConstraintViolationComparator() {
-    ConstraintViolationComparator violationComparator = mock(ConstraintViolationComparator.class) ;
+    ConstraintViolationComparator<Solution<?>> violationComparator = mock(ConstraintViolationComparator.class) ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     when(violationComparator.compare(solution1, solution2)).thenReturn(-1) ;
-    comparator = new DominanceComparator(violationComparator) ;
+    comparator = new DominanceComparator<Solution<?>>(violationComparator) ;
     int obtainedValue = comparator.compare(solution1, solution2) ;
 
     assertEquals(-1, obtainedValue) ;
@@ -87,10 +87,10 @@ public class DominanceComparatorTest {
   }
 
   @Test public void shouldCompareReturnZeroIfTheTwoSolutionsHasOneObjectiveWithTheSameValue() {
-    ConstraintViolationComparator violationComparator = mock(ConstraintViolationComparator.class) ;
+    ConstraintViolationComparator<Solution<?>> violationComparator = mock(ConstraintViolationComparator.class) ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     when(violationComparator.compare(solution1, solution2)).thenReturn(0) ;
 
@@ -100,7 +100,7 @@ public class DominanceComparatorTest {
     when(solution1.getObjective(0)).thenReturn(4.0) ;
     when(solution2.getObjective(0)).thenReturn(4.0) ;
 
-    comparator = new DominanceComparator(violationComparator) ;
+    comparator = new DominanceComparator<Solution<?>>(violationComparator) ;
 
     assertEquals(0, comparator.compare(solution1, solution2));
 
@@ -111,10 +111,10 @@ public class DominanceComparatorTest {
   }
 
   @Test public void shouldCompareReturnOneIfTheTwoSolutionsHasOneObjectiveAndTheSecondOneIsLower() {
-    ConstraintViolationComparator violationComparator = mock(ConstraintViolationComparator.class) ;
+    ConstraintViolationComparator<Solution<?>> violationComparator = mock(ConstraintViolationComparator.class) ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     when(violationComparator.compare(solution1, solution2)).thenReturn(0) ;
 
@@ -124,7 +124,7 @@ public class DominanceComparatorTest {
     when(solution1.getObjective(0)).thenReturn(4.0) ;
     when(solution2.getObjective(0)).thenReturn(2.0) ;
 
-    comparator = new DominanceComparator(violationComparator) ;
+    comparator = new DominanceComparator<Solution<?>>(violationComparator) ;
 
     assertEquals(1, comparator.compare(solution1, solution2));
 
@@ -135,10 +135,10 @@ public class DominanceComparatorTest {
   }
 
   @Test public void shouldCompareReturnMinusOneIfTheTwoSolutionsHasOneObjectiveAndTheFirstOneIsLower() {
-    ConstraintViolationComparator violationComparator = mock(ConstraintViolationComparator.class) ;
+    ConstraintViolationComparator<Solution<?>> violationComparator = mock(ConstraintViolationComparator.class) ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     when(violationComparator.compare(solution1, solution2)).thenReturn(0) ;
 
@@ -148,7 +148,7 @@ public class DominanceComparatorTest {
     when(solution1.getObjective(0)).thenReturn(-1.0) ;
     when(solution2.getObjective(0)).thenReturn(2.0) ;
 
-    comparator = new DominanceComparator(violationComparator) ;
+    comparator = new DominanceComparator<Solution<?>>(violationComparator) ;
 
     assertEquals(-1, comparator.compare(solution1, solution2));
 
@@ -162,10 +162,10 @@ public class DominanceComparatorTest {
    * Case A: solution1 has objectives [-1.0, 5.0, 9.0] and solution2 has [2.0, 6.0, 15.0]
    */
   @Test public void shouldCompareReturnMinusOneIfTheFirstSolutionDominatesTheSecondOneCaseA() {
-    ConstraintViolationComparator violationComparator = mock(ConstraintViolationComparator.class) ;
+    ConstraintViolationComparator<Solution<?>> violationComparator = mock(ConstraintViolationComparator.class) ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     when(violationComparator.compare(solution1, solution2)).thenReturn(0) ;
 
@@ -179,7 +179,7 @@ public class DominanceComparatorTest {
     when(solution2.getObjective(1)).thenReturn(6.0) ;
     when(solution2.getObjective(2)).thenReturn(15.0) ;
 
-    comparator = new DominanceComparator(violationComparator) ;
+    comparator = new DominanceComparator<Solution<?>>(violationComparator) ;
 
     assertEquals(-1, comparator.compare(solution1, solution2));
 
@@ -193,10 +193,10 @@ public class DominanceComparatorTest {
    * Case B: solution1 has objectives [-1.0, 5.0, 9.0] and solution2 has [-1.0, 5.0, 10.0]
    */
   @Test public void shouldCompareReturnMinusOneIfTheFirstSolutionDominatesTheSecondOneCaseB() {
-    ConstraintViolationComparator violationComparator = mock(ConstraintViolationComparator.class) ;
+    ConstraintViolationComparator<Solution<?>> violationComparator = mock(ConstraintViolationComparator.class) ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     when(violationComparator.compare(solution1, solution2)).thenReturn(0) ;
 
@@ -210,7 +210,7 @@ public class DominanceComparatorTest {
     when(solution2.getObjective(1)).thenReturn(5.0) ;
     when(solution2.getObjective(2)).thenReturn(10.0) ;
 
-    comparator = new DominanceComparator(violationComparator) ;
+    comparator = new DominanceComparator<Solution<?>>(violationComparator) ;
 
     assertEquals(-1, comparator.compare(solution1, solution2));
 
@@ -224,7 +224,7 @@ public class DominanceComparatorTest {
    * Case C: solution1 has  objectives [-1.0, 5.0, 9.0] and solution2 has [-2.0, 5.0, 9.0]
    */
   @Test public void shouldCompareReturnOneIfTheSecondSolutionDominatesTheFirstOneCaseC() {
-    ConstraintViolationComparator violationComparator = mock(ConstraintViolationComparator.class) ;
+    ConstraintViolationComparator<Solution<?>> violationComparator = mock(ConstraintViolationComparator.class) ;
 
     BinarySolution solution1 = mock(BinarySolution.class) ;
     BinarySolution solution2 = mock(BinarySolution.class) ;
@@ -241,7 +241,7 @@ public class DominanceComparatorTest {
     when(solution2.getObjective(1)).thenReturn(5.0) ;
     when(solution2.getObjective(2)).thenReturn(9.0) ;
 
-    comparator = new DominanceComparator(violationComparator) ;
+    comparator = new DominanceComparator<Solution<?>>(violationComparator) ;
 
     assertEquals(1, comparator.compare(solution1, solution2));
 
@@ -255,10 +255,10 @@ public class DominanceComparatorTest {
    * Case D: solution1 has  objectives [-1.0, 5.0, 9.0] and solution2 has [-1.0, 5.0, 8.0]
    */
   @Test public void shouldCompareReturnOneIfTheSecondSolutionDominatesTheFirstOneCaseD() {
-    ConstraintViolationComparator violationComparator = mock(ConstraintViolationComparator.class) ;
+    ConstraintViolationComparator<Solution<?>> violationComparator = mock(ConstraintViolationComparator.class) ;
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     when(violationComparator.compare(solution1, solution2)).thenReturn(0) ;
 
@@ -272,7 +272,7 @@ public class DominanceComparatorTest {
     when(solution2.getObjective(1)).thenReturn(5.0) ;
     when(solution2.getObjective(2)).thenReturn(8.0) ;
 
-    comparator = new DominanceComparator(violationComparator) ;
+    comparator = new DominanceComparator<Solution<?>>(violationComparator) ;
 
     assertEquals(1, comparator.compare(solution1, solution2));
 

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/ObjectiveComparatorTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/ObjectiveComparatorTest.java
@@ -29,35 +29,35 @@ import static org.mockito.Mockito.*;
  * @version 1.0
  */
 public class ObjectiveComparatorTest {
-  private ObjectiveComparator comparator ;
+  private ObjectiveComparator<Solution<?>> comparator ;
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
   @Test public void shouldCompareReturnOneIfTheFirstSolutionIsNull() {
-    comparator = new ObjectiveComparator(0) ;
+    comparator = new ObjectiveComparator<Solution<?>>(0) ;
 
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     assertEquals(1, comparator.compare(null, solution2)) ;
   }
 
   @Test public void shouldCompareReturnMinusOneIfTheSecondSolutionIsNull() {
-    comparator = new ObjectiveComparator(0) ;
+    comparator = new ObjectiveComparator<Solution<?>>(0) ;
 
-    Solution solution1 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
 
     assertEquals(-1, comparator.compare(solution1, null)) ;
   }
 
   @Test public void shouldCompareReturnZeroIfBothSolutionsAreNull() {
-    comparator = new ObjectiveComparator(0) ;
+    comparator = new ObjectiveComparator<Solution<?>>(0) ;
 
     assertEquals(0, comparator.compare(null, null)) ;
   }
 
   @Test public void shouldCompareReturnMinusOneIfTheObjectiveOfSolution1IsLower() {
-    comparator = new ObjectiveComparator(0) ;
+    comparator = new ObjectiveComparator<Solution<?>>(0) ;
 
     DoubleSolution solution1 = mock(DoubleSolution.class) ;
     DoubleSolution solution2 = mock(DoubleSolution.class) ;
@@ -74,7 +74,7 @@ public class ObjectiveComparatorTest {
   }
 
   @Test public void shouldCompareReturnOneIfTheObjectiveOfSolution2IsLower() {
-    comparator = new ObjectiveComparator(2) ;
+    comparator = new ObjectiveComparator<Solution<?>>(2) ;
 
     DoubleSolution solution1 = mock(DoubleSolution.class) ;
     DoubleSolution solution2 = mock(DoubleSolution.class) ;
@@ -89,7 +89,7 @@ public class ObjectiveComparatorTest {
   }
 
   @Test public void shouldCompareReturnZeroIfTheObjectiveOfTheSolutionsIsTheSame() {
-    comparator = new ObjectiveComparator(2) ;
+    comparator = new ObjectiveComparator<Solution<?>>(2) ;
 
     DoubleSolution solution1 = mock(DoubleSolution.class) ;
     DoubleSolution solution2 = mock(DoubleSolution.class) ;
@@ -104,7 +104,7 @@ public class ObjectiveComparatorTest {
   }
 
   @Test public void shouldCompareReturnMinusOneIfTheObjectiveOfSolution1IsGreaterInDescendingOrder() {
-    comparator = new ObjectiveComparator(0, ObjectiveComparator.Ordering.DESCENDING) ;
+    comparator = new ObjectiveComparator<Solution<?>>(0, ObjectiveComparator.Ordering.DESCENDING) ;
 
     DoubleSolution solution1 = mock(DoubleSolution.class) ;
     DoubleSolution solution2 = mock(DoubleSolution.class) ;
@@ -121,7 +121,7 @@ public class ObjectiveComparatorTest {
   }
 
   @Test public void shouldCompareReturnOneIfTheObjectiveOfSolution2IsGreaterInDescendingOrder() {
-    comparator = new ObjectiveComparator(2, ObjectiveComparator.Ordering.DESCENDING) ;
+    comparator = new ObjectiveComparator<Solution<?>>(2, ObjectiveComparator.Ordering.DESCENDING) ;
 
     DoubleSolution solution1 = mock(DoubleSolution.class) ;
     DoubleSolution solution2 = mock(DoubleSolution.class) ;
@@ -145,7 +145,7 @@ public class ObjectiveComparatorTest {
     exception.expectMessage(containsString("The solution1 has 3 objectives and the objective "
         + "to sort is 5"));
 
-    comparator = new ObjectiveComparator(5, ObjectiveComparator.Ordering.DESCENDING) ;
+    comparator = new ObjectiveComparator<Solution<?>>(5, ObjectiveComparator.Ordering.DESCENDING) ;
 
     DoubleSolution solution1 = mock(DoubleSolution.class) ;
     DoubleSolution solution2 = mock(DoubleSolution.class) ;
@@ -164,7 +164,7 @@ public class ObjectiveComparatorTest {
     exception.expectMessage(containsString("The solution2 has 5 objectives and the objective "
         + "to sort is 5"));
 
-    comparator = new ObjectiveComparator(5, ObjectiveComparator.Ordering.DESCENDING) ;
+    comparator = new ObjectiveComparator<Solution<?>>(5, ObjectiveComparator.Ordering.DESCENDING) ;
 
     DoubleSolution solution1 = mock(DoubleSolution.class) ;
     DoubleSolution solution2 = mock(DoubleSolution.class) ;

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/RankingAndCrowdingDistanceComparatorTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/RankingAndCrowdingDistanceComparatorTest.java
@@ -32,10 +32,10 @@ import static org.mockito.Mockito.when;
  * @version 1.0
  */
 public class RankingAndCrowdingDistanceComparatorTest {
-  private RankingAndCrowdingDistanceComparator comparator ;
+  private RankingAndCrowdingDistanceComparator<Solution<?>> comparator ;
 
   @Before public void setup() {
-    comparator = new RankingAndCrowdingDistanceComparator() ;
+    comparator = new RankingAndCrowdingDistanceComparator<Solution<?>>() ;
   }
 
   @After public void teardown() {
@@ -47,46 +47,46 @@ public class RankingAndCrowdingDistanceComparatorTest {
   }
 
   @Test public void shouldCompareWithANullSolutionAsFirstArgumentReturnOne() {
-    Solution solution = mock(Solution.class) ;
+    Solution<?> solution = mock(Solution.class) ;
     assertEquals(1, comparator.compare(null, solution)) ;
   }
 
   @Test public void shouldCompareWithANullSolutionAsSecondArgumentReturnMinusOne() {
-    Solution solution = mock(Solution.class) ;
+    Solution<?> solution = mock(Solution.class) ;
     assertEquals(-1, comparator.compare(solution, null)) ;
   }
 
   @Test public void shouldCompareWithNullRankingAttributeSolutionAsFirstArgumentReturnOne() {
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     assertEquals(1, comparator.compare(null, solution2)) ;
   }
 
   @Test public void shouldCompareWithRankingYieldingANonZeroValueReturnThatValue() {
-    Comparator<Solution> rankComparator = mock(Comparator.class) ;
+    Comparator<Solution<?>> rankComparator = mock(Comparator.class) ;
 
     when(rankComparator.compare(any(Solution.class), any(Solution.class))).thenReturn(1) ;
 
     ReflectionTestUtils.setField(comparator, "rankComparator", rankComparator);
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
     assertEquals(1, comparator.compare(solution1, solution2)) ;
     verify(rankComparator).compare(solution1, solution2) ;
   }
 
   @Test public void shouldCompareWhenRankingYieldingAZeroReturnTheCrowdingDistanceValue() {
-    Comparator<Solution> rankComparator = mock(Comparator.class) ;
+    Comparator<Solution<?>> rankComparator = mock(Comparator.class) ;
     when(rankComparator.compare(any(Solution.class), any(Solution.class))).thenReturn(0) ;
 
-    Comparator<Solution> crowdingDistanceComparator = mock(CrowdingDistanceComparator.class) ;
+    Comparator<Solution<?>> crowdingDistanceComparator = mock(CrowdingDistanceComparator.class) ;
     when(crowdingDistanceComparator.compare(any(Solution.class), any(Solution.class))).thenReturn(-1) ;
 
     ReflectionTestUtils.setField(comparator, "rankComparator", rankComparator);
     ReflectionTestUtils.setField(comparator, "crowdingDistanceComparator", crowdingDistanceComparator);
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     assertEquals(-1, comparator.compare(solution1, solution2)) ;
     verify(rankComparator).compare(solution1, solution2) ;

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/RankingComparatorTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/RankingComparatorTest.java
@@ -30,20 +30,20 @@ import static org.mockito.Mockito.*;
  * @version 1.0
  */
 public class RankingComparatorTest {
-  private RankingComparator comparator ;
+  private RankingComparator<Solution<?>> comparator ;
 
   @Before public void setup() {
-    comparator = new RankingComparator() ;
+    comparator = new RankingComparator<Solution<?>>() ;
   }
 
   @Test public void shouldCompareReturnOneIfTheFirstSolutionIsNull() {
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     assertEquals(1, comparator.compare(null, solution2)) ;
   }
 
   @Test public void shouldCompareReturnMinusOneIfTheSecondSolutionIsNull() {
-    Solution solution1 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
 
     assertEquals(-1, comparator.compare(solution1, null)) ;
   }
@@ -53,20 +53,20 @@ public class RankingComparatorTest {
   }
 
   @Test public void shouldCompareReturnZeroIfBothSolutionsHaveNoRankingAttribute() {
-    Ranking ranking = mock(Ranking.class) ;
+    Ranking<Solution<?>> ranking = mock(Ranking.class) ;
     when(ranking.getAttribute(any(Solution.class))).thenReturn(null, null) ;
 
     ReflectionTestUtils.setField(comparator, "ranking", ranking);
 
-    Solution solution1 = mock(Solution.class) ;
-    Solution solution2 = mock(Solution.class) ;
+    Solution<?> solution1 = mock(Solution.class) ;
+    Solution<?> solution2 = mock(Solution.class) ;
 
     assertEquals(0, comparator.compare(solution1, solution2));
     verify(ranking, times(2)).getAttribute(any(Solution.class)) ;
   }
 
   @Test public void shouldCompareReturnZeroIfBothSolutionsHaveTheSameRanking() {
-    Ranking ranking = mock(Ranking.class) ;
+    Ranking<Solution<?>> ranking = mock(Ranking.class) ;
     when(ranking.getAttribute(any(DoubleSolution.class))).thenReturn(1, 1, 1, 1) ;
 
     ReflectionTestUtils.setField(comparator, "ranking", ranking);
@@ -79,7 +79,7 @@ public class RankingComparatorTest {
   }
 
   @Test public void shouldCompareReturnMinusOneIfSolutionAHasLessRanking() {
-    Ranking ranking = mock(Ranking.class) ;
+    Ranking<Solution<?>> ranking = mock(Ranking.class) ;
     when(ranking.getAttribute(any(BinarySolution.class))).thenReturn(0, 0, 2, 2) ;
 
     ReflectionTestUtils.setField(comparator, "ranking", ranking);
@@ -92,7 +92,7 @@ public class RankingComparatorTest {
   }
 
   @Test public void shouldCompareReturnOneIfSolutionBHasLessRanking() {
-    Ranking ranking = mock(Ranking.class) ;
+    Ranking<Solution<?>> ranking = mock(Ranking.class) ;
     when(ranking.getAttribute(any(BinarySolution.class))).thenReturn(3, 3, 2, 2) ;
 
     ReflectionTestUtils.setField(comparator, "ranking", ranking);

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/neighborhood/impl/C9Test.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/neighborhood/impl/C9Test.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.mock;
  * Created by ajnebro on 26/5/15.
  */
 public class C9Test {
-  private C9 neighborhood ;
 
   /**
    * Case 1
@@ -29,7 +28,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase1() {
     int rows = 1 ;
     int columns = 1 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -53,7 +52,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase2() {
     int rows = 1 ;
     int columns = 2 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -78,7 +77,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase3() {
     int rows = 1 ;
     int columns = 2 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -104,7 +103,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase4() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -131,7 +130,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase5() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -158,7 +157,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase6() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -185,7 +184,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase7() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -212,7 +211,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase8() {
     int rows = 2 ;
     int columns = 4 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -241,7 +240,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase9() {
     int rows = 2 ;
     int columns = 4 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -271,7 +270,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase10() {
     int rows = 3 ;
     int columns = 4 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -303,7 +302,7 @@ public class C9Test {
   public void shouldGetNeighborsReturnFourNeighborsCase11() {
     int rows = 3 ;
     int columns = 4 ;
-    neighborhood = new C9(rows, columns) ;
+    C9<IntegerSolution> neighborhood = new C9<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/neighborhood/impl/L5Test.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/neighborhood/impl/L5Test.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.mock;
  * Created by ajnebro on 26/5/15.
  */
 public class L5Test {
-  private L5 neighborhood ;
 
   /**
    * Case 1
@@ -29,7 +28,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase1() {
     int rows = 1 ;
     int columns = 1 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -53,7 +52,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase2() {
     int rows = 1 ;
     int columns = 2 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -78,7 +77,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase3() {
     int rows = 1 ;
     int columns = 2 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -104,7 +103,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase4() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -130,7 +129,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase5() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -156,7 +155,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase6() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -182,7 +181,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase7() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -208,7 +207,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase8() {
     int rows = 2 ;
     int columns = 4 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -237,7 +236,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase9() {
     int rows = 4 ;
     int columns = 2 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -266,7 +265,7 @@ public class L5Test {
   public void shouldGetNeighborsReturnFourNeighborsCase10() {
     int rows = 4 ;
     int columns = 2 ;
-    neighborhood = new L5(rows, columns) ;
+    L5<IntegerSolution> neighborhood = new L5<IntegerSolution>(rows, columns) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/neighborhood/impl/TwoDimensionalMeshTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/neighborhood/impl/TwoDimensionalMeshTest.java
@@ -4,8 +4,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.uma.jmetal.solution.IntegerSolution;
+import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalException;
-import org.uma.jmetal.util.neighborhood.Neighborhood;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
  * Created by ajnebro on 21/5/15.
  */
 public class TwoDimensionalMeshTest {
-  private Neighborhood neighborhood ;
 
   private static final int [] north      = {-1,  0};
   private static final int [] south      = { 1 , 0};
@@ -32,7 +31,7 @@ public class TwoDimensionalMeshTest {
 
   @Test
   public void shouldGetNeighborsWithANullListOfSolutionsThrowAnException() {
-    neighborhood = new TwoDimensionalMesh(3, 3, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<Solution<?>> neighborhood = new TwoDimensionalMesh<Solution<?>>(3, 3, new int[][]{north, south, east, west}) ;
 
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is null"));
@@ -42,7 +41,7 @@ public class TwoDimensionalMeshTest {
 
   @Test
   public void shouldGetNeighborsWithAnEmptyListOfSolutionsThrowAnException() {
-    neighborhood = new TwoDimensionalMesh(3, 3, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(3, 3, new int[][]{north, south, east, west}) ;
 
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution list is empty"));
@@ -54,7 +53,7 @@ public class TwoDimensionalMeshTest {
 
   @Test
   public void shouldGetNeighborsWithANegativeSolutionIndexThrowAnException() {
-    neighborhood = new TwoDimensionalMesh(3, 3, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(3, 3, new int[][]{north, south, east, west}) ;
 
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString("The solution position value is negative: -1"));
@@ -70,7 +69,7 @@ public class TwoDimensionalMeshTest {
 
   @Test
   public void shouldGetNeighborsWithASolutionIndexValueEqualToTheListSizeThrowAnException() {
-    neighborhood = new TwoDimensionalMesh(1, 1, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(1, 1, new int[][]{north, south, east, west}) ;
 
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString(
@@ -84,7 +83,7 @@ public class TwoDimensionalMeshTest {
 
   @Test
   public void shouldGetNeighborsWithASolutionIndexValueGreaterThanTheListSizeThrowAnException() {
-    neighborhood = new TwoDimensionalMesh(2, 2, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(2, 2, new int[][]{north, south, east, west}) ;
 
     exception.expect(JMetalException.class);
     exception.expectMessage(containsString(
@@ -113,7 +112,7 @@ public class TwoDimensionalMeshTest {
   public void shouldGetNeighborsReturnFourNeighborsCase1() {
     int rows = 3 ;
     int columns = 3 ;
-    neighborhood = new TwoDimensionalMesh(rows, columns, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(rows, columns, new int[][]{north, south, east, west}) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -142,7 +141,7 @@ public class TwoDimensionalMeshTest {
   public void shouldGetNeighborsReturnFourNeighborsCase2() {
     int rows = 3 ;
     int columns = 3 ;
-    neighborhood = new TwoDimensionalMesh(rows, columns, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(rows, columns, new int[][]{north, south, east, west}) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -171,7 +170,7 @@ public class TwoDimensionalMeshTest {
   public void shouldGetNeighborsReturnFourNeighborsCase3() {
     int rows = 3 ;
     int columns = 3 ;
-    neighborhood = new TwoDimensionalMesh(rows, columns, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(rows, columns, new int[][]{north, south, east, west}) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -200,7 +199,7 @@ public class TwoDimensionalMeshTest {
   public void shouldGetNeighborsReturnFourNeighborsCase4() {
     int rows = 3 ;
     int columns = 3 ;
-    neighborhood = new TwoDimensionalMesh(rows, columns, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(rows, columns, new int[][]{north, south, east, west}) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -229,7 +228,7 @@ public class TwoDimensionalMeshTest {
   public void shouldGetNeighborsReturnFourNeighborsCase5() {
     int rows = 3 ;
     int columns = 3 ;
-    neighborhood = new TwoDimensionalMesh(rows, columns, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(rows, columns, new int[][]{north, south, east, west}) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -257,7 +256,7 @@ public class TwoDimensionalMeshTest {
   public void shouldGetNeighborsReturnFourNeighborsCase6() {
     int rows = 2 ;
     int columns = 3 ;
-    neighborhood = new TwoDimensionalMesh(rows, columns, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(rows, columns, new int[][]{north, south, east, west}) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -284,7 +283,7 @@ public class TwoDimensionalMeshTest {
   public void shouldGetNeighborsReturnFourNeighborsCase7() {
     int rows = 2 ;
     int columns = 3 ;
-    neighborhood = new TwoDimensionalMesh(rows, columns, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(rows, columns, new int[][]{north, south, east, west}) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {
@@ -311,7 +310,7 @@ public class TwoDimensionalMeshTest {
   public void shouldGetNeighborsReturnFourNeighborsCase8() {
     int rows = 2 ;
     int columns = 2 ;
-    neighborhood = new TwoDimensionalMesh(rows, columns, new int[][]{north, south, east, west}) ;
+    TwoDimensionalMesh<IntegerSolution> neighborhood = new TwoDimensionalMesh<IntegerSolution>(rows, columns, new int[][]{north, south, east, west}) ;
 
     List<IntegerSolution> list = new ArrayList<>(rows*columns) ;
     for (int i = 0 ; i < rows*columns; i++) {

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/point/impl/ArrayPointTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/point/impl/ArrayPointTest.java
@@ -71,7 +71,7 @@ public class ArrayPointTest {
 
   @Test
   public void shouldConstructFromASolutionReturnTheCorrectPoint() {
-    Solution solution = Mockito.mock(Solution.class) ;
+    Solution<?> solution = Mockito.mock(Solution.class) ;
 
     Mockito.when(solution.getNumberOfObjectives()).thenReturn(3) ;
     Mockito.when(solution.getObjective(0)).thenReturn(0.2) ;
@@ -91,7 +91,7 @@ public class ArrayPointTest {
 
   @Test (expected = JMetalException.class)
   public void shouldConstructAPointFromANullSolutionRaiseAnException() {
-    Solution solution = null ;
+    Solution<?> solution = null ;
 
     new ArrayPoint(solution) ;
   }

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/solutionattribute/impl/DominanceRankingTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/solutionattribute/impl/DominanceRankingTest.java
@@ -13,7 +13,6 @@
 
 package org.uma.jmetal.util.solutionattribute.impl;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -39,18 +38,10 @@ public class DominanceRankingTest {
   @Mock
   private DoubleProblem problem ;
 
-  private Ranking ranking ;
-
-  @Before
-  public void startup() {
-    //problem = Mockito.mock(Problem.class) ;
-    ranking = new DominanceRanking() ;
-  }
-
   @Test
   public void rankingOfAnEmptyPopulation() {
-    List<Solution> population = Collections.emptyList() ;
-    Ranking ranking = new DominanceRanking() ;
+    List<Solution<?>> population = Collections.emptyList() ;
+    Ranking<Solution<?>> ranking = new DominanceRanking<Solution<?>>() ;
     ranking.computeRanking(population) ;
     assertEquals(0, ranking.getNumberOfSubfronts()) ;
   }
@@ -63,7 +54,7 @@ public class DominanceRankingTest {
             new DefaultDoubleSolution(problem),
             new DefaultDoubleSolution(problem));
 
-    Ranking ranking = new DominanceRanking() ;
+    Ranking<DoubleSolution> ranking = new DominanceRanking<DoubleSolution>() ;
     ranking.computeRanking(population) ;
 
     assertEquals(1, ranking.getNumberOfSubfronts());

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/AlgorithmBuilder2.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/AlgorithmBuilder2.java
@@ -7,7 +7,7 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by ajnebro on 3/1/15.
  */
-public interface AlgorithmBuilder2<S extends Solution, P extends Problem<S>> {
-  public Algorithm build(P problem) ;
+public interface AlgorithmBuilder2<S extends Solution<?>, P extends Problem<S>> {
+  public Algorithm<?> build(P problem) ;
   public P getProblem() ;
 }

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/NSGAIIBuilder2.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/NSGAIIBuilder2.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 16/11/14.
  */
-public class NSGAIIBuilder2<S extends Solution, P extends Problem<S>> implements AlgorithmBuilder2<S,P> {
+public class NSGAIIBuilder2<S extends Solution<?>, P extends Problem<S>> implements AlgorithmBuilder2<S,P> {
 
   public enum NSGAIIVariant2 {NSGAII, SteadyStateNSGAII, Measures}
 
@@ -29,30 +29,30 @@ public class NSGAIIBuilder2<S extends Solution, P extends Problem<S>> implements
   private P problem;
   private int maxIterations;
   private int populationSize;
-  private CrossoverOperator<List<S>, List<S>>  crossoverOperator;
+  private CrossoverOperator<S>  crossoverOperator;
   private MutationOperator<S> mutationOperator;
-  private SelectionOperator selectionOperator;
-  private SolutionListEvaluator evaluator;
+  private SelectionOperator<List<S>, S> selectionOperator;
+  private SolutionListEvaluator<S> evaluator;
 
   private NSGAIIVariant2 variant;
 
   /**
    * NSGAIIBuilder constructor
    */
-  public NSGAIIBuilder2(CrossoverOperator<List<S>, List<S>> crossoverOperator,
+  public NSGAIIBuilder2(CrossoverOperator<S> crossoverOperator,
       MutationOperator<S> mutationOperator, NSGAIIVariant2 variant) {
     this.problem = null ;
     maxIterations = 250;
     populationSize = 100;
     this.crossoverOperator = crossoverOperator ;
     this.mutationOperator = mutationOperator ;
-    selectionOperator = new BinaryTournamentSelection();
-    evaluator = new SequentialSolutionListEvaluator();
+    selectionOperator = new BinaryTournamentSelection<S>();
+    evaluator = new SequentialSolutionListEvaluator<S>();
 
     this.variant = variant ;
   }
 
-  public NSGAIIBuilder2 setMaxIterations(int maxIterations) {
+  public NSGAIIBuilder2<S, P> setMaxIterations(int maxIterations) {
     if (maxIterations < 0) {
       throw new JMetalException("maxIterations is negative: " + maxIterations);
     }
@@ -61,7 +61,7 @@ public class NSGAIIBuilder2<S extends Solution, P extends Problem<S>> implements
     return this;
   }
 
-  public NSGAIIBuilder2 setPopulationSize(int populationSize) {
+  public NSGAIIBuilder2<S, P> setPopulationSize(int populationSize) {
     if (populationSize < 0) {
       throw new JMetalException("Population size is negative: " + populationSize);
     }
@@ -71,7 +71,7 @@ public class NSGAIIBuilder2<S extends Solution, P extends Problem<S>> implements
     return this;
   }
 
-  public NSGAIIBuilder2 setSelectionOperator(SelectionOperator selectionOperator) {
+  public NSGAIIBuilder2<S, P> setSelectionOperator(SelectionOperator<List<S>, S> selectionOperator) {
     if (selectionOperator == null) {
       throw new JMetalException("selectionOperator is null");
     }
@@ -80,7 +80,7 @@ public class NSGAIIBuilder2<S extends Solution, P extends Problem<S>> implements
     return this;
   }
 
-  public NSGAIIBuilder2 setSolutionListEvaluator(SolutionListEvaluator evaluator) {
+  public NSGAIIBuilder2<S, P> setSolutionListEvaluator(SolutionListEvaluator<S> evaluator) {
     if (evaluator == null) {
       throw new JMetalException("evaluator is null");
     }
@@ -99,7 +99,7 @@ public class NSGAIIBuilder2<S extends Solution, P extends Problem<S>> implements
       algorithm = new SteadyStateNSGAII<S>(problem, maxIterations, populationSize, crossoverOperator,
           mutationOperator, selectionOperator, evaluator);
     } else if (variant.equals(NSGAIIVariant2.Measures)) {
-      algorithm = new NSGAIIMeasures(problem, maxIterations, populationSize, crossoverOperator,
+      algorithm = new NSGAIIMeasures<S>(problem, maxIterations, populationSize, crossoverOperator,
           mutationOperator, selectionOperator, evaluator);
     }
 
@@ -119,19 +119,19 @@ public class NSGAIIBuilder2<S extends Solution, P extends Problem<S>> implements
     return populationSize;
   }
 
-  public CrossoverOperator getCrossoverOperator() {
+  public CrossoverOperator<S> getCrossoverOperator() {
     return crossoverOperator;
   }
 
-  public MutationOperator getMutationOperator() {
+  public MutationOperator<S> getMutationOperator() {
     return mutationOperator;
   }
 
-  public SelectionOperator getSelectionOperator() {
+  public SelectionOperator<List<S>, S> getSelectionOperator() {
     return selectionOperator;
   }
 
-  public SolutionListEvaluator getSolutionListEvaluator() {
+  public SolutionListEvaluator<S> getSolutionListEvaluator() {
     return evaluator;
   }
 }

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/NSGAIIStudy.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/NSGAIIStudy.java
@@ -6,6 +6,7 @@ import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
 import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.problem.multiobjective.zdt.*;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.experiment.ExperimentConfiguration;
 import org.uma.jmetal.util.experiment.ExperimentConfigurationBuilder;
 import org.uma.jmetal.util.experiment.ExperimentalStudy;
@@ -20,12 +21,12 @@ import java.util.List;
  */
 public class NSGAIIStudy  {
   public NSGAIIStudy() {
-    List<Problem> problemList = Arrays.<Problem>asList(new ZDT1(), new ZDT2(),
+    List<Problem<DoubleSolution>> problemList = Arrays.<Problem<DoubleSolution>>asList(new ZDT1(), new ZDT2(),
         new ZDT3(), new ZDT4(), new ZDT6()) ;
 
-    List<Algorithm> algorithmList = configureAlgorithmList(problemList) ;
+    List<Algorithm<List<DoubleSolution>>> algorithmList = configureAlgorithmList(problemList) ;
 
-    ExperimentConfiguration configuration = new ExperimentConfigurationBuilder("Experiment")
+    ExperimentConfiguration<DoubleSolution> configuration = new ExperimentConfigurationBuilder<DoubleSolution>("Experiment")
         .setAlgorithmList(algorithmList)
         .setProblemList(problemList)
         .setExperimentBaseDirectory("/Users/antelverde/Softw/jMetal/jMetalGitHub/pruebas")
@@ -45,8 +46,8 @@ public class NSGAIIStudy  {
 
 
 
-  List<Algorithm> configureAlgorithmList(List<Problem> problemList) {
-    List<Algorithm> algorithms = new ArrayList<>() ;
+  List<Algorithm<List<DoubleSolution>>> configureAlgorithmList(List<Problem<DoubleSolution>> problemList) {
+    List<Algorithm<List<DoubleSolution>>> algorithms = new ArrayList<>() ;
     for (int i = 0 ; i < problemList.size(); i++) {
       algorithms.add(
           new NSGAIIBuilder<>(problemList.get(i), new SBXCrossover(1.0, 20.0),

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ABYSSRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ABYSSRunner.java
@@ -39,7 +39,7 @@ public class ABYSSRunner {
    */
   public static void main(String[] args) throws Exception {
     DoubleProblem problem;
-    Algorithm algorithm;
+    Algorithm<List<DoubleSolution>> algorithm;
     String problemName ;
     if (args!=null && args.length == 1) {
       problemName = args[0] ;
@@ -47,9 +47,9 @@ public class ABYSSRunner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT4";
     }
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
-    Archive archive = new CrowdingDistanceArchive(100) ;
+    Archive<DoubleSolution> archive = new CrowdingDistanceArchive<DoubleSolution>(100) ;
 
     algorithm = new ABYSSBuilder(problem, archive)
         .build();

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/GDE3Runner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/GDE3Runner.java
@@ -51,7 +51,7 @@ public class GDE3Runner {
    */
   public static void main(String[] args) {
     DoubleProblem problem;
-    Algorithm algorithm;
+    Algorithm<List<DoubleSolution>> algorithm;
     DifferentialEvolutionSelection selection;
     DifferentialEvolutionCrossover crossover;
 
@@ -63,7 +63,7 @@ public class GDE3Runner {
       problemName = "org.uma.jmetal.problem.multiobjective.Srinivas";
     }
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
      /*
      * Alternatives:

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/IBEARunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/IBEARunner.java
@@ -21,7 +21,6 @@
 
 package org.uma.jmetal.runner.multiobjective;
 
-import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.algorithm.multiobjective.ibea.IBEA;
 import org.uma.jmetal.algorithm.multiobjective.ibea.IBEABuilder;
 import org.uma.jmetal.operator.CrossoverOperator;
@@ -31,7 +30,7 @@ import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
 import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
 import org.uma.jmetal.problem.Problem;
-import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.ProblemUtils;
@@ -55,11 +54,11 @@ public class IBEARunner {
    *       - org.uma.jmetal45.runner.multiobjective.IBEARunner problemName paretoFrontFile
    */
   public static void main(String[] args) throws Exception {
-    Problem problem;
-    Algorithm algorithm;
-    CrossoverOperator crossover;
-    MutationOperator mutation;
-    SelectionOperator selection;
+    Problem<DoubleSolution> problem;
+    IBEA<DoubleSolution> algorithm;
+    CrossoverOperator<DoubleSolution> crossover;
+    MutationOperator<DoubleSolution> mutation;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName ;
     if (args.length == 1) {
@@ -79,7 +78,7 @@ public class IBEARunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection() ;
+    selection = new BinaryTournamentSelection<DoubleSolution>() ;
 
     algorithm = new IBEABuilder(problem)
       .setArchiveSize(100)
@@ -93,7 +92,7 @@ public class IBEARunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
       .execute() ;
 
-    List<Solution> population = ((IBEA)algorithm).getResult() ;
+    List<DoubleSolution> population = algorithm.getResult() ;
     long computingTime = algorithmRunner.getComputingTime() ;
 
     new SolutionSetOutput.Printer(population)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/MOCHCRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/MOCHCRunner.java
@@ -51,10 +51,10 @@ import java.util.List;
  */
 public class MOCHCRunner {
   public static void main(String[] args) throws Exception {
-    CrossoverOperator<List<BinarySolution>,List<BinarySolution>> crossoverOperator;
+    CrossoverOperator<BinarySolution> crossoverOperator;
     MutationOperator<BinarySolution> mutationOperator;
-    SelectionOperator parentsSelection;
-    SelectionOperator newGenerationSelection;
+    SelectionOperator<List<BinarySolution>, BinarySolution> parentsSelection;
+    SelectionOperator<List<BinarySolution>, List<BinarySolution>> newGenerationSelection;
     Algorithm<List<BinarySolution>> algorithm ;
 
     BinaryProblem problem ;
@@ -66,11 +66,11 @@ public class MOCHCRunner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT5";
     }
 
-    problem = (BinaryProblem)ProblemUtils.loadProblem(problemName);
+    problem = (BinaryProblem) ProblemUtils.<BinarySolution> loadProblem(problemName);
 
     crossoverOperator = new HUXCrossover(1.0) ;
-    parentsSelection = new RandomSelection() ;
-    newGenerationSelection = new RankingAndCrowdingSelection(100) ;
+    parentsSelection = new RandomSelection<BinarySolution>() ;
+    newGenerationSelection = new RankingAndCrowdingSelection<BinarySolution>(100) ;
     mutationOperator = new BitFlipMutation(0.35) ;
 
     algorithm = new MOCHCBuilder(problem)
@@ -83,7 +83,7 @@ public class MOCHCRunner {
             .setNewGenerationSelection(newGenerationSelection)
             .setCataclysmicMutation(mutationOperator)
             .setParentSelection(parentsSelection)
-            .setEvaluator(new SequentialSolutionListEvaluator())
+            .setEvaluator(new SequentialSolutionListEvaluator<BinarySolution>())
             .build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/MOCellRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/MOCellRunner.java
@@ -40,9 +40,9 @@ public class MOCellRunner {
   public static void main(String[] args) throws JMetalException {
     Problem<DoubleSolution> problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName ;
     if (args.length == 1) {
@@ -61,14 +61,14 @@ public class MOCellRunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
+    selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 
     algorithm = new MOCellBuilder<>(problem, crossover, mutation)
         .setSelectionOperator(selection)
         .setMaxEvaluations(25000)
         .setPopulationSize(100)
         .setArchiveSize(100)
-        .setNeighborhood(new L5(10, 10))
+        .setNeighborhood(new L5<DoubleSolution>(10, 10))
         .build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/MOEADRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/MOEADRunner.java
@@ -45,8 +45,8 @@ public class MOEADRunner {
    */
   public static void main(String[] args) {
     DoubleProblem problem;
-    Algorithm algorithm;
-    MutationOperator mutation;
+    Algorithm<List<DoubleSolution>> algorithm;
+    MutationOperator<DoubleSolution> mutation;
     DifferentialEvolutionCrossover crossover;
 
     String problemName ;
@@ -56,7 +56,7 @@ public class MOEADRunner {
       problemName = "org.uma.jmetal.problem.multiobjective.lz09.LZ09F2";
     }
 
-    problem = (DoubleProblem)ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem)ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
      /*
      * Alternatives:
@@ -88,7 +88,7 @@ public class MOEADRunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
         .execute() ;
 
-    List<DoubleSolution> population = (List<DoubleSolution>)algorithm.getResult() ;
+    List<DoubleSolution> population = algorithm.getResult() ;
     long computingTime = algorithmRunner.getComputingTime() ;
 
     new SolutionSetOutput.Printer(population)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIBinaryRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIBinaryRunner.java
@@ -58,13 +58,13 @@ public class NSGAIIBinaryRunner {
 
     BinaryProblem problem;
     Algorithm<List<BinarySolution>> algorithm;
-    CrossoverOperator<List<BinarySolution>, List<BinarySolution>> crossover;
+    CrossoverOperator<BinarySolution> crossover;
     MutationOperator<BinarySolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<BinarySolution>, BinarySolution> selection;
 
     String problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT5" ;
 
-    problem = (BinaryProblem) ProblemUtils.loadProblem(problemName);
+    problem = (BinaryProblem) ProblemUtils.<BinarySolution> loadProblem(problemName);
 
     double crossoverProbability = 0.9 ;
     crossover = new SinglePointCrossover(crossoverProbability) ;
@@ -72,9 +72,9 @@ public class NSGAIIBinaryRunner {
     double mutationProbability = 1.0 / problem.getNumberOfBits(0) ;
     mutation = new BitFlipMutation(mutationProbability) ;
 
-    selection = new BinaryTournamentSelection() ;
+    selection = new BinaryTournamentSelection<BinarySolution>() ;
 
-    algorithm = new NSGAIIBuilder(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII)
+    algorithm = new NSGAIIBuilder<BinarySolution>(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII)
             .setSelectionOperator(selection)
             .setMaxIterations(250)
             .setPopulationSize(100)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIEbesRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIEbesRunner.java
@@ -21,7 +21,6 @@
 package org.uma.jmetal.runner.multiobjective;
 
 import org.uma.jmetal.algorithm.Algorithm;
-import org.uma.jmetal.algorithm.multiobjective.nsgaii.NSGAII;
 import org.uma.jmetal.algorithm.multiobjective.nsgaii.NSGAIIBuilder;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
@@ -31,7 +30,7 @@ import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
 import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.problem.multiobjective.ebes.Ebes;
 import org.uma.jmetal.problem.multiobjective.ebes.EbesMutation;
-import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.JMetalLogger;
@@ -56,11 +55,11 @@ public class NSGAIIEbesRunner {
    *        - org.uma.jmetal.runner.multiobjective.NSGAIIRunner problemName paretoFrontFile
    */
   public static void main(String[] args) throws JMetalException {
-    Problem problem;
-    Algorithm algorithm;
-    CrossoverOperator crossover;
-    MutationOperator mutation;
-    SelectionOperator selection;
+    Problem<DoubleSolution> problem;
+    Algorithm<List<DoubleSolution>> algorithm;
+    CrossoverOperator<DoubleSolution> crossover;
+    MutationOperator<DoubleSolution> mutation;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName = "org.uma.jmetal.problem.multiobjective.ebes.Ebes" ;
 
@@ -73,9 +72,9 @@ public class NSGAIIEbesRunner {
     double mutationProbability = 1.0 / ((Ebes)problem).getnumberOfGroupElements() ;
     mutation = new EbesMutation(mutationProbability) ;
 
-    selection = new BinaryTournamentSelection();
+    selection = new BinaryTournamentSelection<DoubleSolution>();
 
-    algorithm = new NSGAIIBuilder(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII)
+    algorithm = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII)
             .setSelectionOperator(selection)
             .setMaxIterations(250)
             .setPopulationSize(100)
@@ -84,7 +83,7 @@ public class NSGAIIEbesRunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
             .execute() ;
 
-    List<Solution> population = ((NSGAII)algorithm).getResult() ;
+    List<DoubleSolution> population = algorithm.getResult() ;
     long computingTime = algorithmRunner.getComputingTime() ;
 
     new SolutionSetOutput.Printer(population)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIIRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIIRunner.java
@@ -21,7 +21,6 @@
 package org.uma.jmetal.runner.multiobjective;
 
 import org.uma.jmetal.algorithm.Algorithm;
-import org.uma.jmetal.algorithm.multiobjective.nsgaiii.NSGAIII;
 import org.uma.jmetal.algorithm.multiobjective.nsgaiii.NSGAIIIBuilder;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
@@ -30,7 +29,7 @@ import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
 import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
 import org.uma.jmetal.problem.Problem;
-import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.JMetalLogger;
@@ -46,11 +45,11 @@ import java.util.List;
 public class NSGAIIIRunner {
 
   public static void main(String[] args) throws JMetalException {
-    Problem problem;
-    Algorithm algorithm;
-    CrossoverOperator crossover;
-    MutationOperator mutation;
-    SelectionOperator selection;
+    Problem<DoubleSolution> problem;
+    Algorithm<List<DoubleSolution>> algorithm;
+    CrossoverOperator<DoubleSolution> crossover;
+    MutationOperator<DoubleSolution> mutation;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName = "org.uma.jmetal.problem.multiobjective.dtlz.DTLZ3" ;
 
@@ -64,9 +63,9 @@ public class NSGAIIIRunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection();
+    selection = new BinaryTournamentSelection<DoubleSolution>();
 
-    algorithm = new NSGAIIIBuilder(problem)
+    algorithm = new NSGAIIIBuilder<DoubleSolution>(problem)
             .setCrossoverOperator(crossover)
             .setMutationOperator(mutation)
             .setSelectionOperator(selection)
@@ -77,7 +76,7 @@ public class NSGAIIIRunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
             .execute() ;
 
-    List<Solution> population = ((NSGAIII)algorithm).getResult() ;
+    List<DoubleSolution> population = algorithm.getResult() ;
     long computingTime = algorithmRunner.getComputingTime() ;
 
     new SolutionSetOutput.Printer(population)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIIntegerRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIIntegerRunner.java
@@ -56,13 +56,13 @@ public class NSGAIIIntegerRunner {
   public static void main(String[] args) {
     IntegerProblem problem;
     Algorithm<List<IntegerSolution>> algorithm;
-    CrossoverOperator<List<IntegerSolution>, List<IntegerSolution>> crossover;
+    CrossoverOperator<IntegerSolution> crossover;
     MutationOperator<IntegerSolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<IntegerSolution>, IntegerSolution> selection;
     
     String problemName = "org.uma.jmetal.problem.multiobjective.NMMin" ;
 
-    problem = (IntegerProblem) ProblemUtils.loadProblem(problemName);
+    problem = (IntegerProblem) ProblemUtils.<IntegerSolution> loadProblem(problemName);
 
     double crossoverProbability = 0.9 ;
     double crossoverDistributionIndex = 20.0 ;
@@ -72,9 +72,9 @@ public class NSGAIIIntegerRunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new IntegerPolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection() ;
+    selection = new BinaryTournamentSelection<IntegerSolution>() ;
 
-    algorithm = new NSGAIIBuilder(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII)
+    algorithm = new NSGAIIBuilder<IntegerSolution>(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII)
             .setSelectionOperator(selection)
             .setMaxIterations(250)
             .setPopulationSize(100)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIMeasuresRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIMeasuresRunner.java
@@ -37,7 +37,6 @@ import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.problem.multiobjective.Golinski;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.ProblemUtils;
@@ -65,14 +64,14 @@ public class NSGAIIMeasuresRunner {
   public static void main(String[] args) throws JMetalException, InterruptedException {
     DoubleProblem problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName ;
     if (args.length == 1) {
       problemName = args[0] ;
-      problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+      problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
     } else {
       problem = new Golinski();
     }
@@ -85,7 +84,7 @@ public class NSGAIIMeasuresRunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
+    selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 
     int maxIterations = 250 ;
     int populationSize = 100 ;
@@ -98,7 +97,7 @@ public class NSGAIIMeasuresRunner {
         .build() ;
 
     /* Measure management */
-    MeasureManager measureManager = ((NSGAIIMeasures)algorithm).getMeasureManager() ;
+    MeasureManager measureManager = ((NSGAIIMeasures<DoubleSolution>)algorithm).getMeasureManager() ;
 
     CountingMeasure iteration =
         (CountingMeasure) measureManager.<Long>getPullMeasure("currentIteration");
@@ -107,13 +106,13 @@ public class NSGAIIMeasuresRunner {
     BasicMeasure<Integer> nonDominatedSolutions =
         (BasicMeasure<Integer>) measureManager.<Integer>getPullMeasure("numberOfNonDominatedSolutionsInPopulation");
 
-    BasicMeasure<List<Solution>> solutionListMeasure =
-        (BasicMeasure) measureManager.getPushMeasure("currentPopulation");
+    BasicMeasure<List<DoubleSolution>> solutionListMeasure =
+        (BasicMeasure<List<DoubleSolution>>) measureManager.<List<DoubleSolution>> getPushMeasure("currentPopulation");
     CountingMeasure iteration2 =
         (CountingMeasure) measureManager.<Long>getPushMeasure("currentIteration");
 
     BasicMeasure<Integer> numberOfFeasibleSolutions =
-        (BasicMeasure) measureManager.getPushMeasure("numberOfFeasibleSolutionsInPopulation") ;
+        (BasicMeasure<Integer>) measureManager.<Integer> getPushMeasure("numberOfFeasibleSolutionsInPopulation") ;
 
     solutionListMeasure.register(new Listener());
     iteration2.register(new Listener2());
@@ -152,10 +151,10 @@ public class NSGAIIMeasuresRunner {
   }
 
 
-  private static class Listener implements MeasureListener<List<Solution>> {
+  private static class Listener implements MeasureListener<List<DoubleSolution>> {
     private int counter = 0 ;
 
-    @Override synchronized public void measureGenerated(List<Solution> solutions) {
+    @Override synchronized public void measureGenerated(List<DoubleSolution> solutions) {
       if ((counter % 10 == 0)) {
         System.out.println("PUSH MEASURE. Counter = " + counter+ " First solution: " + solutions.get(0)) ;
       }

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIIRunner.java
@@ -58,9 +58,9 @@ public class NSGAIIRunner {
   public static void main(String[] args) throws JMetalException {
     DoubleProblem problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>,List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName ;
     if (args.length == 1) {
@@ -69,7 +69,7 @@ public class NSGAIIRunner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT1";
     }
 
-    problem = (DoubleProblem)ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem)ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
     double crossoverProbability = 0.9 ;
     double crossoverDistributionIndex = 20.0 ;
@@ -79,7 +79,7 @@ public class NSGAIIRunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
+    selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 
     algorithm = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation,
         NSGAIIBuilder.NSGAIIVariant.NSGAII)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIITSPRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/NSGAIITSPRunner.java
@@ -59,9 +59,9 @@ public class NSGAIITSPRunner {
   public static void main(String[] args) throws JMetalException, IOException {
     PermutationProblem<PermutationSolution<Integer>> problem;
     Algorithm<List<PermutationSolution<Integer>>> algorithm;
-    CrossoverOperator crossover;
+    CrossoverOperator<PermutationSolution<Integer>> crossover;
     MutationOperator<PermutationSolution<Integer>> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<PermutationSolution<Integer>>, PermutationSolution<Integer>> selection;
 
     problem = new MultiobjectiveTSP("/tspInstances/kroA100.tsp", "/tspInstances/kroB100.tsp");
 
@@ -70,7 +70,7 @@ public class NSGAIITSPRunner {
     double mutationProbability = 0.2 ;
     mutation = new PermutationSwapMutation<Integer>(mutationProbability) ;
 
-    selection = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
+    selection = new BinaryTournamentSelection<PermutationSolution<Integer>>(new RankingAndCrowdingDistanceComparator<PermutationSolution<Integer>>());
 
     algorithm = new NSGAIIBuilder<PermutationSolution<Integer>>(problem, crossover, mutation,
         NSGAIIBuilder.NSGAIIVariant.NSGAII)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/OMOPSORunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/OMOPSORunner.java
@@ -64,8 +64,8 @@ public class OMOPSORunner {
    */
   public static void main(String[] args) throws Exception {
     DoubleProblem problem;
-    Algorithm algorithm;
-    MutationOperator mutation;
+    Algorithm<List<DoubleSolution>> algorithm;
+    MutationOperator<DoubleSolution> mutation;
 
     String problemName ;
     if (args.length == 1) {
@@ -74,13 +74,13 @@ public class OMOPSORunner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT1";
     }
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
-    Archive archive = new CrowdingDistanceArchive(100) ;
+    Archive<DoubleSolution> archive = new CrowdingDistanceArchive<DoubleSolution>(100) ;
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
 
-    algorithm = new OMOPSOBuilder(problem, new SequentialSolutionListEvaluator())
+    algorithm = new OMOPSOBuilder(problem, new SequentialSolutionListEvaluator<DoubleSolution>())
         .setMaxIterations(250)
         .setSwarmSize(100)
         .setUniformMutation(new UniformMutation(mutationProbability, 0.5))
@@ -90,7 +90,7 @@ public class OMOPSORunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
         .execute();
 
-    List<DoubleSolution> population = (List<DoubleSolution>)algorithm.getResult();
+    List<DoubleSolution> population = algorithm.getResult();
     long computingTime = algorithmRunner.getComputingTime();
 
     new SolutionSetOutput.Printer(population)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/PESA2Runner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/PESA2Runner.java
@@ -55,7 +55,7 @@ public class PESA2Runner {
   public static void main(String[] args) throws JMetalException {
     Problem<DoubleSolution> problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
 
     String problemName ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ParallelGDE3Runner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ParallelGDE3Runner.java
@@ -53,7 +53,7 @@ public class ParallelGDE3Runner {
    */
   public static void main(String[] args) {
     DoubleProblem problem;
-    Algorithm algorithm;
+    Algorithm<List<DoubleSolution>> algorithm;
     DifferentialEvolutionSelection selection;
     DifferentialEvolutionCrossover crossover;
 
@@ -64,14 +64,14 @@ public class ParallelGDE3Runner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT1";
     }
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
     double cr = 0.5 ;
     double f = 0.5 ;
     crossover = new DifferentialEvolutionCrossover(cr, f, "rand/1/bin") ;
     selection = new DifferentialEvolutionSelection() ;
 
-    SolutionListEvaluator evaluator = new MultithreadedSolutionListEvaluator(0, problem) ;
+    SolutionListEvaluator<DoubleSolution> evaluator = new MultithreadedSolutionListEvaluator<DoubleSolution>(0, problem) ;
 
     algorithm = new GDE3Builder(problem)
         .setCrossover(crossover)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ParallelNSGAIIRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ParallelNSGAIIRunner.java
@@ -57,13 +57,13 @@ public class ParallelNSGAIIRunner {
   public static void main(String[] args) throws JMetalException {
     DoubleProblem problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT1" ;
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
     double crossoverProbability = 0.9 ;
     double crossoverDistributionIndex = 20.0 ;
@@ -73,13 +73,13 @@ public class ParallelNSGAIIRunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection();
+    selection = new BinaryTournamentSelection<DoubleSolution>();
 
-    algorithm = new NSGAIIBuilder(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII)
+    algorithm = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation, NSGAIIBuilder.NSGAIIVariant.NSGAII)
             .setSelectionOperator(selection)
             .setMaxIterations(250)
             .setPopulationSize(100)
-            .setSolutionListEvaluator(new MultithreadedSolutionListEvaluator(8, problem))
+            .setSolutionListEvaluator(new MultithreadedSolutionListEvaluator<DoubleSolution>(8, problem))
             .build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ParallelPESA2Runner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ParallelPESA2Runner.java
@@ -57,7 +57,7 @@ public class ParallelPESA2Runner {
   public static void main(String[] args) throws JMetalException {
     Problem<DoubleSolution> problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
 
     String problemName ;
@@ -77,7 +77,7 @@ public class ParallelPESA2Runner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    SolutionListEvaluator evaluator = new MultithreadedSolutionListEvaluator(0, problem) ;
+    SolutionListEvaluator<DoubleSolution> evaluator = new MultithreadedSolutionListEvaluator<DoubleSolution>(0, problem) ;
 
     algorithm = new PESA2Builder<DoubleSolution>(problem, crossover, mutation)
         .setMaxEvaluations(25000)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ParallelSPEA2Runner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/ParallelSPEA2Runner.java
@@ -21,7 +21,6 @@
 package org.uma.jmetal.runner.multiobjective;
 
 import org.uma.jmetal.algorithm.Algorithm;
-import org.uma.jmetal.algorithm.multiobjective.spea2.SPEA2;
 import org.uma.jmetal.algorithm.multiobjective.spea2.SPEA2Builder;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
@@ -30,7 +29,7 @@ import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
 import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
 import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
 import org.uma.jmetal.problem.Problem;
-import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.JMetalLogger;
@@ -59,12 +58,12 @@ public class ParallelSPEA2Runner {
    *        - org.uma.jmetal.runner.multiobjective.NSGAIIRunner problemName
    */
   public static void main(String[] args) throws JMetalException {
-    Problem problem;
-    Algorithm algorithm;
-    CrossoverOperator crossover;
-    MutationOperator mutation;
-    SelectionOperator selection;
-    SolutionListEvaluator evaluator ;
+    Problem<DoubleSolution> problem;
+    Algorithm<List<DoubleSolution>> algorithm;
+    CrossoverOperator<DoubleSolution> crossover;
+    MutationOperator<DoubleSolution> mutation;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
+    SolutionListEvaluator<DoubleSolution> evaluator ;
 
     String problemName ;
     if (args.length == 1) {
@@ -83,11 +82,11 @@ public class ParallelSPEA2Runner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
+    selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 
-    evaluator = new MultithreadedSolutionListEvaluator(0, problem) ;
+    evaluator = new MultithreadedSolutionListEvaluator<DoubleSolution>(0, problem) ;
 
-    algorithm = new SPEA2Builder(problem, crossover, mutation)
+    algorithm = new SPEA2Builder<DoubleSolution>(problem, crossover, mutation)
         .setSelectionOperator(selection)
         .setMaxIterations(250)
         .setPopulationSize(100)
@@ -97,7 +96,7 @@ public class ParallelSPEA2Runner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
         .execute() ;
 
-    List<Solution> population =((SPEA2)algorithm).getResult();
+    List<DoubleSolution> population =algorithm.getResult();
 
 
 

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/RandomSearchRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/RandomSearchRunner.java
@@ -60,7 +60,7 @@ public class RandomSearchRunner {
 
     problem = ProblemUtils.loadProblem(problemName);
 
-    algorithm = new RandomSearchBuilder(problem)
+    algorithm = new RandomSearchBuilder<DoubleSolution>(problem)
             .setMaxEvaluations(2500000)
             .build() ;
 

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSOHvRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSOHvRunner.java
@@ -64,8 +64,8 @@ public class SMPSOHvRunner {
    */
   public static void main(String[] args) throws Exception {
     DoubleProblem problem;
-    Algorithm algorithm;
-    MutationOperator mutation;
+    Algorithm<List<DoubleSolution>> algorithm;
+    MutationOperator<DoubleSolution> mutation;
 
     String problemName ;
     if (args.length == 1) {
@@ -74,9 +74,9 @@ public class SMPSOHvRunner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT1";
     }
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
-    Archive archive = new FastHypervolumeArchive(100, problem.getNumberOfObjectives()) ;
+    Archive<DoubleSolution> archive = new FastHypervolumeArchive<DoubleSolution>(100, problem.getNumberOfObjectives()) ;
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
@@ -87,7 +87,7 @@ public class SMPSOHvRunner {
             .setMaxIterations(250)
             .setSwarmSize(100)
             //.setRandomGenerator(new MersenneTwisterGenerator())
-            .setSolutionListEvaluator(new SequentialSolutionListEvaluator())
+            .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
             .build();
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORunner.java
@@ -64,8 +64,8 @@ public class SMPSORunner {
    */
   public static void main(String[] args) throws Exception {
     DoubleProblem problem;
-    Algorithm algorithm;
-    MutationOperator mutation;
+    Algorithm<List<DoubleSolution>> algorithm;
+    MutationOperator<DoubleSolution> mutation;
 
     String problemName ;
     if (args.length == 1) {
@@ -74,9 +74,9 @@ public class SMPSORunner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT1";
     }
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
-    Archive archive = new CrowdingDistanceArchive(100) ;
+    Archive<DoubleSolution> archive = new CrowdingDistanceArchive<DoubleSolution>(100) ;
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
@@ -87,7 +87,7 @@ public class SMPSORunner {
             .setMaxIterations(250)
             .setSwarmSize(100)
             //.setRandomGenerator(new MersenneTwisterGenerator())
-            .setSolutionListEvaluator(new SequentialSolutionListEvaluator())
+            .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
             .build();
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMSEMOARunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMSEMOARunner.java
@@ -57,9 +57,9 @@ public class SMSEMOARunner {
   public static void main(String[] args) throws JMetalException {
     DoubleProblem problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>,List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName ;
     if (args.length == 1) {
@@ -68,7 +68,7 @@ public class SMSEMOARunner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT4";
     }
 
-    problem = (DoubleProblem)ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem)ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
     double crossoverProbability = 0.9 ;
     double crossoverDistributionIndex = 20.0 ;
@@ -78,7 +78,7 @@ public class SMSEMOARunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new RandomSelection();
+    selection = new RandomSelection<DoubleSolution>();
 
     algorithm = new SMSEMOABuilder<DoubleSolution>(problem, crossover, mutation)
             .setSelectionOperator(selection)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SPEA2BinaryRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SPEA2BinaryRunner.java
@@ -58,9 +58,9 @@ public class SPEA2BinaryRunner {
   public static void main(String[] args) throws JMetalException {
     BinaryProblem problem;
     Algorithm<List<BinarySolution>> algorithm;
-    CrossoverOperator<List<BinarySolution>, List<BinarySolution>> crossover;
+    CrossoverOperator<BinarySolution> crossover;
     MutationOperator<BinarySolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<BinarySolution>, BinarySolution> selection;
 
     String problemName ;
     if (args.length == 1) {
@@ -69,7 +69,7 @@ public class SPEA2BinaryRunner {
       problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT5";
     }
 
-    problem = (BinaryProblem)ProblemUtils.loadProblem(problemName);
+    problem = (BinaryProblem)ProblemUtils.<BinarySolution> loadProblem(problemName);
 
     double crossoverProbability = 0.9 ;
     crossover = new SinglePointCrossover(crossoverProbability) ;
@@ -77,7 +77,7 @@ public class SPEA2BinaryRunner {
     double mutationProbability = 1.0 / problem.getTotalNumberOfBits() ;
     mutation = new BitFlipMutation(mutationProbability) ;
 
-    selection = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
+    selection = new BinaryTournamentSelection<BinarySolution>(new RankingAndCrowdingDistanceComparator<BinarySolution>());
 
     algorithm = new SPEA2Builder<>(problem, crossover, mutation)
         .setSelectionOperator(selection)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SPEA2Runner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SPEA2Runner.java
@@ -39,9 +39,9 @@ public class SPEA2Runner {
   public static void main(String[] args) throws JMetalException {
     Problem<DoubleSolution> problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName ;
     if (args.length == 1) {
@@ -60,7 +60,7 @@ public class SPEA2Runner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
+    selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 
     //algorithm = new SPEA2Builder(problem)
     algorithm = new SPEA2Builder<>(problem, crossover, mutation)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SteadyStateNSGAIIRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SteadyStateNSGAIIRunner.java
@@ -56,9 +56,9 @@ public class SteadyStateNSGAIIRunner {
   public static void main(String[] args) throws JMetalException {
     DoubleProblem problem;
     Algorithm<List<DoubleSolution>> algorithm;
-    CrossoverOperator<List<DoubleSolution>,List<DoubleSolution>> crossover;
+    CrossoverOperator<DoubleSolution> crossover;
     MutationOperator<DoubleSolution> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
 
     String problemName ;
     if (args.length == 1) {
@@ -67,7 +67,7 @@ public class SteadyStateNSGAIIRunner {
       problemName = "org.uma.jmetal.problem.multiobjective.Srinivas";
     }
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
     double crossoverProbability = 0.9 ;
     double crossoverDistributionIndex = 20.0 ;
@@ -77,7 +77,7 @@ public class SteadyStateNSGAIIRunner {
     double mutationDistributionIndex = 20.0 ;
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
 
-    selection = new BinaryTournamentSelection();
+    selection = new BinaryTournamentSelection<DoubleSolution>();
 
     algorithm = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation,
         NSGAIIBuilder.NSGAIIVariant.SteadyStateNSGAII)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/CovarianceMatrixAdaptationEvolutionStrategyRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/CovarianceMatrixAdaptationEvolutionStrategyRunner.java
@@ -24,7 +24,7 @@ import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.algorithm.singleobjective.evolutionstrategy.CovarianceMatrixAdaptationEvolutionStrategy;
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.problem.singleobjective.Sphere;
-import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.fileoutput.SolutionSetOutput;
@@ -40,7 +40,7 @@ public class CovarianceMatrixAdaptationEvolutionStrategyRunner {
    */
   public static void main(String[] args) throws Exception {
 
-    Algorithm algorithm;
+    Algorithm<DoubleSolution> algorithm;
     DoubleProblem problem = new Sphere() ;
 
     algorithm = new CovarianceMatrixAdaptationEvolutionStrategy.Builder(problem)
@@ -50,8 +50,8 @@ public class CovarianceMatrixAdaptationEvolutionStrategyRunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
             .execute() ;
 
-    Solution solution = ((CovarianceMatrixAdaptationEvolutionStrategy)algorithm).getResult() ;
-    List<Solution> population = new ArrayList<>(1) ;
+    DoubleSolution solution = algorithm.getResult() ;
+    List<DoubleSolution> population = new ArrayList<>(1) ;
     population.add(solution) ;
 
     long computingTime = algorithmRunner.getComputingTime() ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/DifferentialEvolutionRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/DifferentialEvolutionRunner.java
@@ -18,7 +18,7 @@ import org.uma.jmetal.algorithm.singleobjective.differentialevolution.Differenti
 import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.operator.impl.selection.DifferentialEvolutionSelection;
 import org.uma.jmetal.problem.DoubleProblem;
-import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.ProblemUtils;
@@ -46,14 +46,14 @@ public class DifferentialEvolutionRunner {
   public static void main(String[] args) throws Exception {
 
     DoubleProblem problem;
-    Algorithm<Solution> algorithm;
+    Algorithm<DoubleSolution> algorithm;
     DifferentialEvolutionSelection selection;
     DifferentialEvolutionCrossover crossover;
-    SolutionListEvaluator evaluator ;
+    SolutionListEvaluator<DoubleSolution> evaluator ;
 
     String problemName = "org.uma.jmetal.problem.singleobjective.Sphere" ;
 
-    problem = (DoubleProblem) ProblemUtils.loadProblem(problemName);
+    problem = (DoubleProblem) ProblemUtils.<DoubleSolution> loadProblem(problemName);
 
     int numberOfCores ;
     if (args.length == 1) {
@@ -63,9 +63,9 @@ public class DifferentialEvolutionRunner {
     }
 
     if (numberOfCores == 1) {
-      evaluator = new SequentialSolutionListEvaluator() ;
+      evaluator = new SequentialSolutionListEvaluator<DoubleSolution>() ;
     } else {
-      evaluator = new MultithreadedSolutionListEvaluator(numberOfCores, problem) ;
+      evaluator = new MultithreadedSolutionListEvaluator<DoubleSolution>(numberOfCores, problem) ;
     }
 
     crossover = new DifferentialEvolutionCrossover(0.5, 0.5, "rand/1/bin") ;
@@ -82,10 +82,10 @@ public class DifferentialEvolutionRunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
         .execute() ;
 
-    Solution solution = algorithm.getResult() ;
+    DoubleSolution solution = algorithm.getResult() ;
     long computingTime = algorithmRunner.getComputingTime() ;
 
-    List<Solution> population = new ArrayList<>(1) ;
+    List<DoubleSolution> population = new ArrayList<>(1) ;
     population.add(solution) ;
     new SolutionSetOutput.Printer(population)
         .setSeparator("\t")

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/ElitistEvolutionStrategyRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/ElitistEvolutionStrategyRunner.java
@@ -22,7 +22,6 @@ import org.uma.jmetal.problem.BinaryProblem;
 import org.uma.jmetal.problem.singleobjective.OneMax;
 import org.uma.jmetal.solution.BinarySolution;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.fileoutput.SolutionSetOutput;
@@ -60,8 +59,8 @@ public class ElitistEvolutionStrategyRunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
         .execute() ;
 
-    Solution solution = algorithm.getResult() ;
-    List<Solution> population = new ArrayList<>(1) ;
+    BinarySolution solution = algorithm.getResult() ;
+    List<BinarySolution> population = new ArrayList<>(1) ;
     population.add(solution) ;
 
     long computingTime = algorithmRunner.getComputingTime() ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/GenerationalGeneticAlgorithmRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/GenerationalGeneticAlgorithmRunner.java
@@ -45,9 +45,9 @@ public class GenerationalGeneticAlgorithmRunner {
     Algorithm<BinarySolution> algorithm;
     BinaryProblem problem = new OneMax(512) ;
 
-    CrossoverOperator<List<BinarySolution>, List<BinarySolution>> crossoverOperator = new SinglePointCrossover(0.9) ;
+    CrossoverOperator<BinarySolution> crossoverOperator = new SinglePointCrossover(0.9) ;
     MutationOperator<BinarySolution> mutationOperator = new BitFlipMutation(1.0 / problem.getNumberOfBits(0)) ;
-    SelectionOperator selectionOperator = new BinaryTournamentSelection();
+    SelectionOperator<List<BinarySolution>, BinarySolution> selectionOperator = new BinaryTournamentSelection<BinarySolution>();
 
     algorithm = new GeneticAlgorithmBuilder<BinarySolution>(problem,
         crossoverOperator, mutationOperator, GeneticAlgorithmBuilder.GeneticAlgorithmVariant.GENERATIONAL)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/GenerationalGeneticAlgorithmTSPRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/GenerationalGeneticAlgorithmTSPRunner.java
@@ -45,9 +45,9 @@ public class GenerationalGeneticAlgorithmTSPRunner {
   public static void main(String[] args) throws Exception {
     PermutationProblem<PermutationSolution<Integer>> problem;
     Algorithm<PermutationSolution<Integer>> algorithm;
-    CrossoverOperator crossover;
+    CrossoverOperator<PermutationSolution<Integer>> crossover;
     MutationOperator<PermutationSolution<Integer>> mutation;
-    SelectionOperator selection;
+    SelectionOperator<List<PermutationSolution<Integer>>, PermutationSolution<Integer>> selection;
 
     problem = new TSP("/tspInstances/kroA100.tsp");
     problem = new TSP("/tspInstances/mona-lisa100K.tsp");
@@ -57,7 +57,7 @@ public class GenerationalGeneticAlgorithmTSPRunner {
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     mutation = new PermutationSwapMutation<Integer>(mutationProbability) ;
 
-    selection = new BinaryTournamentSelection(new RankingAndCrowdingDistanceComparator());
+    selection = new BinaryTournamentSelection<PermutationSolution<Integer>>(new RankingAndCrowdingDistanceComparator<PermutationSolution<Integer>>());
 
     algorithm = new GeneticAlgorithmBuilder<>(problem, crossover, mutation, GeneticAlgorithmBuilder.GeneticAlgorithmVariant.GENERATIONAL)
             .setPopulationSize(100)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/NonElitistEvolutionStrategyRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/NonElitistEvolutionStrategyRunner.java
@@ -15,13 +15,11 @@ package org.uma.jmetal.runner.singleobjective;
 
 import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.algorithm.singleobjective.evolutionstrategy.EvolutionStrategyBuilder;
-import org.uma.jmetal.algorithm.singleobjective.evolutionstrategy.NonElitistEvolutionStrategy;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.impl.mutation.BitFlipMutation;
 import org.uma.jmetal.problem.BinaryProblem;
 import org.uma.jmetal.problem.singleobjective.OneMax;
 import org.uma.jmetal.solution.BinarySolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.fileoutput.SolutionSetOutput;
@@ -57,8 +55,8 @@ public class NonElitistEvolutionStrategyRunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
             .execute() ;
 
-    Solution solution = ((NonElitistEvolutionStrategy)algorithm).getResult() ;
-    List<Solution> population = new ArrayList<>(1) ;
+    BinarySolution solution = algorithm.getResult() ;
+    List<BinarySolution> population = new ArrayList<>(1) ;
     population.add(solution) ;
 
     long computingTime = algorithmRunner.getComputingTime() ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/ParallelGenerationalGeneticAlgorithmRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/ParallelGenerationalGeneticAlgorithmRunner.java
@@ -14,7 +14,6 @@
 package org.uma.jmetal.runner.singleobjective;
 
 import org.uma.jmetal.algorithm.Algorithm;
-import org.uma.jmetal.algorithm.singleobjective.geneticalgorithm.GenerationalGeneticAlgorithm;
 import org.uma.jmetal.algorithm.singleobjective.geneticalgorithm.GeneticAlgorithmBuilder;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
@@ -25,7 +24,6 @@ import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
 import org.uma.jmetal.problem.BinaryProblem;
 import org.uma.jmetal.problem.singleobjective.OneMax;
 import org.uma.jmetal.solution.BinarySolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.evaluator.impl.MultithreadedSolutionListEvaluator;
@@ -58,23 +56,23 @@ public class ParallelGenerationalGeneticAlgorithmRunner {
       numberOfCores = DEFAULT_NUMBER_OF_CORES ;
     }
 
-    CrossoverOperator<List<BinarySolution>, List<BinarySolution>> crossoverOperator = new SinglePointCrossover(0.9) ;
+    CrossoverOperator<BinarySolution> crossoverOperator = new SinglePointCrossover(0.9) ;
     MutationOperator<BinarySolution> mutationOperator = new BitFlipMutation(1.0 / problem.getNumberOfBits(0)) ;
-    SelectionOperator selectionOperator = new BinaryTournamentSelection();
+    SelectionOperator<List<BinarySolution>, BinarySolution> selectionOperator = new BinaryTournamentSelection<BinarySolution>();
 
     algorithm = new GeneticAlgorithmBuilder<BinarySolution>(problem, crossoverOperator, mutationOperator,
         GeneticAlgorithmBuilder.GeneticAlgorithmVariant.GENERATIONAL)
             .setPopulationSize(100)
             .setMaxEvaluations(25000)
             .setSelectionOperator(selectionOperator)
-            .setSolutionListEvaluator(new MultithreadedSolutionListEvaluator(numberOfCores, problem))
+            .setSolutionListEvaluator(new MultithreadedSolutionListEvaluator<BinarySolution>(numberOfCores, problem))
             .build() ;
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
             .execute() ;
 
-    Solution solution = ((GenerationalGeneticAlgorithm)algorithm).getResult() ;
-    List<Solution> population = new ArrayList<>(1) ;
+    BinarySolution solution = algorithm.getResult() ;
+    List<BinarySolution> population = new ArrayList<>(1) ;
     population.add(solution) ;
 
     long computingTime = algorithmRunner.getComputingTime() ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/SteadyStateGeneticAlgorithmRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/SteadyStateGeneticAlgorithmRunner.java
@@ -24,7 +24,6 @@ import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.problem.singleobjective.Sphere;
 import org.uma.jmetal.solution.DoubleSolution;
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.AlgorithmRunner;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.fileoutput.SolutionSetOutput;
@@ -46,11 +45,11 @@ public class SteadyStateGeneticAlgorithmRunner {
     Algorithm<DoubleSolution> algorithm;
     DoubleProblem problem = new Sphere(20) ;
 
-    CrossoverOperator<List<DoubleSolution>, List<DoubleSolution>> crossoverOperator =
+    CrossoverOperator<DoubleSolution> crossoverOperator =
         new SBXCrossover(0.9, 20.0) ;
     MutationOperator<DoubleSolution> mutationOperator =
         new PolynomialMutation(1.0 / problem.getNumberOfVariables(), 20.0) ;
-    SelectionOperator selectionOperator = new BinaryTournamentSelection() ;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selectionOperator = new BinaryTournamentSelection<DoubleSolution>() ;
 
     algorithm = new GeneticAlgorithmBuilder<DoubleSolution>(problem, crossoverOperator, mutationOperator,
         GeneticAlgorithmBuilder.GeneticAlgorithmVariant.STEADY_STATE)
@@ -65,7 +64,7 @@ public class SteadyStateGeneticAlgorithmRunner {
     long computingTime = algorithmRunner.getComputingTime() ;
 
     DoubleSolution solution = algorithm.getResult() ;
-    List<Solution> population = new ArrayList<>(1) ;
+    List<DoubleSolution> population = new ArrayList<>(1) ;
     population.add(solution) ;
 
     new SolutionSetOutput.Printer(population)

--- a/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/BLXAlphaCrossoverWorkingTest.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/BLXAlphaCrossoverWorkingTest.java
@@ -44,7 +44,7 @@ public class BLXAlphaCrossoverWorkingTest {
     DoubleProblem problem ;
 
     problem = new Kursawe(1) ;
-    CrossoverOperator crossover = new BLXAlphaCrossover(1.0, alpha) ;
+    CrossoverOperator<DoubleSolution> crossover = new BLXAlphaCrossover(1.0, alpha) ;
 
     DoubleSolution solution1 = problem.createSolution() ;
     DoubleSolution solution2 = problem.createSolution() ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/IntegerPolynomialMutationWorkingTest.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/IntegerPolynomialMutationWorkingTest.java
@@ -59,7 +59,7 @@ public class IntegerPolynomialMutationWorkingTest {
     IntegerProblem problem ;
 
     problem = new NIntegerMin(1, 10, -1000, 1000);
-    MutationOperator mutation = new IntegerPolynomialMutation(1.0, distributionIndex) ;
+    MutationOperator<IntegerSolution> mutation = new IntegerPolynomialMutation(1.0, distributionIndex) ;
 
     IntegerSolution solution = problem.createSolution() ;
     solution.setVariableValue(0, 0);

--- a/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/IntegerSBXCrossoverWorkingTest.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/IntegerSBXCrossoverWorkingTest.java
@@ -45,7 +45,7 @@ public class IntegerSBXCrossoverWorkingTest {
     IntegerProblem problem ;
 
     problem = new NMMin(1, -50, 50, -100, 100) ;
-    CrossoverOperator crossover = new IntegerSBXCrossover(1.0, distributionIndex) ;
+    CrossoverOperator<IntegerSolution> crossover = new IntegerSBXCrossover(1.0, distributionIndex) ;
 
     IntegerSolution solution1 = problem.createSolution() ;
     IntegerSolution solution2 = problem.createSolution() ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/PolynomialMutationWorkingTest.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/PolynomialMutationWorkingTest.java
@@ -45,7 +45,7 @@ public class PolynomialMutationWorkingTest {
     DoubleProblem problem ;
 
     problem = new Sphere(1) ;
-    MutationOperator mutation = new PolynomialMutation(1.0, distributionIndex) ;
+    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(1.0, distributionIndex) ;
 
     DoubleSolution solution = problem.createSolution() ;
     solution.setVariableValue(0, 0.0);

--- a/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/SBXCrossoverWorkingTest.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/workingTest/SBXCrossoverWorkingTest.java
@@ -44,7 +44,7 @@ public class SBXCrossoverWorkingTest {
     DoubleProblem problem ;
 
     problem = new Kursawe(1) ;
-    CrossoverOperator crossover = new SBXCrossover(1.0, distributionIndex) ;
+    CrossoverOperator<DoubleSolution> crossover = new SBXCrossover(1.0, distributionIndex) ;
 
     DoubleSolution solution1 = problem.createSolution() ;
     DoubleSolution solution2 = problem.createSolution() ;

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/ebes/Ebes.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/ebes/Ebes.java
@@ -896,8 +896,8 @@ public class Ebes extends AbstractDoubleProblem implements ConstrainedProblem<Do
       } // end if
     } // gr 
 
-    setLowerLimit(new ArrayList(Arrays.<Double>asList(lowerLimit_)));
-    setUpperLimit(new ArrayList(Arrays.<Double>asList(upperLimit_)));
+    setLowerLimit(new ArrayList<Double>(Arrays.<Double>asList(lowerLimit_)));
+    setUpperLimit(new ArrayList<Double>(Arrays.<Double>asList(upperLimit_)));
 
     // greates difference between nodes
     elementsBetweenDiffGreat_ = 0;

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/singleobjective/cec2005competitioncode/Benchmark.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/singleobjective/cec2005competitioncode/Benchmark.java
@@ -111,7 +111,7 @@ public class Benchmark {
 
   // Class loader & reflection
   static final public ClassLoader loader = ClassLoader.getSystemClassLoader();
-  static final Class[] test_func_arg_types = {int.class, double.class};
+  static final Class<?>[] test_func_arg_types = {int.class, double.class};
 
   // Class variables
   static private double[] m_iSqrt;

--- a/jmetal-problem/src/test/java/org/uma/jmetal/problem/multiobjective/NMMinTest.java
+++ b/jmetal-problem/src/test/java/org/uma/jmetal/problem/multiobjective/NMMinTest.java
@@ -2,7 +2,7 @@ package org.uma.jmetal.problem.multiobjective;
 
 import org.junit.Test;
 import org.uma.jmetal.problem.Problem;
-import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.IntegerSolution;
 
 import static org.junit.Assert.assertEquals;
 
@@ -10,12 +10,12 @@ import static org.junit.Assert.assertEquals;
  * Created by Antonio J. Nebro on 17/09/14.
  */
 public class NMMinTest {
-  Problem problem ;
+  Problem<IntegerSolution> problem ;
 
   @Test
   public void evaluateSimpleSolutions() {
     problem = new NMMin(1, 100, -100, -1000, 1000) ;
-    Solution solution = problem.createSolution() ;
+    IntegerSolution solution = problem.createSolution() ;
     solution.setVariableValue(0, 100);
     problem.evaluate(solution);
 


### PR DESCRIPTION
With this branch, I focus on expliciting the generics in order to increase type alignments. In the process, expliciting generics create errors which are fixed by expliciting other generics, so the code is only changed regarding these generics, which means it is fundamentally equivalent. This is due to the fact that generics are only used at compilation time: they are lost in the process (type erasure) so the final bytecode is exactly the same with the generics or without, because generics does not apply anymore in the bytecode.

I have actually changed some pieces of the code when needed, but in such a case I notice it in the commit (please check each commit message to know which ones, there is only a few of them). I do not notice them if they are trivial changes like this one:
```
public int compare(Object o1, Object o2) {
  Pair<Integer, Double> pair1 = (Pair<Integer, Double>)o1;
  Pair<Integer, Double> pair2 = (Pair<Integer, Double>)o2;
  ...
```
which has become, due to expliciting types:
```
public int compare(Pair<Integer, Double> pair1, Pair<Integer, Double> pair2) {
  ...
```