### PR TITLE
Issue with generics

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/util/distance/impl/EuclideanDistanceBetweenSolutionAndASolutionListInObjectiveSpace.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/distance/impl/EuclideanDistanceBetweenSolutionAndASolutionListInObjectiveSpace.java
@@ -27,10 +27,10 @@ import java.util.List;
 public class EuclideanDistanceBetweenSolutionAndASolutionListInObjectiveSpace<S extends Solution<Double>, L extends List<S>>
     implements Distance<S, L> {
 
-  private EuclideanDistanceBetweenSolutionsInObjectiveSpace distance ;
+  private EuclideanDistanceBetweenSolutionsInObjectiveSpace<S> distance ;
 
   public EuclideanDistanceBetweenSolutionAndASolutionListInObjectiveSpace() {
-    distance = new EuclideanDistanceBetweenSolutionsInObjectiveSpace() ;
+    distance = new EuclideanDistanceBetweenSolutionsInObjectiveSpace<S>() ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java
@@ -48,22 +48,21 @@ import java.util.*;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-@SuppressWarnings("unchecked")
 public class ComputeQualityIndicators<Result> implements ExperimentComponent {
 
   private final Experiment<?, Result> experiment;
 
-  public ComputeQualityIndicators(Experiment experiment) {
+  public ComputeQualityIndicators(Experiment<?, Result> experiment) {
     this.experiment = experiment ;
     this.experiment.removeDuplicatedAlgorithms();
   }
 
   @Override
   public void run() throws IOException {
-    for (GenericIndicator indicator : experiment.getIndicatorList()) {
+    for (GenericIndicator<?> indicator : experiment.getIndicatorList()) {
       JMetalLogger.logger.info("Computing indicator: " + indicator.getName()); ;
 
-      for (TaggedAlgorithm algorithm : experiment.getAlgorithmList()) {
+      for (TaggedAlgorithm<Result> algorithm : experiment.getAlgorithmList()) {
         String algorithmDirectory ;
         algorithmDirectory = experiment.getExperimentBaseDirectory() + "/data/" +
             algorithm.getTag() ;
@@ -146,8 +145,8 @@ public class ComputeQualityIndicators<Result> implements ExperimentComponent {
   }
 
   public void findBestIndicatorFronts(Experiment<?, Result> experiment) throws IOException {
-    for (GenericIndicator indicator : experiment.getIndicatorList()) {
-      for (TaggedAlgorithm algorithm : experiment.getAlgorithmList()) {
+    for (GenericIndicator<?> indicator : experiment.getIndicatorList()) {
+      for (TaggedAlgorithm<Result> algorithm : experiment.getAlgorithmList()) {
         String algorithmDirectory;
         algorithmDirectory = experiment.getExperimentBaseDirectory() + "/data/" +
             algorithm.getTag();

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateFriedmanTestTables.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateFriedmanTestTables.java
@@ -16,7 +16,7 @@ package org.uma.jmetal.util.experiment.component;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.uma.jmetal.qualityindicator.QualityIndicator;
+import org.uma.jmetal.qualityindicator.impl.GenericIndicator;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.experiment.Experiment;
 import org.uma.jmetal.util.experiment.ExperimentComponent;
@@ -50,8 +50,7 @@ public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
   private int numberOfAlgorithms ;
   private int numberOfProblems ;
 
-  @SuppressWarnings("unchecked")
-  public GenerateFriedmanTestTables(Experiment experimentConfiguration) {
+  public GenerateFriedmanTestTables(Experiment<?, Result> experimentConfiguration) {
     this.experiment = experimentConfiguration ;
 
     experiment.removeDuplicatedAlgorithms();
@@ -65,7 +64,7 @@ public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
   public void run() throws IOException {
     latexDirectoryName = experiment.getExperimentBaseDirectory() + "/" + DEFAULT_LATEX_DIRECTORY;
 
-    for (QualityIndicator indicator : experiment.getIndicatorList()) {
+    for (GenericIndicator<?> indicator : experiment.getIndicatorList()) {
       Vector<Vector<Double>> data = readData(indicator);
       double []averageRanking = computeAverageRanking(data) ;
       String fileContents = prepareFileOutputContents(averageRanking) ;
@@ -73,7 +72,7 @@ public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
     }
   }
 
-  private Vector<Vector<Double>> readData(QualityIndicator indicator) {
+  private Vector<Vector<Double>> readData(GenericIndicator<?> indicator) {
     Vector<Vector<Double>> data = new Vector<Vector<Double>>() ;
 
     for (int algorithm = 0; algorithm < experiment.getAlgorithmList().size(); algorithm++) {
@@ -138,7 +137,7 @@ public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
 
     for (int j = 0; j < numberOfAlgorithms; j++) {
       for (int i = 0; i < numberOfProblems; i++) {
-        mean[i][j] = (Double)((Vector) data.elementAt(j)).elementAt(i);
+        mean[i][j] = data.elementAt(j).elementAt(i);
       }
     }
 
@@ -238,7 +237,7 @@ public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
    * @param indicator
    * @param fileContents
    */
-  private void writeLatexFile(QualityIndicator indicator, String fileContents) {
+  private void writeLatexFile(GenericIndicator<?> indicator, String fileContents) {
     String outputFile = latexDirectoryName +"/FriedmanTest"+indicator.getName()+".tex";
 
     try {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateLatexTablesWithStatistics.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateLatexTablesWithStatistics.java
@@ -219,7 +219,7 @@ public class GenerateLatexTablesWithStatistics implements ExperimentComponent {
     os.write("\\begin{tabular}{l");
 
     // calculate the number of columns
-    for (TaggedAlgorithm algorithm : experiment.getAlgorithmList()) {
+    for (TaggedAlgorithm<?> algorithm : experiment.getAlgorithmList()) {
       os.write("l");
     }
     os.write("}\n");

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoFront.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoFront.java
@@ -47,7 +47,7 @@ import java.util.List;
 public class GenerateReferenceParetoFront implements ExperimentComponent{
   private final Experiment<?, ?> experiment;
   
-  public GenerateReferenceParetoFront(Experiment experimentConfiguration) {
+  public GenerateReferenceParetoFront(Experiment<?, ?> experimentConfiguration) {
     this.experiment = experimentConfiguration ;
     this.experiment.removeDuplicatedAlgorithms();
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoSetAndFrontFromDoubleSolutions.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoSetAndFrontFromDoubleSolutions.java
@@ -64,7 +64,7 @@ import java.util.List;
 public class GenerateReferenceParetoSetAndFrontFromDoubleSolutions implements ExperimentComponent{
   private final Experiment<?, ?> experiment;
 
-  public GenerateReferenceParetoSetAndFrontFromDoubleSolutions(Experiment experimentConfiguration) {
+  public GenerateReferenceParetoSetAndFrontFromDoubleSolutions(Experiment<?, ?> experimentConfiguration) {
     this.experiment = experimentConfiguration ;
     this.experiment.removeDuplicatedAlgorithms();
   }

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/distance/impl/CosineDistanceBetweenSolutionsInObjectiveSpaceTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/distance/impl/CosineDistanceBetweenSolutionsInObjectiveSpaceTest.java
@@ -11,29 +11,28 @@ import static org.mockito.Mockito.when;
 /**
  * Created by ajnebro on 12/2/16.
  */
-@SuppressWarnings("unchecked")
 public class CosineDistanceBetweenSolutionsInObjectiveSpaceTest {
   private static final double EPSILON = 0.00000000001 ;
 
   @Test
   public void shouldIdenticalPointsHaveADistanceOfOne() {
-    Solution idealPoint = mock(Solution.class) ;
+    Solution<?> idealPoint = mock(Solution.class) ;
     when(idealPoint.getObjective(0)).thenReturn(0.0) ;
     when(idealPoint.getObjective(1)).thenReturn(0.0) ;
     when(idealPoint.getNumberOfObjectives()).thenReturn(3) ;
 
-    Solution point1 = mock(Solution.class) ;
+    Solution<?> point1 = mock(Solution.class) ;
     when(point1.getObjective(0)).thenReturn(1.0) ;
     when(point1.getObjective(1)).thenReturn(1.0) ;
     when(point1.getNumberOfObjectives()).thenReturn(3) ;
 
-    Solution point2 = mock(Solution.class) ;
+    Solution<?> point2 = mock(Solution.class) ;
     when(point2.getObjective(0)).thenReturn(1.0) ;
     when(point2.getObjective(1)).thenReturn(1.0) ;
     when(point2.getNumberOfObjectives()).thenReturn(3) ;
 
-    CosineDistanceBetweenSolutionsInObjectiveSpace distance =
-        new CosineDistanceBetweenSolutionsInObjectiveSpace(idealPoint) ;
+    CosineDistanceBetweenSolutionsInObjectiveSpace<Solution<?>> distance =
+        new CosineDistanceBetweenSolutionsInObjectiveSpace<Solution<?>>(idealPoint) ;
 
     double receivedValue = distance.getDistance(point1, point2) ;
     assertEquals(1.0, receivedValue, EPSILON) ;
@@ -41,23 +40,23 @@ public class CosineDistanceBetweenSolutionsInObjectiveSpaceTest {
 
   @Test
   public void shouldIdenticalPointsInTheSameDirectionHaveADistanceOfOne() {
-    Solution idealPoint = mock(Solution.class) ;
+    Solution<?> idealPoint = mock(Solution.class) ;
     when(idealPoint.getObjective(0)).thenReturn(0.0) ;
     when(idealPoint.getObjective(1)).thenReturn(0.0) ;
     when(idealPoint.getNumberOfObjectives()).thenReturn(3) ;
 
-    Solution point1 = mock(Solution.class) ;
+    Solution<?> point1 = mock(Solution.class) ;
     when(point1.getObjective(0)).thenReturn(1.0) ;
     when(point1.getObjective(1)).thenReturn(1.0) ;
     when(point1.getNumberOfObjectives()).thenReturn(3) ;
 
-    Solution point2 = mock(Solution.class) ;
+    Solution<?> point2 = mock(Solution.class) ;
     when(point2.getObjective(0)).thenReturn(2.0) ;
     when(point2.getObjective(1)).thenReturn(2.0) ;
     when(point2.getNumberOfObjectives()).thenReturn(3) ;
 
-    CosineDistanceBetweenSolutionsInObjectiveSpace distance =
-        new CosineDistanceBetweenSolutionsInObjectiveSpace(idealPoint) ;
+    CosineDistanceBetweenSolutionsInObjectiveSpace<Solution<?>> distance =
+        new CosineDistanceBetweenSolutionsInObjectiveSpace<Solution<?>>(idealPoint) ;
 
     double receivedValue = distance.getDistance(point1, point2) ;
     assertEquals(1.0, receivedValue, EPSILON) ;
@@ -65,23 +64,23 @@ public class CosineDistanceBetweenSolutionsInObjectiveSpaceTest {
 
   @Test
   public void shouldTwoPerpendicularPointsHaveADistanceOfZero() {
-    Solution idealPoint = mock(Solution.class) ;
+    Solution<?> idealPoint = mock(Solution.class) ;
     when(idealPoint.getObjective(0)).thenReturn(0.0) ;
     when(idealPoint.getObjective(1)).thenReturn(0.0) ;
     when(idealPoint.getNumberOfObjectives()).thenReturn(3) ;
 
-    Solution point1 = mock(Solution.class) ;
+    Solution<?> point1 = mock(Solution.class) ;
     when(point1.getObjective(0)).thenReturn(0.0) ;
     when(point1.getObjective(1)).thenReturn(1.0) ;
     when(point1.getNumberOfObjectives()).thenReturn(3) ;
 
-    Solution point2 = mock(Solution.class) ;
+    Solution<?> point2 = mock(Solution.class) ;
     when(point2.getObjective(0)).thenReturn(1.0) ;
     when(point2.getObjective(1)).thenReturn(0.0) ;
     when(point2.getNumberOfObjectives()).thenReturn(3) ;
 
-    CosineDistanceBetweenSolutionsInObjectiveSpace distance =
-        new CosineDistanceBetweenSolutionsInObjectiveSpace(idealPoint) ;
+    CosineDistanceBetweenSolutionsInObjectiveSpace<Solution<?>> distance =
+        new CosineDistanceBetweenSolutionsInObjectiveSpace<Solution<?>>(idealPoint) ;
 
     double receivedValue = distance.getDistance(point1, point2) ;
     assertEquals(0.0, receivedValue, EPSILON) ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/AbstractAlgorithmRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/AbstractAlgorithmRunner.java
@@ -45,8 +45,7 @@ public abstract class AbstractAlgorithmRunner {
    * @param paretoFrontFile
    * @throws FileNotFoundException
    */
-  @SuppressWarnings("unchecked")
-  public static void printQualityIndicators(List<? extends Solution<?>> population, String paretoFrontFile)
+  public static <S extends Solution<?>> void printQualityIndicators(List<S> population, String paretoFrontFile)
       throws FileNotFoundException {
     Front referenceFront = new ArrayFront(paretoFrontFile);
     FrontNormalizer frontNormalizer = new FrontNormalizer(referenceFront) ;
@@ -60,28 +59,28 @@ public abstract class AbstractAlgorithmRunner {
     outputString += "Hypervolume (N) : " +
         new PISAHypervolume<DoubleSolution>(normalizedReferenceFront).evaluate(normalizedPopulation) + "\n";
     outputString += "Hypervolume     : " +
-        new PISAHypervolume(referenceFront).evaluate(population) + "\n";
+        new PISAHypervolume<S>(referenceFront).evaluate(population) + "\n";
     outputString += "Epsilon (N)     : " +
         new Epsilon<DoubleSolution>(normalizedReferenceFront).evaluate(normalizedPopulation) +
         "\n" ;
     outputString += "Epsilon         : " +
-        new Epsilon(referenceFront).evaluate(population) + "\n" ;
+        new Epsilon<S>(referenceFront).evaluate(population) + "\n" ;
     outputString += "GD (N)          : " +
         new GenerationalDistance<DoubleSolution>(normalizedReferenceFront).evaluate(normalizedPopulation) + "\n";
     outputString += "GD              : " +
-        new GenerationalDistance(referenceFront).evaluate(population) + "\n";
+        new GenerationalDistance<S>(referenceFront).evaluate(population) + "\n";
     outputString += "IGD (N)         : " +
         new InvertedGenerationalDistance<DoubleSolution>(normalizedReferenceFront).evaluate(normalizedPopulation) + "\n";
     outputString +="IGD             : " +
-        new InvertedGenerationalDistance(referenceFront).evaluate(population) + "\n";
+        new InvertedGenerationalDistance<S>(referenceFront).evaluate(population) + "\n";
     outputString += "IGD+ (N)        : " +
         new InvertedGenerationalDistancePlus<DoubleSolution>(normalizedReferenceFront).evaluate(normalizedPopulation) + "\n";
     outputString += "IGD+            : " +
-        new InvertedGenerationalDistancePlus(referenceFront).evaluate(population) + "\n";
+        new InvertedGenerationalDistancePlus<S>(referenceFront).evaluate(population) + "\n";
     outputString += "Spread (N)      : " +
         new Spread<DoubleSolution>(normalizedReferenceFront).evaluate(normalizedPopulation) + "\n";
     outputString += "Spread          : " +
-        new Spread(referenceFront).evaluate(population) + "\n";
+        new Spread<S>(referenceFront).evaluate(population) + "\n";
 //    outputString += "R2 (N)          : " +
 //        new R2<List<DoubleSolution>>(normalizedReferenceFront).evaluate(normalizedPopulation) + "\n";
 //    outputString += "R2              : " +

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/MOCHCRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/MOCHCRunner.java
@@ -91,7 +91,7 @@ public class MOCHCRunner extends AbstractAlgorithmRunner {
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
             .execute() ;
 
-    List<BinarySolution> population = ((MOCHC)algorithm).getResult() ;
+    List<BinarySolution> population = algorithm.getResult() ;
     long computingTime = algorithmRunner.getComputingTime() ;
 
     JMetalLogger.logger.info("Total execution time: " + computingTime + "ms");


### PR DESCRIPTION
The first commit is just a useless cast.

The second tries to fix some $#!?§£... hum, 36 raw type warnings, but I am facing a conflict.

At [line 105 of BinaryProblemStudy](https://github.com/jMetal/jMetal/blob/master/jmetal-exec/src/main/java/org/uma/jmetal/experiment/BinaryProblemsStudy.java#L105) you compute the quality indicators of your experiment. This experiment, defined at [line 85](https://github.com/jMetal/jMetal/blob/master/jmetal-exec/src/main/java/org/uma/jmetal/experiment/BinaryProblemsStudy.java#L85), deals with `BinarySolution` solutions and a `List<BinarySolution>` for its result. To compute them, you instantiate a `ComputeQualityIndicators` by providing it this experiment. Now, this is the tricky part: [it does not fill its generics](https://github.com/jMetal/jMetal/blob/master/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java#L56) (Boo! Bad boy!) but what you get is just a warning, so let's just add a cool `@SuppressWarnings("unchecked")` at [line 51](https://github.com/jMetal/jMetal/blob/master/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java#L51), so no other warning appears (No warning? No problem!). Then let's continue: in its `run()` method, you have many things which do not, also, fill their generics (Boo! But they are not displayed anymore, so who cares.). In particular at [line 63](https://github.com/jMetal/jMetal/blob/master/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java#L63) where you obtain the indicator from the experiment, you should then obtain a `GenericIndicator<BinarySolution>`, but here the code does not know because no generics (Shhh! Don't care!). If we go ahead, we reach [line 96](https://github.com/jMetal/jMetal/blob/master/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java#L96) which generates a front as a `List<DoubleSolution>` and then use it on the next line to be evaluated by the indicator... Oops! Where is our `BinarySolution`?

Consequently, I am currently fixing these warnings (which are errors for me, so no `unchecked` can hide them: no excuse for lazy guys!) and I face this situation where it cannot compile, because the types are conflicting. So I kindly ask someone to tell me how to fix this issue or to give it a thorough check (and to switch the raw type warnings to errors for people not having it yet).