### PR TITLE
Fix CommandLineIndicatorRunner when normalizing fronts

### DIFF
--- a/jmetal-exec/src/main/java/org/uma/jmetal/qualityIndicator/CommandLineIndicatorRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/qualityIndicator/CommandLineIndicatorRunner.java
@@ -108,8 +108,9 @@ public class CommandLineIndicatorRunner {
     Front front = new ArrayFront(args[2]);
 
     if (normalize) {
-      referenceFront = new FrontNormalizer(referenceFront).normalize(referenceFront) ;
-      front = new FrontNormalizer(referenceFront).normalize(front) ;
+      FrontNormalizer frontNormalizer = new FrontNormalizer(referenceFront);
+      referenceFront = frontNormalizer.normalize(referenceFront);
+      front = frontNormalizer.normalize(front);
       JMetalLogger.logger.info("The fronts are NORMALIZED before computing the indicators"); ;
     } else {
       JMetalLogger.logger.info("The fronts are NOT NORMALIZED before computing the indicators") ;


### PR DESCRIPTION
The current code is normalizing just the reference Pareto front but no the obtained one. That is happening because it is using an already normalized front as the normalized.