### PR TITLE
Explicit the types to consider.

### DIFF
--- a/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/CrowdingDistanceComparatorTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/CrowdingDistanceComparatorTest.java
@@ -54,7 +54,7 @@ public class CrowdingDistanceComparatorTest {
 
   @Test public void shouldCompareReturnZeroIfBothSolutionsHaveNoCrowdingDistanceAttribute() {
     CrowdingDistance<Solution<?>> distance = mock(CrowdingDistance.class) ;
-    when(distance.getAttribute(any(Solution.class))).thenReturn(null, null) ;
+    when(distance.getAttribute(any(Solution.class))).thenReturn((Double) null, (Double) null) ;
 
     ReflectionTestUtils.setField(comparator, "crowdingDistance", distance);
 

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/RankingComparatorTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/comparator/RankingComparatorTest.java
@@ -54,7 +54,7 @@ public class RankingComparatorTest {
 
   @Test public void shouldCompareReturnZeroIfBothSolutionsHaveNoRankingAttribute() {
     Ranking<Solution<?>> ranking = mock(Ranking.class) ;
-    when(ranking.getAttribute(any(Solution.class))).thenReturn(null, null) ;
+    when(ranking.getAttribute(any(Solution.class))).thenReturn((Integer) null, (Integer) null) ;
 
     ReflectionTestUtils.setField(comparator, "ranking", ranking);
 


### PR DESCRIPTION
Expliciting these types (i.e. saying exactly what you expect it to be) allow for the compiler to properly check that you are using the method properly. Otherwise it leads to a warning because it will anyway not lead to a compilation error, due to type erasure.