### PR TITLE
Decrease loops for faster testing.

### DIFF
--- a/jmetal-core/src/test/java/org/uma/jmetal/solution/impl/DoubleSolutionComparisonIT.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/solution/impl/DoubleSolutionComparisonIT.java
@@ -28,13 +28,14 @@ public class DoubleSolutionComparisonIT {
     long startTime ;
 
     startTime = System.currentTimeMillis() ;
-    for (int i = 0 ; i < 150000; i++) {
+    int loops = 10000;
+	for (int i = 0 ; i < loops; i++) {
       problem1.createSolution() ;
     }
     long timeToCreateObjectsWithProblem1 = System.currentTimeMillis() - startTime ;
 
     startTime = System.currentTimeMillis() ;
-    for (int i = 0 ; i < 150000; i++) {
+    for (int i = 0 ; i < loops; i++) {
       problem2.createSolution() ;
     }
     long timeToCreateObjectsWithProblem2 = System.currentTimeMillis() - startTime ;
@@ -57,14 +58,15 @@ public class DoubleSolutionComparisonIT {
     DoubleSolution solution ;
     solution = problem1.createSolution() ;
     startTime = System.currentTimeMillis() ;
-    for (int i = 0 ; i < 1500000; i++) {
+    int loops = 10000;
+	for (int i = 0 ; i < loops; i++) {
       problem1.evaluate(solution);
     }
     long timeToCreateObjectsWithProblem1 = System.currentTimeMillis() - startTime ;
 
     solution = problem2.createSolution() ;
     startTime = System.currentTimeMillis() ;
-    for (int i = 0 ; i < 1500000; i++) {
+    for (int i = 0 ; i < loops; i++) {
       problem2.evaluate(solution) ;
     }
     long timeToCreateObjectsWithProblem2 = System.currentTimeMillis() - startTime ;


### PR DESCRIPTION
There is [a test](https://github.com/jMetal/jMetal/blob/9c110f9c9dec116ba4f40589815158ea8accc991/jmetal-core/src/test/java/org/uma/jmetal/solution/impl/DoubleSolutionComparisonIT.java#L51) which takes really long to execute. It seems that it is just to compare that 1 case takes less time to execute than another. Can't we reduce the amount if it is just for that? Like to 100 or 1'000 instead of 1'500'000? The other test of the same class also takes several seconds by looping 150'000 times.

I have run them dozens of times with 1'000 and it failed only once. So I guess 10'000 is enough. With this value, it takes less than a second per test. With your values, one takes 6s and the other 106s on my machine, so it's really long. All the tests but these two are really fast (running the 556 tests takes less than 5s), so it is frustrating to wait for these two. Especially when you want to check several commits.