### PR TITLE
Useless warning.

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/GenericSolutionAttribute.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/GenericSolutionAttribute.java
@@ -27,6 +27,7 @@ import org.uma.jmetal.util.solutionattribute.SolutionAttribute;
  */
 public class GenericSolutionAttribute <S extends Solution<?>, V> implements SolutionAttribute<S, V>{
 
+  @SuppressWarnings("unchecked")
   @Override
   public V getAttribute(S solution) {
     return (V)solution.getAttribute(getAttributeID());


### PR DESCRIPTION
In this case, the type is known because we are supposed to be the only one writing it with setAttribute, thus we expect it to be of the same type when we read it. Thus the warning is useless.