### PR TITLE
Ignore mock type safety, following logics of other classes.

### DIFF
--- a/jmetal-core/src/test/java/org/uma/jmetal/util/archive/impl/NonDominatedSolutionListArchiveTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/archive/impl/NonDominatedSolutionListArchiveTest.java
@@ -23,6 +23,7 @@ public class NonDominatedSolutionListArchiveTest {
 
   @Test
   public void shouldConstructorAssignThePassedComparator() {
+    @SuppressWarnings("unchecked")
     DominanceComparator<IntegerSolution> comparator = mock(DominanceComparator.class) ;
 
     NonDominatedSolutionListArchive<IntegerSolution> archive ;


### PR DESCRIPTION
It was done that way in #139.