### PR TITLE
Defaults and lambdas

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/CountingMeasure.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/CountingMeasure.java
@@ -150,13 +150,7 @@ public class CountingMeasure extends SimplePushMeasure<Long> implements
 		if (linkedMeasures.containsKey(measure)) {
 			// already linked
 		} else {
-			MeasureListener<T> listener = new MeasureListener<T>() {
-
-				@Override
-				public void measureGenerated(T value) {
-					increment();
-				}
-			};
+			MeasureListener<T> listener = (value) -> increment();
 			measure.register(listener);
 			linkedMeasures.put(measure, listener);
 		}

--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/ListenerTimeMeasure.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/ListenerTimeMeasure.java
@@ -67,14 +67,11 @@ public class ListenerTimeMeasure extends SimplePullMeasure<Long> implements
 					.get(wrapped);
 
 			if (wrapper == null) {
-				wrapper = new MeasureListener<Value>() {
-					@Override
-					public void measureGenerated(Value value) {
+				wrapper = (value) -> {
 						long start = System.currentTimeMillis();
 						wrapped.measureGenerated(value);
 						long stop = System.currentTimeMillis();
 						time += stop - Math.max(start, lastReset);
-					}
 				};
 				listenerCache.put(wrapped, wrapper);
 			} else {

--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/MeasureFactory.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/MeasureFactory.java
@@ -45,13 +45,7 @@ public class MeasureFactory {
 	public <Value> PullMeasure<Value> createPullFromPush(
 			final PushMeasure<Value> push, Value initialValue) {
 		final Object[] cache = { initialValue };
-		final MeasureListener<Value> listener = new MeasureListener<Value>() {
-
-			@Override
-			public void measureGenerated(Value value) {
-				cache[0] = value;
-			}
-		};
+		final MeasureListener<Value> listener = (Value value) -> cache[0] = value;
 		push.register(listener);
 		return new PullMeasure<Value>() {
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/MeasureFactory.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/MeasureFactory.java
@@ -234,7 +234,7 @@ public class MeasureFactory {
 		for (final Field field : clazz.getFields()) {
 			String key = field.getName();
 			// TODO exploit return type to restrict the generics
-			measures.put(key, new PullMeasure<Object>() {
+			measures.put(key, new SimplePullMeasure<Object>(key) {
 				@Override
 				public Object get() {
 					try {

--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/MeasureFactory.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/MeasureFactory.java
@@ -240,8 +240,7 @@ public class MeasureFactory {
 		for (final Field field : clazz.getFields()) {
 			String key = field.getName();
 			// TODO exploit return type to restrict the generics
-			measures.put(key, new SimplePullMeasure<Object>(key) {
-
+			measures.put(key, new PullMeasure<Object>() {
 				@Override
 				public Object get() {
 					try {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/naming/DescribedEntity.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/naming/DescribedEntity.java
@@ -12,11 +12,11 @@ public interface DescribedEntity {
 	 * 
 	 * @return the name of the {@link DescribedEntity}
 	 */
-	public String getName();
+	default String getName() {return toString();}
 
 	/**
 	 * 
 	 * @return the description of the {@link DescribedEntity}
 	 */
-	public String getDescription();
+	default String getDescription() {return "<No description yet>";}
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/naming/DescribedEntity.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/naming/DescribedEntity.java
@@ -12,7 +12,13 @@ public interface DescribedEntity {
 	 * 
 	 * @return the name of the {@link DescribedEntity}
 	 */
-	default String getName() {return toString();}
+	default String getName() {
+		/*
+		 * Inspired from toString(). We don't use it directly to avoid side
+		 * effects (the method is usually overwritten).
+		 */
+		return getClass().getName() + '@' + Integer.toHexString(hashCode());
+	}
 
 	/**
 	 * 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/naming/impl/SimpleDescribedEntity.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/naming/impl/SimpleDescribedEntity.java
@@ -36,24 +36,25 @@ public class SimpleDescribedEntity implements DescribedEntity {
 	}
 
 	/**
-	 * Create a {@link SimpleDescribedEntity} with a given name and a
-	 * <code>null</code> description.
+	 * Create a {@link SimpleDescribedEntity} with a given name and a default
+	 * description.
 	 * 
 	 * @param name
 	 *            the name of the {@link DescribedEntity}
 	 */
 	public SimpleDescribedEntity(String name) {
 		this(name, null);
+		setDescription(DescribedEntity.super.getDescription());
 	}
 
 	/**
-	 * Create a {@link SimpleDescribedEntity} with the class name as its name
-	 * and a <code>null</code> description.
-	 * 
+	 * Create a {@link SimpleDescribedEntity} with a default name and
+	 * description.
 	 */
 	public SimpleDescribedEntity() {
-		this(null);
-		setName(getClass().getSimpleName());
+		this(null, null);
+		setName(DescribedEntity.super.getName());
+		setDescription(DescribedEntity.super.getDescription());
 	}
 
 	/**

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/CountingMeasureTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/CountingMeasureTest.java
@@ -1,7 +1,6 @@
 package org.uma.jmetal.measure.impl;
 
 import org.junit.Test;
-import org.uma.jmetal.measure.MeasureListener;
 
 import static org.junit.Assert.*;
 
@@ -25,13 +24,7 @@ public class CountingMeasureTest {
 	public void testIncrementNotificationsOccur() {
 		CountingMeasure measure = new CountingMeasure(15);
 		final boolean[] isCalled = { false };
-		measure.register(new MeasureListener<Long>() {
-
-			@Override
-			public void measureGenerated(Long value) {
-				isCalled[0] = true;
-			}
-		});
+		measure.register((value) -> isCalled[0] = true);
 
 		isCalled[0] = false;
 		measure.increment();
@@ -50,13 +43,9 @@ public class CountingMeasureTest {
 	public void testGetAlignedWithNotifications() {
 		final CountingMeasure measure = new CountingMeasure(15);
 		final int[] notifications = { 0 };
-		measure.register(new MeasureListener<Long>() {
-
-			@Override
-			public void measureGenerated(Long value) {
+		measure.register((value) -> {
 				notifications[0]++;
 				assertEquals(value, measure.get());
-			}
 		});
 		measure.increment();
 		assertEquals(1, notifications[0]);
@@ -179,13 +168,7 @@ public class CountingMeasureTest {
 	public void testResetNotificationsOccur() {
 		CountingMeasure measure = new CountingMeasure(15);
 		final boolean[] isCalled = { false };
-		measure.register(new MeasureListener<Long>() {
-
-			@Override
-			public void measureGenerated(Long value) {
-				isCalled[0] = true;
-			}
-		});
+		measure.register((value) -> isCalled[0] = true);
 
 		isCalled[0] = false;
 		measure.reset();
@@ -208,13 +191,7 @@ public class CountingMeasureTest {
 	public void testIncrementNotificationsOccurIfNonZero() {
 		CountingMeasure measure = new CountingMeasure(15);
 		final boolean[] isCalled = { false };
-		measure.register(new MeasureListener<Long>() {
-
-			@Override
-			public void measureGenerated(Long value) {
-				isCalled[0] = true;
-			}
-		});
+		measure.register((value) -> isCalled[0] = true);
 
 		isCalled[0] = false;
 		measure.increment(3);

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/LastEvaluationMeasureTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/LastEvaluationMeasureTest.java
@@ -1,7 +1,6 @@
 package org.uma.jmetal.measure.impl;
 
 import org.junit.Test;
-import org.uma.jmetal.measure.MeasureListener;
 import org.uma.jmetal.measure.impl.LastEvaluationMeasure.Evaluation;
 
 import static org.junit.Assert.assertEquals;
@@ -14,13 +13,7 @@ public class LastEvaluationMeasureTest {
 		LastEvaluationMeasure<String, Integer> measure = new LastEvaluationMeasure<>();
 		@SuppressWarnings("unchecked")
 		final Evaluation<String, Integer>[] lastEvaluation = new Evaluation[] { null };
-		measure.register(new MeasureListener<Evaluation<String, Integer>>() {
-
-			@Override
-			public void measureGenerated(Evaluation<String, Integer> evaluation) {
-				lastEvaluation[0] = evaluation;
-			}
-		});
+		measure.register((evaluation) -> lastEvaluation[0] = evaluation);
 
 		String solution = "individual";
 		int value = 3;

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
@@ -4,6 +4,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.uma.jmetal.measure.MeasureListener;
 import org.uma.jmetal.measure.MeasureManager;
+import org.uma.jmetal.measure.PullMeasure;
 import org.uma.jmetal.measure.PushMeasure;
 
 import static org.junit.Assert.*;
@@ -302,7 +303,7 @@ public class ListenerTimeMeasureTest {
 	public void testAdditionalKeyForWrappedManagerRejectAlreadyUsedKeys() {
 		ListenerTimeMeasure measure = new ListenerTimeMeasure();
 
-		SimplePullMeasure<Object> pull = new SimplePullMeasure<Object>() {
+		PullMeasure<Object> pull = new PullMeasure<Object>() {
 
 			@Override
 			public Object get() {

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
@@ -351,10 +351,7 @@ public class ListenerTimeMeasureTest {
 		MeasureListener<Object> wrapper50ms = measure
 				.wrapListener(original50ms);
 
-		MeasureListener<Object> original50msWithReset = new MeasureListener<Object>() {
-
-			@Override
-			public void measureGenerated(Object value) {
+		MeasureListener<Object> original50msWithReset = (Object value) -> {
 				try {
 					Thread.sleep(25);
 					measure.reset();
@@ -362,7 +359,6 @@ public class ListenerTimeMeasureTest {
 				} catch (InterruptedException e) {
 					throw new RuntimeException(e);
 				}
-			}
 		};
 		MeasureListener<Object> wrapper50msWithReset = measure
 				.wrapListener(original50msWithReset);

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/ListenerTimeMeasureTest.java
@@ -299,17 +299,10 @@ public class ListenerTimeMeasureTest {
 	}
 
 	@Test
-	@SuppressWarnings("serial")
 	public void testAdditionalKeyForWrappedManagerRejectAlreadyUsedKeys() {
 		ListenerTimeMeasure measure = new ListenerTimeMeasure();
 
-		PullMeasure<Object> pull = new PullMeasure<Object>() {
-
-			@Override
-			public Object get() {
-				return null;
-			}
-		};
+		PullMeasure<Object> pull = () -> null;
 		SimplePushMeasure<Object> push = new SimplePushMeasure<Object>();
 		SimpleMeasureManager wrapped = new SimpleMeasureManager();
 		wrapped.setPullMeasure(1, pull);

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/MeasureFactoryTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/MeasureFactoryTest.java
@@ -2,7 +2,6 @@ package org.uma.jmetal.measure.impl;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.uma.jmetal.measure.MeasureListener;
 import org.uma.jmetal.measure.PullMeasure;
 import org.uma.jmetal.measure.PushMeasure;
 
@@ -77,14 +76,8 @@ public class MeasureFactoryTest {
 		// register for notifications from now
 		final long start = System.currentTimeMillis();
 		final LinkedList<Long> timestamps = new LinkedList<>();
-		push.register(new MeasureListener<Integer>() {
-
-			@Override
-			public void measureGenerated(Integer value) {
-				// store the time spent since the registration
-				timestamps.add(System.currentTimeMillis() - start);
-			}
-		});
+		// store the time spent since the registration
+		push.register((value) -> timestamps.add(System.currentTimeMillis() - start));
 
 		// decide the number of notifications to wait for
 		/*
@@ -157,13 +150,7 @@ public class MeasureFactoryTest {
 
 		// register for notifications only from now
 		final LinkedList<Integer> timestamps = new LinkedList<>();
-		push.register(new MeasureListener<Integer>() {
-
-			@Override
-			public void measureGenerated(Integer value) {
-				timestamps.add(value);
-			}
-		});
+		push.register((value) -> timestamps.add(value));
 
 		// check no notifications are coming anymore
 		Thread.sleep(10 * period);
@@ -221,13 +208,7 @@ public class MeasureFactoryTest {
 
 		// register for notifications from now
 		final LinkedList<Integer> notified = new LinkedList<>();
-		push.register(new MeasureListener<Integer>() {
-
-			@Override
-			public void measureGenerated(Integer value) {
-				notified.add(value);
-			}
-		});
+		push.register((value) -> notified.add(value));
 
 		// check no change provide no notifications
 		Thread.sleep(10 * period);

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/MeasureFactoryTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/MeasureFactoryTest.java
@@ -211,8 +211,8 @@ public class MeasureFactoryTest {
 			throws InterruptedException {
 		// create a pull measure which changes only when we change the value of
 		// the array
-		final Integer[] value = { null };
-		PullMeasure<Integer> pull = () -> value[0];
+		final Integer[] pulledValue = { null };
+		PullMeasure<Integer> pull = () -> pulledValue[0];
 
 		// create the push measure
 		MeasureFactory factory = new MeasureFactory();
@@ -234,20 +234,20 @@ public class MeasureFactoryTest {
 		assertEquals(0, notified.size());
 
 		// check 1 change provides 1 notification with the correct value
-		value[0] = 56;
+		pulledValue[0] = 56;
 		Thread.sleep(10 * period);
 		assertEquals(1, notified.size());
 		assertEquals(56, (Object) notified.get(0));
 
 		// check 1 more change provides 1 more notification with the new value
-		value[0] = 43;
+		pulledValue[0] = 43;
 		Thread.sleep(10 * period);
 		assertEquals(2, notified.size());
 		assertEquals(56, (Object) notified.get(0));
 		assertEquals(43, (Object) notified.get(1));
 
 		// check 1 more change provides 1 more notification with the new value
-		value[0] = -43;
+		pulledValue[0] = -43;
 		Thread.sleep(10 * period);
 		assertEquals(3, notified.size());
 		assertEquals(56, (Object) notified.get(0));

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/MeasureFactoryTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/MeasureFactoryTest.java
@@ -46,7 +46,7 @@ public class MeasureFactoryTest {
 		 * ensure that it leads to a proper notification, so it is not ignored.
 		 */
 		final int maxExecutionTime = 5;
-		PullMeasure<Integer> pull = new SimplePullMeasure<Integer>() {
+		PullMeasure<Integer> pull = new PullMeasure<Integer>() {
 			private final Random rand = new Random();
 			private int count = 0;
 
@@ -134,7 +134,7 @@ public class MeasureFactoryTest {
 			throws InterruptedException {
 		// create a pull measure which is always different, thus leading to
 		// generate a notification at every check
-		PullMeasure<Integer> pull = new SimplePullMeasure<Integer>() {
+		PullMeasure<Integer> pull = new PullMeasure<Integer>() {
 
 			int count = 0;
 
@@ -177,7 +177,7 @@ public class MeasureFactoryTest {
 		// create a pull measure which is always different, thus leading to
 		// generate a notification at every check
 		final boolean[] isCalled = { false };
-		PullMeasure<Integer> pull = new SimplePullMeasure<Integer>() {
+		PullMeasure<Integer> pull = new PullMeasure<Integer>() {
 
 			int count = 0;
 
@@ -213,7 +213,8 @@ public class MeasureFactoryTest {
 		// create a pull measure which changes only when we change the value of
 		// the array
 		final Integer[] value = { null };
-		PullMeasure<Integer> pull = new SimplePullMeasure<Integer>() {
+		PullMeasure<Integer> pull = new PullMeasure<Integer>() {
+
 			@Override
 			public Integer get() {
 				return value[0];

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/MeasureFactoryTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/MeasureFactoryTest.java
@@ -207,19 +207,12 @@ public class MeasureFactoryTest {
 	}
 
 	@Test
-	@SuppressWarnings("serial")
 	public void testCreatePushFromPullNotifiesOnlyWhenValueChanged()
 			throws InterruptedException {
 		// create a pull measure which changes only when we change the value of
 		// the array
 		final Integer[] value = { null };
-		PullMeasure<Integer> pull = new PullMeasure<Integer>() {
-
-			@Override
-			public Integer get() {
-				return value[0];
-			}
-		};
+		PullMeasure<Integer> pull = () -> value[0];
 
 		// create the push measure
 		MeasureFactory factory = new MeasureFactory();

--- a/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/SimplePushMeasureTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/measure/impl/SimplePushMeasureTest.java
@@ -10,15 +10,8 @@ public class SimplePushMeasureTest {
 	@Test
 	public void testNotifiedWhenRegistered() {
 		final Integer[] lastReceived = { null };
-		MeasureListener<Integer> listener = new MeasureListener<Integer>() {
-
-			@Override
-			public void measureGenerated(Integer value) {
-				lastReceived[0] = value;
-			}
-		};
 		SimplePushMeasure<Integer> pusher = new SimplePushMeasure<Integer>();
-		pusher.register(listener);
+		pusher.register((value) -> lastReceived[0] = value);
 
 		pusher.push(3);
 		assertEquals(3, (Object) lastReceived[0]);
@@ -31,13 +24,7 @@ public class SimplePushMeasureTest {
 	@Test
 	public void testNotNotifiedWhenUnregistered() {
 		final Integer[] lastReceived = { null };
-		MeasureListener<Integer> listener = new MeasureListener<Integer>() {
-
-			@Override
-			public void measureGenerated(Integer value) {
-				lastReceived[0] = value;
-			}
-		};
+		MeasureListener<Integer> listener = (value) -> lastReceived[0] = value;
 		SimplePushMeasure<Integer> pusher = new SimplePushMeasure<Integer>();
 		pusher.register(listener);
 		pusher.unregister(listener);

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/naming/impl/SimpleDescribedEntityTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/naming/impl/SimpleDescribedEntityTest.java
@@ -45,21 +45,29 @@ public class SimpleDescribedEntityTest {
 	}
 
 	@Test
-	public void testDefaultDescriptionUsedForNamleOnlyConstructor() {
+	public void testNullNameForCompleteConstructorWithNullName() {
+		assertNull(new SimpleDescribedEntity(null, "Test").getName());
+	}
+
+	@Test
+	public void testNullDescriptionForCompleteConstructorWithNullDescription() {
+		assertNull(new SimpleDescribedEntity("Test", null).getDescription());
+	}
+
+	@Test
+	public void testNullNameForNameOnlyConstructorWithNullName() {
+		assertNull(new SimpleDescribedEntity(null).getName());
+	}
+
+	@Test
+	public void testDefaultDescriptionForNamleOnlyConstructor() {
 		String expected = new DescribedEntity() {}.getDescription();
 		String actual = new SimpleDescribedEntity("Test").getDescription();
 		assertEquals(expected, actual);
 	}
 
 	@Test
-	public void testDefaultDescriptionUsedForEmptyConstructor() {
-		String expected = new DescribedEntity() {}.getDescription();
-		String actual = new SimpleDescribedEntity().getDescription();
-		assertEquals(expected, actual);
-	}
-
-	@Test
-	public void testDefaultNameUsedForEmptyConstructor() {
+	public void testDefaultNameForEmptyConstructor() {
 		/*
 		 * This test is simplified one. If someone find out how to get exactly
 		 * the expected value without copy-pasting the default code (which can
@@ -68,5 +76,12 @@ public class SimpleDescribedEntityTest {
 		String name = new SimpleDescribedEntity().getName();
 		assertNotNull(name);
 		assertFalse(name.isEmpty());
+	}
+
+	@Test
+	public void testDefaultDescriptionForEmptyConstructor() {
+		String expected = new DescribedEntity() {}.getDescription();
+		String actual = new SimpleDescribedEntity().getDescription();
+		assertEquals(expected, actual);
 	}
 }

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/naming/impl/SimpleDescribedEntityTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/naming/impl/SimpleDescribedEntityTest.java
@@ -1,8 +1,9 @@
 package org.uma.jmetal.util.naming.impl;
 
 import org.junit.Test;
+import org.uma.jmetal.util.naming.DescribedEntity;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class SimpleDescribedEntityTest {
 
@@ -43,4 +44,29 @@ public class SimpleDescribedEntityTest {
 				description).getDescription());
 	}
 
+	@Test
+	public void testDefaultDescriptionUsedForNamleOnlyConstructor() {
+		String expected = new DescribedEntity() {}.getDescription();
+		String actual = new SimpleDescribedEntity("Test").getDescription();
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testDefaultDescriptionUsedForEmptyConstructor() {
+		String expected = new DescribedEntity() {}.getDescription();
+		String actual = new SimpleDescribedEntity().getDescription();
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testDefaultNameUsedForEmptyConstructor() {
+		/*
+		 * This test is simplified one. If someone find out how to get exactly
+		 * the expected value without copy-pasting the default code (which can
+		 * evolve), please consider improving this test.
+		 */
+		String name = new SimpleDescribedEntity().getName();
+		assertNotNull(name);
+		assertFalse(name.isEmpty());
+	}
 }

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/naming/impl/SimpleDescribedEntityTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/naming/impl/SimpleDescribedEntityTest.java
@@ -3,7 +3,6 @@ package org.uma.jmetal.util.naming.impl;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class SimpleDescribedEntityTest {
 
@@ -27,21 +26,6 @@ public class SimpleDescribedEntityTest {
 
 		entity.setDescription("abc");
 		assertEquals("abc", entity.getDescription());
-	}
-
-	class TestedClass extends SimpleDescribedEntity {
-	}
-
-	@Test
-	public void testClassNameWhenNoName() {
-		assertEquals(TestedClass.class.getSimpleName(),
-				new TestedClass().getName());
-	}
-
-	@Test
-	public void testNullDescriptionWhenNoDescription() {
-		assertNull(new SimpleDescribedEntity().getDescription());
-		assertNull(new SimpleDescribedEntity("name").getDescription());
 	}
 
 	@Test


### PR DESCRIPTION
Commits related to Java 8 adaptation (#166).

After playing around with lambdas and default methods, here are some commits. There is also a bit of analysis to share:
- default methods are nice to transform abstract classes into interfaces, which allows then to implements several of them instead of extending only one. However, if the abstract class needs internal variables, then it must remain abstract (interface can't have that, only `static final` variables). In other words, default methods can be used as long as the methods are relatively independent or stateless. There is probaly ways to hack that, but it seems to be the general way to go for them.
- lambdas can be used for any interface which meets the functional requirements: being an interface requiring to implement a single method. "Requiring to implement" is important, because the interface may define several methods but the ones having default methods do not count. For instance, I have revised the `DescribedEntity` interface to use default methods, so any interface extending it is completely free to implement or not there own methods (they should, but technically they can avoid it). Especially, `PullMeasure` and `QualityIndicator` adding a single method each, they can be used through lambdas. Without the default methods they couldn't, because they would need to implement 3 methods instead of 1. A counter example is `DensityEstimator`, which adds a single method but cannot be used through lambdas because it extends `SolutionAttribute`, which adds several methods with no default.

Other classes already usable as lambdas:
- `Distance`
- `ExperimentComponent`
- `Neighborhood`
- `AlgorithmBuilder`

I did not exploit lambdas for them in my commits because they are all used for defining classes. None have anonymous instances, which are the best candidates for using lambdas.