### PR TITLE
Update MOEADSTM.java

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADSTM.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADSTM.java
@@ -251,7 +251,7 @@ public class MOEADSTM extends AbstractMOEAD<DoubleSolution> {
 
 		population.clear();
 		for (int i = 0; i < populationSize; i++)
-			population.add(i, jointPopulation.get(i));
+			population.add(i, jointPopulation.get(idx[i]));
 	}
 
 	/**


### PR DESCRIPTION
A bug fix for not using the index array "idx" in the final selection.

More specifically, the array "idx" keeps the record of the matching results, and should be used to guide the final selection in line 254. But I did not use it at the end.