### PR TITLE
Remove syntaxical factoring.

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3.java
@@ -36,6 +36,7 @@ import java.util.*;
 public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
   protected int maxEvaluations;
   protected int evaluations;
+  private int maxPopulationSize ;
 
   protected Comparator<DoubleSolution> dominanceComparator;
 
@@ -61,6 +62,13 @@ public class GDE3 extends AbstractDifferentialEvolution<List<DoubleSolution>> {
     crowdingDistance = new CrowdingDistance<DoubleSolution>();
 
     this.evaluator = evaluator ;
+  }
+  
+  public void setMaxPopulationSize(int maxPopulationSize) {
+    this.maxPopulationSize = maxPopulationSize ;
+  }
+  public int getMaxPopulationSize() {
+    return maxPopulationSize ;
   }
 
   @Override protected void initProgress() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mochc/MOCHC.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mochc/MOCHC.java
@@ -51,6 +51,7 @@ public class MOCHC extends AbstractEvolutionaryAlgorithm<BinarySolution, List<Bi
   private BinaryProblem problem;
 
   private int maxEvaluations;
+  private int maxPopulationSize ;
   private int convergenceValue;
   private double preservedPopulation;
   private double initialConvergenceCount;
@@ -94,6 +95,13 @@ public class MOCHC extends AbstractEvolutionaryAlgorithm<BinarySolution, List<Bi
     minimumDistance = (int) Math.floor(this.initialConvergenceCount * size);
 
     comparator = new CrowdingDistanceComparator<BinarySolution>();
+  }
+  
+  public void setMaxPopulationSize(int maxPopulationSize) {
+    this.maxPopulationSize = maxPopulationSize ;
+  }
+  public int getMaxPopulationSize() {
+    return maxPopulationSize ;
   }
 
   @Override protected void initProgress() {

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractEvolutionaryAlgorithm.java
@@ -29,7 +29,6 @@ import java.util.List;
 @SuppressWarnings("serial")
 public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, R>  implements Algorithm<R>{
   private List<S> population;
-  private int maxPopulationSize ;
   private Problem<S> problem ;
 
   public List<S> getPopulation() {
@@ -37,13 +36,6 @@ public abstract class AbstractEvolutionaryAlgorithm<S extends Solution<?>, R>  i
   }
   public void setPopulation(List<S> population) {
     this.population = population;
-  }
-
-  public void setMaxPopulationSize(int maxPopulationSize) {
-    this.maxPopulationSize = maxPopulationSize ;
-  }
-  public int getMaxPopulationSize() {
-    return maxPopulationSize ;
   }
 
   public void setProblem(Problem<S> problem) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/algorithm/impl/AbstractGeneticAlgorithm.java
@@ -30,11 +30,20 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public abstract class AbstractGeneticAlgorithm<S extends Solution<?>, Result> extends AbstractEvolutionaryAlgorithm<S, Result> {
+  private int maxPopulationSize ;
   protected SelectionOperator<List<S>, S> selectionOperator ;
   protected CrossoverOperator<S> crossoverOperator ;
   protected MutationOperator<S> mutationOperator ;
 
-  /* Getters */
+  /* Setters and getters */
+  public void setMaxPopulationSize(int maxPopulationSize) {
+    this.maxPopulationSize = maxPopulationSize ;
+  }
+  
+  public int getMaxPopulationSize() {
+    return maxPopulationSize ;
+  }
+  
   public SelectionOperator<List<S>, S> getSelectionOperator() {
     return selectionOperator;
   }


### PR DESCRIPTION
Remove maxPopulationSize dependence from AbstractEvolutionaryAlgorithm because it does not use it (syntaxical factoring of child classes). It has been moved to the child classes actually using it.

If it is only a matter of factoring the code, then it is better to make a dedicated class to manage common properties, and use it internally in all the algorithms needing it.