### PR TITLE
Population generalization + PESA2 fix

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3.java
@@ -90,7 +90,7 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
       DoubleSolution newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
   /**
@@ -98,7 +98,7 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
    * @param population The list of solutions to be evaluated
    * @return A list of evaluated solutions
    */
-  @Override protected List<DoubleSolution> evaluatePopulation(List<DoubleSolution> population) {
+  protected List<DoubleSolution> evaluatePopulation(List<DoubleSolution> population) {
     return evaluator.evaluate(population, problem);
   }
 
@@ -138,6 +138,7 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
 
   @Override protected List<DoubleSolution> replacement(List<DoubleSolution> population,
       List<DoubleSolution> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     List<DoubleSolution> tmpList = new ArrayList<>();
     for (int i = 0; i < populationSize; i++) {
       // Dominance test

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCell.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCell.java
@@ -98,10 +98,9 @@ public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, L
       population.add(newIndividual);
     }
     location = new LocationAttribute<>(population);
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override
   protected List<S> evaluatePopulation(List<S> population) {
     population = evaluator.evaluate(population, problem);
     for (S solution : population) {
@@ -141,6 +140,7 @@ public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, L
 
   @Override
   protected List<S> replacement(List<S> population, List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     int flag = dominanceComparator.compare(population.get(currentIndividual),offspringPopulation.get(0));
 
     if (flag == 1) { //The new individual dominates

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCell.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCell.java
@@ -24,7 +24,7 @@ import java.util.*;
  *
  * @param <S>
  */
-public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class MOCell<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>, List<S>> {
   protected int evaluations;
   protected int maxEvaluations;
   protected int populationSize;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAII.java
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class NSGAII<S extends  Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class NSGAII<S extends  Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>, List<S>> {
   protected final int maxIterations;
   protected final int populationSize;
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAII.java
@@ -66,10 +66,10 @@ public class NSGAII<S extends  Solution<?>> extends AbstractGeneticAlgorithm<S, 
       S newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     population = evaluator.evaluate(population, problem);
 
     return population;
@@ -104,6 +104,7 @@ public class NSGAII<S extends  Solution<?>> extends AbstractGeneticAlgorithm<S, 
   }
 
   @Override protected List<S> replacement(List<S> population, List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     List<S> jointPopulation = new ArrayList<>();
     jointPopulation.addAll(population);
     jointPopulation.addAll(offspringPopulation);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIII.java
@@ -85,10 +85,10 @@ public class NSGAIII<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, 
       S newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     population = evaluator.evaluate(population, problem);
 
     return population;
@@ -133,7 +133,8 @@ public class NSGAIII<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, 
 
   @Override protected List<S> replacement(List<S> population,
       List<S> offspringPopulation) {
-
+    offspringPopulation = evaluatePopulation(offspringPopulation);
+    
     List<S> jointPopulation = new ArrayList<>();
     jointPopulation.addAll(population);
     jointPopulation.addAll(offspringPopulation);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIII.java
@@ -18,7 +18,7 @@ import java.util.Vector;
  * This implementation is based on the code of Tsung-Che Chiang
  * http://web.ntnu.edu.tw/~tcchiang/publications/nsga3cpp/nsga3cpp.htm
  */
-public class NSGAIII<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class NSGAIII<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>, List<S>> {
   protected int evaluations;
   protected int maxEvaluations;
   protected int populationSize;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/paes/PAES.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/paes/PAES.java
@@ -89,10 +89,10 @@ public class PAES<S extends Solution<?>> extends AbstractEvolutionStrategy<S, Li
   @Override protected List<S> createInitialPopulation() {
     List<S> solutionList = new ArrayList<>(1);
     solutionList.add(problem.createSolution());
-    return solutionList;
+    return evaluatePopulation(solutionList);
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     problem.evaluate(population.get(0));
     return population;
   }
@@ -113,6 +113,7 @@ public class PAES<S extends Solution<?>> extends AbstractEvolutionStrategy<S, Li
 
   @SuppressWarnings("unchecked")
   @Override protected List<S> replacement(List<S> population, List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     S current = population.get(0);
     S mutatedSolution = offspringPopulation.get(0);
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2.java
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class PESA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class PESA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>, List<S>> {
   private int maxEvaluations ;
   private int archiveSize ;
   private int populationSize ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2.java
@@ -80,10 +80,10 @@ public class PESA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, Li
       S newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     population = evaluator.evaluate(population, problem);
 
     return population;
@@ -122,6 +122,7 @@ public class PESA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, Li
   }
 
   @Override protected List<S> replacement(List<S> population, List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     for (S solution : offspringPopulation) {
       archive.add(solution) ;
     }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA.java
@@ -38,7 +38,7 @@ import java.util.List;
 /**
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class SMSEMOA<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class SMSEMOA<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>, List<S>> {
   protected final int maxEvaluations;
   protected final int populationSize;
   protected final double offset ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOA.java
@@ -87,10 +87,10 @@ public class SMSEMOA<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, 
       S newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     for (S solution : population) {
       problem.evaluate(solution);
     }
@@ -123,6 +123,7 @@ public class SMSEMOA<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, 
   }
 
   @Override protected List<S> replacement(List<S> population, List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     List<S> jointPopulation = new ArrayList<>();
     jointPopulation.addAll(population);
     jointPopulation.addAll(offspringPopulation);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/SPEA2.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/SPEA2.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * @author Juan J. Durillo
  **/
-public class SPEA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>> {
+public class SPEA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>, List<S>> {
   protected final int maxIterations;
   protected final int populationSize;
   protected final Problem<S> problem;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/SPEA2.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/SPEA2.java
@@ -79,10 +79,9 @@ public class SPEA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, Li
       S newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override
   protected List<S> evaluatePopulation(List<S> population) {
     population = evaluator.evaluate(population, problem);
     return population;
@@ -120,6 +119,7 @@ public class SPEA2<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, Li
   @Override
   protected List<S> replacement(List<S> population,
       List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     return offspringPopulation;
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolution.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolution.java
@@ -93,10 +93,10 @@ public class DifferentialEvolution extends AbstractDifferentialEvolution<DoubleS
       DoubleSolution newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override protected List<DoubleSolution> evaluatePopulation(List<DoubleSolution> population) {
+  protected List<DoubleSolution> evaluatePopulation(List<DoubleSolution> population) {
     return evaluator.evaluate(population, problem);
   }
 
@@ -122,6 +122,7 @@ public class DifferentialEvolution extends AbstractDifferentialEvolution<DoubleS
 
   @Override protected List<DoubleSolution> replacement(List<DoubleSolution> population,
       List<DoubleSolution> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     List<DoubleSolution> pop = new ArrayList<>();
 
     for (int i = 0; i < populationSize; i++) {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
@@ -201,10 +201,10 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
       DoubleSolution newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override protected List<DoubleSolution> evaluatePopulation(List<DoubleSolution> population) {
+  protected List<DoubleSolution> evaluatePopulation(List<DoubleSolution> population) {
     for (DoubleSolution solution : population) {
       problem.evaluate(solution);
     }
@@ -228,6 +228,7 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
 
   @Override protected List<DoubleSolution> replacement(List<DoubleSolution> population,
       List<DoubleSolution> offspringPopulation) {
+	offspringPopulation = evaluatePopulation(offspringPopulation);
     return offspringPopulation;
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/ElitistEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/ElitistEvolutionStrategy.java
@@ -72,11 +72,10 @@ public class ElitistEvolutionStrategy<S extends Solution<?>> extends AbstractEvo
       S newIndividual = (S)problem.createSolution();
       population.add(newIndividual);
     }
-
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     for (S solution : population) {
       problem.evaluate(solution);
     }
@@ -104,6 +103,7 @@ public class ElitistEvolutionStrategy<S extends Solution<?>> extends AbstractEvo
 
   @Override protected List<S> replacement(List<S> population,
       List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     for (int i = 0; i < mu; i++) {
       offspringPopulation.add(population.get(i));
     }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/NonElitistEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/NonElitistEvolutionStrategy.java
@@ -72,11 +72,10 @@ public class NonElitistEvolutionStrategy<S extends Solution<?>> extends Abstract
       S newIndividual = (S)problem.createSolution();
       population.add(newIndividual);
     }
-
-    return population;
+    return evaluatePopulation(population);
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     for (S solution : population) {
       problem.evaluate(solution);
     }
@@ -109,6 +108,7 @@ public class NonElitistEvolutionStrategy<S extends Solution<?>> extends Abstract
 
   @Override protected List<S> replacement(List<S> population,
       List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     Collections.sort(offspringPopulation, comparator) ;
 
     List<S> newPopulation = new ArrayList<>(mu);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/GenerationalGeneticAlgorithm.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/GenerationalGeneticAlgorithm.java
@@ -27,7 +27,7 @@ import java.util.*;
 /**
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class GenerationalGeneticAlgorithm<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, S> {
+public class GenerationalGeneticAlgorithm<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>, S> {
   private Comparator<S> comparator;
   private int maxEvaluations;
   private int populationSize;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/GenerationalGeneticAlgorithm.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/GenerationalGeneticAlgorithm.java
@@ -66,10 +66,11 @@ public class GenerationalGeneticAlgorithm<S extends Solution<?>> extends Abstrac
       S newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
   @Override protected List<S> replacement(List<S> population, List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     Collections.sort(population, comparator);
     offspringPopulation.add(population.get(0));
     offspringPopulation.add(population.get(1));
@@ -107,7 +108,7 @@ public class GenerationalGeneticAlgorithm<S extends Solution<?>> extends Abstrac
     return matingPopulation;
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     population = evaluator.evaluate(population,problem);
 
     return population;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/SteadyStateGeneticAlgorithm.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/SteadyStateGeneticAlgorithm.java
@@ -63,10 +63,11 @@ public class SteadyStateGeneticAlgorithm<S extends Solution<?>> extends Abstract
       S newIndividual = problem.createSolution();
       population.add(newIndividual);
     }
-    return population;
+    return evaluatePopulation(population);
   }
 
   @Override protected List<S> replacement(List<S> population, List<S> offspringPopulation) {
+    offspringPopulation = evaluatePopulation(offspringPopulation);
     Collections.sort(population, comparator) ;
     int worstSolutionIndex = population.size() - 1;
     if (comparator.compare(population.get(worstSolutionIndex), offspringPopulation.get(0)) > 0) {
@@ -101,7 +102,7 @@ public class SteadyStateGeneticAlgorithm<S extends Solution<?>> extends Abstract
     return matingPopulation;
   }
 
-  @Override protected List<S> evaluatePopulation(List<S> population) {
+  protected List<S> evaluatePopulation(List<S> population) {
     for (S solution : population) {
       problem.evaluate(solution);
     }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/SteadyStateGeneticAlgorithm.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/SteadyStateGeneticAlgorithm.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class SteadyStateGeneticAlgorithm<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, S> {
+public class SteadyStateGeneticAlgorithm<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, List<S>, S> {
   private Comparator<S> comparator;
   private int maxEvaluations;
   private int populationSize;

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractDifferentialEvolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractDifferentialEvolution.java
@@ -14,6 +14,8 @@
 
 package org.uma.jmetal.algorithm.impl;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.operator.impl.selection.DifferentialEvolutionSelection;
 import org.uma.jmetal.solution.DoubleSolution;
@@ -23,7 +25,7 @@ import org.uma.jmetal.solution.DoubleSolution;
  * @author Antonio J. Nebro
  * @version 1.0
  */
-public abstract class AbstractDifferentialEvolution<Result> extends AbstractEvolutionaryAlgorithm<DoubleSolution, Result> {
+public abstract class AbstractDifferentialEvolution<Result> extends AbstractEvolutionaryAlgorithm<DoubleSolution, List<DoubleSolution>, Result> {
   protected DifferentialEvolutionCrossover crossoverOperator ;
   protected DifferentialEvolutionSelection selectionOperator ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionStrategy.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionStrategy.java
@@ -1,11 +1,13 @@
 package org.uma.jmetal.algorithm.impl;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.solution.Solution;
 
 /**
  * Created by ajnebro on 26/10/14.
  */
-public abstract class AbstractEvolutionStrategy<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, Result> {
+public abstract class AbstractEvolutionStrategy<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, List<S>, Result> {
   protected MutationOperator<S> mutationOperator ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
@@ -10,14 +10,14 @@ import java.util.List;
  * @param <S> Solution
  * @param <R> Result
  */
-public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, R>  implements Algorithm<R>{
-  private List<S> population;
+public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, Population extends Iterable<S>, R>  implements Algorithm<R>{
+  private Population population;
 
-  public List<S> getPopulation() {
+  public Population getPopulation() {
     return population;
   }
 
-  public void setPopulation(List<S> population) {
+  public void setPopulation(Population population) {
     this.population = population;
   }
 
@@ -27,21 +27,21 @@ public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, R>  i
 
   protected abstract boolean isStoppingConditionReached();
 
-  protected abstract List<S> createInitialPopulation();
+  protected abstract Population createInitialPopulation();
 
-  protected abstract List<S> evaluatePopulation(List<S> population);
+  protected abstract Population evaluatePopulation(Population population);
 
-  protected abstract List<S> selection(List<S> population);
+  protected abstract Population selection(Population population);
 
-  protected abstract List<S> reproduction(List<S> population);
+  protected abstract Population reproduction(Population population);
 
-  protected abstract List<S> replacement(List<S> population, List<S> offspringPopulation);
+  protected abstract Population replacement(Population population, Population offspringPopulation);
 
   @Override public abstract R getResult();
 
   @Override public void run() {
-    List<S> offspringPopulation;
-    List<S> matingPopulation;
+    Population offspringPopulation;
+    Population matingPopulation;
 
     population = createInitialPopulation();
     population = evaluatePopulation(population);

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
@@ -10,7 +10,7 @@ import java.util.List;
  * @param <S> Solution
  * @param <R> Result
  */
-public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, Population extends Iterable<S>, R>  implements Algorithm<R>{
+public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, Population, R>  implements Algorithm<R>{
   private Population population;
 
   public Population getPopulation() {

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
@@ -29,24 +29,24 @@ public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, Popul
 
   protected abstract Population createInitialPopulation();
 
-  protected abstract Population selection(Population population);
+  protected abstract List<S> selection(Population population);
 
-  protected abstract Population reproduction(Population population);
+  protected abstract List<S> reproduction(List<S> selectedIndividuals);
 
-  protected abstract Population replacement(Population population, Population offspringPopulation);
+  protected abstract Population replacement(Population population, List<S> offsprings);
 
   @Override public abstract R getResult();
 
   @Override public void run() {
-    Population offspringPopulation;
-    Population matingPopulation;
+    List<S> offsprings;
+    List<S> selectedIndividuals;
 
     population = createInitialPopulation();
     initProgress();
     while (!isStoppingConditionReached()) {
-      matingPopulation = selection(population);
-      offspringPopulation = reproduction(matingPopulation);
-      population = replacement(population, offspringPopulation);
+      selectedIndividuals = selection(population);
+      offsprings = reproduction(selectedIndividuals);
+      population = replacement(population, offsprings);
       updateProgress();
     }
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
@@ -29,8 +29,6 @@ public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, Popul
 
   protected abstract Population createInitialPopulation();
 
-  protected abstract Population evaluatePopulation(Population population);
-
   protected abstract Population selection(Population population);
 
   protected abstract Population reproduction(Population population);
@@ -44,12 +42,10 @@ public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, Popul
     Population matingPopulation;
 
     population = createInitialPopulation();
-    population = evaluatePopulation(population);
     initProgress();
     while (!isStoppingConditionReached()) {
       matingPopulation = selection(population);
       offspringPopulation = reproduction(matingPopulation);
-      offspringPopulation = evaluatePopulation(offspringPopulation);
       population = replacement(population, offspringPopulation);
       updateProgress();
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
@@ -5,13 +5,11 @@ import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.SelectionOperator;
 import org.uma.jmetal.solution.Solution;
 
-import java.util.List;
-
 /**
  * Created by ajnebro on 26/10/14.
  */
-public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, List<S>, Result> {
-  protected SelectionOperator<List<S>, S> selectionOperator ;
+public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Population extends Iterable<S>, Result> extends AbstractEvolutionaryAlgorithm<S, Population, Result> {
+  protected SelectionOperator<Population, S> selectionOperator ;
   protected CrossoverOperator<S> crossoverOperator ;
   protected MutationOperator<S> mutationOperator ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * Created by ajnebro on 26/10/14.
  */
-public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, Result> {
+public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, List<S>, Result> {
   protected SelectionOperator<List<S>, S> selectionOperator ;
   protected CrossoverOperator<S> crossoverOperator ;
   protected MutationOperator<S> mutationOperator ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
@@ -8,7 +8,7 @@ import org.uma.jmetal.solution.Solution;
 /**
  * Created by ajnebro on 26/10/14.
  */
-public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Population extends Iterable<S>, Result> extends AbstractEvolutionaryAlgorithm<S, Population, Result> {
+public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Population, Result> extends AbstractEvolutionaryAlgorithm<S, Population, Result> {
   protected SelectionOperator<Population, S> selectionOperator ;
   protected CrossoverOperator<S> crossoverOperator ;
   protected MutationOperator<S> mutationOperator ;


### PR DESCRIPTION
This pull request relates to what was discussed in issue #100. It introduces several modifications, and they don't have all the same interests:

The 3 first commits should be integrated anyway, because they improve the genericity of high level classes without impacting the implementations, thus extending the possibilities offered by these high level classes.

The 4th commit introduce a change in the design choices: it removes the evaluation method from `AbstractEvolutionaryAlgorithm`, which has an impact on each leaf implementation.

The 5th commit, although it is of the same kind than the first commits, cannot be done unless we remove the evaluation method, thus it comes after and it should not be integrated if the 4th commit is not integrated.

Finally, the last commit fixes one of the issues stated in #100 by exploiting the modifications introduced in the previous commits. Of course, it cannot be integrated if the previous commits are not integrated too.
