### PR TITLE
Extract the builder of the CMAES into a dedicated class.

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
@@ -35,6 +35,10 @@ import java.util.*;
 @SuppressWarnings("serial")
 public class CovarianceMatrixAdaptationEvolutionStrategy
     extends AbstractEvolutionStrategy<DoubleSolution, DoubleSolution> {
+  public static final int DEFAULT_LAMBDA = 10 ;
+  public static final int DEFAULT_MAX_EVALUATIONS = 1000000 ;
+  public static final double DEFAULT_SIGMA = 0.3;
+  
   private Comparator<DoubleSolution> comparator ;
   private int lambda ;
   private int evaluations ;
@@ -110,13 +114,28 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
 
   private Random rand;
 
+  /**
+   * Constructor with builder
+   * 
+   * @deprecated Use a constructor without {@link Builder} instead.
+   */
+  @Deprecated
+  private CovarianceMatrixAdaptationEvolutionStrategy(Builder builder) {
+    this(builder.problem, builder.lambda, builder.maxEvaluations, builder.typicalX, builder.sigma);
+  }
+  
+  /** Constructor with default values */
+  public CovarianceMatrixAdaptationEvolutionStrategy(DoubleProblem problem) {
+    this(problem, DEFAULT_LAMBDA, DEFAULT_MAX_EVALUATIONS, null, DEFAULT_SIGMA);
+  }
+  
   /** Constructor */
-  private CovarianceMatrixAdaptationEvolutionStrategy (Builder builder) {
-    super(builder.problem) ;
-    this.lambda = builder.lambda ;
-    this.maxEvaluations = builder.maxEvaluations ;
-    this.typicalX = builder.typicalX;
-    this.sigma = builder.sigma;
+  public CovarianceMatrixAdaptationEvolutionStrategy(DoubleProblem problem, int lambda, int maxEvaluations, double[] typicalX, double sigma) {
+    super(problem) ;
+    this.lambda = lambda ;
+    this.maxEvaluations = maxEvaluations ;
+    this.typicalX = typicalX;
+    this.sigma = sigma;
 
     long seed = System.currentTimeMillis();
     rand = new Random(seed);
@@ -137,12 +156,10 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
 
   /**
    * Buider class
+   * @deprecated Use {@link CovarianceMatrixAdaptationEvolutionStrategyBuilder} instead
    */
+  @Deprecated
   public static class Builder {
-    private static final int DEFAULT_LAMBDA = 10 ;
-    private static final int DEFAULT_MAX_EVALUATIONS = 1000000 ;
-    private static final double DEFAULT_SIGMA = 0.3;
-
     private DoubleProblem problem ;
     private int lambda ;
     private int maxEvaluations ;
@@ -181,6 +198,22 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
     }
   }
 
+  public void setLambda(int lambda) {
+    this.lambda = lambda;
+  }
+
+  public void setMaxEvaluations(int maxEvaluations) {
+    this.maxEvaluations = maxEvaluations;
+  }
+    
+  public void setTypicalX (double [] typicalX) {
+    this.typicalX = typicalX;
+  }
+
+  public void setSigma (double sigma) {
+    this.sigma = sigma;
+  }
+  
   @Override protected void initProgress() {
     evaluations = 0;
   }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategyBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategyBuilder.java
@@ -1,0 +1,57 @@
+package org.uma.jmetal.algorithm.singleobjective.evolutionstrategy;
+
+import org.uma.jmetal.problem.DoubleProblem;
+import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.util.AlgorithmBuilder;
+
+/**
+ * 
+ * @author Inacio Medeiros <inaciogmedeiros@gmail.com>
+ *
+ */
+public class CovarianceMatrixAdaptationEvolutionStrategyBuilder<S extends Solution<?>> implements
+		AlgorithmBuilder<CovarianceMatrixAdaptationEvolutionStrategy> {
+    private DoubleProblem problem ;
+    private int lambda ;
+    private int maxEvaluations ;
+    private double [] typicalX;
+    private double sigma;
+
+    public CovarianceMatrixAdaptationEvolutionStrategyBuilder(DoubleProblem problem) {
+      this.problem = problem;
+      lambda = CovarianceMatrixAdaptationEvolutionStrategy.DEFAULT_LAMBDA;
+      maxEvaluations = CovarianceMatrixAdaptationEvolutionStrategy.DEFAULT_MAX_EVALUATIONS;
+      sigma = CovarianceMatrixAdaptationEvolutionStrategy.DEFAULT_SIGMA;
+    }
+
+    public CovarianceMatrixAdaptationEvolutionStrategyBuilder(DoubleProblem problem, int lambda, int maxEvaluations, double[] typicalX, double sigma) {
+      this.problem = problem;
+      this.lambda = lambda;
+      this.maxEvaluations = maxEvaluations;
+      this.sigma = sigma;
+    }
+
+    public CovarianceMatrixAdaptationEvolutionStrategyBuilder<S> setLambda(int lambda) {
+      this.lambda = lambda;
+      return this;
+    }
+
+    public CovarianceMatrixAdaptationEvolutionStrategyBuilder<S> setMaxEvaluations(int maxEvaluations) {
+      this.maxEvaluations = maxEvaluations;
+      return this;
+    }
+
+    public CovarianceMatrixAdaptationEvolutionStrategyBuilder<S> setTypicalX (double [] typicalX) {
+      this.typicalX = typicalX;
+      return this;
+    }
+
+    public CovarianceMatrixAdaptationEvolutionStrategyBuilder<S> setSigma (double sigma) {
+      this.sigma = sigma;
+      return this;
+    }
+
+    public CovarianceMatrixAdaptationEvolutionStrategy build() {
+      return new CovarianceMatrixAdaptationEvolutionStrategy(problem, lambda, maxEvaluations, typicalX, sigma);
+    }
+}

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/CovarianceMatrixAdaptationEvolutionStrategyRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/singleobjective/CovarianceMatrixAdaptationEvolutionStrategyRunner.java
@@ -43,8 +43,7 @@ public class CovarianceMatrixAdaptationEvolutionStrategyRunner {
     Algorithm<DoubleSolution> algorithm;
     DoubleProblem problem = new Sphere() ;
 
-    algorithm = new CovarianceMatrixAdaptationEvolutionStrategy.Builder(problem)
-            .build() ;
+    algorithm = new CovarianceMatrixAdaptationEvolutionStrategy(problem) ;
 
 
     AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)


### PR DESCRIPTION
The CMAES class is made independent from its builder in the process, and the runner does not use any builder anymore (default values are provided through one of the constructors of the algorithm itself). I have inspired from other builders to have the same pattern, so the CMAESBuilder class is different from the builder provided in the CMAES class. Rather than removing the old stuff, I made it deprecated. It can be removed in a major revision.
