### PR TITLE
Add a test suite to focus on unit tests only.

### DIFF
--- a/jmetal-core/pom.xml
+++ b/jmetal-core/pom.xml
@@ -90,5 +90,11 @@
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.junit-toolbox</groupId>
+            <artifactId>junit-toolbox</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jmetal-core/src/test/java/org/uma/jmetal/UnitTestsOnlySuite.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/UnitTestsOnlySuite.java
@@ -1,0 +1,25 @@
+package org.uma.jmetal;
+
+import org.junit.runner.RunWith;
+
+import com.googlecode.junittoolbox.WildcardPatternSuite;
+import com.googlecode.junittoolbox.SuiteClasses;
+
+/*
+ * We use the WildcardPatternSuite to run one test after the other,
+ * so time-sensible tests are not impacted by the resource consumptions
+ * of other tests. If such tests happen to disappear from the unit tests,
+ * one can use ParallelSuite instead to go faster.
+ */
+@RunWith(WildcardPatternSuite.class)
+@SuiteClasses({ "**/*Test.class" })
+/**
+ * This suite allows for people who do not test through Maven to run only the
+ * unit tests (not the integration tests) to save a significant amount of time.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ *
+ */
+public class UnitTestsOnlySuite {
+
+}


### PR DESCRIPTION
For people who do not use Maven to run the tests.
This suite should not affect Maven testing.

If we make a run in Eclipse on the entire project, because the suite is also in the project the unit tests are run twice (automatically + because the suite is run too). But because doing so would also run the integration tests which are wa~y longer than unit tests from an order of magnitude, the impact on performance is negligible.

The only negative thing I see is that it appears like we have twice as much tests as we actually have. This is nice for the ego but deception strikes when you figure it out. But people should survive so it's OK. {^_°}