### PR TITLE
Added support for adding a Reference Point to a chart in the ChartContainer

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEAD.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEAD.java
@@ -13,14 +13,15 @@
 
 package org.uma.jmetal.algorithm.multiobjective.moead;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.uma.jmetal.algorithm.multiobjective.moead.util.MOEADUtils;
 import org.uma.jmetal.operator.CrossoverOperator;
 import org.uma.jmetal.operator.MutationOperator;
 import org.uma.jmetal.operator.impl.crossover.DifferentialEvolutionCrossover;
 import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.DoubleSolution;
-
-import java.util.List;
 
 /**
  * Class implementing the MOEA/D-DE algorithm described in :
@@ -87,6 +88,7 @@ public class MOEAD extends AbstractMOEAD<DoubleSolution> {
   }
 
   protected void initializePopulation() {
+    population = new ArrayList<>(populationSize);
     for (int i = 0; i < populationSize; i++) {
       DoubleSolution newSolution = (DoubleSolution)problem.createSolution();
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/WASFGAMeasures.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/WASFGAMeasures.java
@@ -27,9 +27,6 @@ public class WASFGAMeasures<S extends Solution<?>> extends WASFGA<S> implements 
     protected DurationMeasure durationMeasure;
     protected SimpleMeasureManager measureManager;
     protected BasicMeasure<List<S>> solutionListMeasure;
-//    protected BasicMeasure<Double> hypervolumeValue;
-//    protected BasicMeasure<Double> epsilonValue;
-//    protected Front referenceFront;
     
 	/**
 	 * Constructor
@@ -65,8 +62,6 @@ public class WASFGAMeasures<S extends Solution<?>> extends WASFGA<S> implements 
     @Override
     protected void updateProgress() {
         this.iterations.increment();
-//        hypervolumeValue.push(new PISAHypervolume<DoubleSolution>(referenceFront).evaluate(getResult()));
-//        epsilonValue.push(new Epsilon<DoubleSolution>(referenceFront).evaluate(getResult()));
         solutionListMeasure.push(getResult());
     }
     
@@ -88,19 +83,13 @@ public class WASFGAMeasures<S extends Solution<?>> extends WASFGA<S> implements 
         durationMeasure = new DurationMeasure();
         iterations = new CountingMeasure(0);
         solutionListMeasure = new BasicMeasure<>();
-//        hypervolumeValue = new BasicMeasure<>();
-//        epsilonValue = new BasicMeasure<>();
 
         measureManager = new SimpleMeasureManager();
         measureManager.setPullMeasure("currentExecutionTime", durationMeasure);
         measureManager.setPullMeasure("currentEvaluation", iterations);
-//        measureManager.setPullMeasure("hypervolume", hypervolumeValue);
-//        measureManager.setPullMeasure("epsilon", epsilonValue);
 
         measureManager.setPushMeasure("currentPopulation", solutionListMeasure);
         measureManager.setPushMeasure("currentEvaluation", iterations);
-//        measureManager.setPushMeasure("hypervolume", hypervolumeValue);
-//        measureManager.setPushMeasure("epsilon", epsilonValue);
     }
     
 	@Override public String getName() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/WASFGAMeasures.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/WASFGAMeasures.java
@@ -1,0 +1,118 @@
+package org.uma.jmetal.algorithm.multiobjective.wasfga;
+
+import java.util.List;
+
+import org.uma.jmetal.measure.Measurable;
+import org.uma.jmetal.measure.MeasureManager;
+import org.uma.jmetal.measure.impl.BasicMeasure;
+import org.uma.jmetal.measure.impl.CountingMeasure;
+import org.uma.jmetal.measure.impl.DurationMeasure;
+import org.uma.jmetal.measure.impl.SimpleMeasureManager;
+import org.uma.jmetal.operator.CrossoverOperator;
+import org.uma.jmetal.operator.MutationOperator;
+import org.uma.jmetal.operator.SelectionOperator;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
+
+/**
+ * Implementation of the preference based algorithm named WASF-GA on jMetal5.0
+ *
+ * @author Jorge Rodriguez
+ */
+@SuppressWarnings("serial")
+public class WASFGAMeasures<S extends Solution<?>> extends WASFGA<S> implements Measurable {
+
+    protected CountingMeasure iterations;
+    protected DurationMeasure durationMeasure;
+    protected SimpleMeasureManager measureManager;
+    protected BasicMeasure<List<S>> solutionListMeasure;
+//    protected BasicMeasure<Double> hypervolumeValue;
+//    protected BasicMeasure<Double> epsilonValue;
+//    protected Front referenceFront;
+    
+	/**
+	 * Constructor
+	 *
+	 * @param problem
+	 *            Problem to solve
+	 */
+	public WASFGAMeasures(Problem<S> problem,
+								int populationSize,
+								int maxIterations,
+								CrossoverOperator<S> crossoverOperator,
+								MutationOperator<S> mutationOperator,
+								SelectionOperator<List<S>, S> selectionOperator,
+								SolutionListEvaluator<S> evaluator,
+								List<Double> referencePoint) {
+
+		super(problem,
+		      populationSize,
+		      maxIterations,
+		      crossoverOperator,
+		      mutationOperator,
+		      selectionOperator,
+		      evaluator,
+		      referencePoint);
+		this.initMeasures();
+	}
+
+    @Override
+    protected void initProgress() {
+        this.iterations.reset();
+    }
+
+    @Override
+    protected void updateProgress() {
+        this.iterations.increment();
+//        hypervolumeValue.push(new PISAHypervolume<DoubleSolution>(referenceFront).evaluate(getResult()));
+//        epsilonValue.push(new Epsilon<DoubleSolution>(referenceFront).evaluate(getResult()));
+        solutionListMeasure.push(getResult());
+    }
+    
+    @Override
+    protected boolean isStoppingConditionReached() {
+        return this.iterations.get() >= maxIterations;
+    }
+
+    @Override
+    public void run() {
+        durationMeasure.reset();
+        durationMeasure.start();
+        super.run();
+        durationMeasure.stop();
+    }
+    
+    /* Measures code */
+    private void initMeasures() {
+        durationMeasure = new DurationMeasure();
+        iterations = new CountingMeasure(0);
+        solutionListMeasure = new BasicMeasure<>();
+//        hypervolumeValue = new BasicMeasure<>();
+//        epsilonValue = new BasicMeasure<>();
+
+        measureManager = new SimpleMeasureManager();
+        measureManager.setPullMeasure("currentExecutionTime", durationMeasure);
+        measureManager.setPullMeasure("currentEvaluation", iterations);
+//        measureManager.setPullMeasure("hypervolume", hypervolumeValue);
+//        measureManager.setPullMeasure("epsilon", epsilonValue);
+
+        measureManager.setPushMeasure("currentPopulation", solutionListMeasure);
+        measureManager.setPushMeasure("currentEvaluation", iterations);
+//        measureManager.setPushMeasure("hypervolume", hypervolumeValue);
+//        measureManager.setPushMeasure("epsilon", epsilonValue);
+    }
+    
+	@Override public String getName() {
+		return "WASFGA" ;
+	}
+
+	@Override public String getDescription() {
+		return "Weighting Achievement Scalarizing Function Genetic Algorithm. Version using Measures" ;
+	}
+
+    @Override
+    public MeasureManager getMeasureManager() {
+        return this.measureManager;
+    }
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/chartcontainer/ChartContainer.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/chartcontainer/ChartContainer.java
@@ -18,6 +18,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +61,7 @@ public class ChartContainer {
     public ChartContainer(String name, int delay) {
         this.name = name;
         this.delay = delay;
-        this.charts = new HashMap<String, XYChart>();
+        this.charts = new LinkedHashMap<String, XYChart>();
         this.iterations = new HashMap<String, List<Integer>>();
         this.indicatorValues = new HashMap<String, List<Double>>();
     }
@@ -69,15 +70,15 @@ public class ChartContainer {
         this.SetFrontChart(objective1, objective2, null);
     }
 
-    public void SetFrontChart(int objective1, int objective2, String referenceFront) throws FileNotFoundException {
+    public void SetFrontChart(int objective1, int objective2, String referenceFrontFileName) throws FileNotFoundException {
         this.objective1 = objective1;
         this.objective2 = objective2;
         this.frontChart = new XYChartBuilder().xAxisTitle("Objective " + this.objective1)
                 .yAxisTitle("Objective " + this.objective2).build();
         this.frontChart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Scatter).setMarkerSize(5);
 
-        if (referenceFront != null) {
-            this.DisplayReferenceFront(referenceFront);
+        if (referenceFrontFileName != null) {
+            this.DisplayReferenceFront(referenceFrontFileName);
         }
 
         double[] xData = new double[] { 0 };
@@ -85,7 +86,16 @@ public class ChartContainer {
         XYSeries frontChartSeries = this.frontChart.addSeries(this.name, xData, yData);
         frontChartSeries.setMarkerColor(Color.blue);
 
-        this.charts.put(this.name, this.frontChart);
+        this.charts.put("Front", this.frontChart);
+    }
+    
+    public void SetReferencePoint(List<Double> referencePoint){
+        double rp1 = referencePoint.get(this.objective1);
+        double rp2 = referencePoint.get(this.objective2);
+        XYSeries referencePointSeries = this.frontChart.addSeries("Reference Point ["+ rp1 + ", " + rp2 + "]",
+                                                                  new double[] { rp1 },
+                                                                  new double[] { rp2 });
+        referencePointSeries.setMarkerColor(Color.green);
     }
 
     public void SetVarChart(int variable1, int variable2) {
@@ -101,7 +111,7 @@ public class ChartContainer {
         XYSeries varChartSeries = this.varChart.addSeries(this.name, xData, yData);
         varChartSeries.setMarkerColor(Color.blue);
 
-        this.charts.put(this.name + "_VAR", this.varChart);
+        this.charts.put("VAR", this.varChart);
     }
 
     public void InitChart() {
@@ -110,19 +120,18 @@ public class ChartContainer {
     }
 
     public void UpdateFrontCharts(List<DoubleSolution> solutionList) {
-        double[] xData;
-        double[] yData;
-
         if (this.frontChart != null) {
-            xData = this.getSolutionsForObjective(solutionList, this.objective1);
-            yData = this.getSolutionsForObjective(solutionList, this.objective2);
-            this.frontChart.updateXYSeries(this.name, xData, yData, null);
+            this.frontChart.updateXYSeries(this.name,
+                                           this.getSolutionsForObjective(solutionList, this.objective1),
+                                           this.getSolutionsForObjective(solutionList, this.objective2),
+                                           null);
         }
 
         if (this.varChart != null) {
-            xData = this.getVariableValues(solutionList, this.variable1);
-            yData = this.getVariableValues(solutionList, this.variable2);
-            this.varChart.updateXYSeries(this.name, xData, yData, null);
+            this.varChart.updateXYSeries(this.name,
+                                         this.getVariableValues(solutionList, this.variable1),
+                                         this.getVariableValues(solutionList, this.variable2),
+                                         null);
         }
     }
 

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/DMOPSOMeasuresRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/DMOPSOMeasuresRunner.java
@@ -16,7 +16,6 @@ package org.uma.jmetal.runner.multiobjective;
 import java.util.List;
 
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
-import org.uma.jmetal.algorithm.multiobjective.dmopso.DMOPSO;
 import org.uma.jmetal.algorithm.multiobjective.dmopso.DMOPSO.FunctionType;
 import org.uma.jmetal.algorithm.multiobjective.dmopso.DMOPSOMeasures;
 import org.uma.jmetal.measure.MeasureListener;
@@ -51,7 +50,7 @@ public class DMOPSOMeasuresRunner extends AbstractAlgorithmRunner {
      */
     public static void main(String[] args) throws Exception {
         DoubleProblem problem;
-        DMOPSO algorithm;
+        DMOPSOMeasures algorithm;
 
         String referenceParetoFront = "";
 
@@ -63,7 +62,7 @@ public class DMOPSOMeasuresRunner extends AbstractAlgorithmRunner {
             referenceParetoFront = args[1];
         } else {
             problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT1";
-            referenceParetoFront = "jmetal-problem/src/test/resources/pareto_fronts/ZDT1.pf";
+            referenceParetoFront = "../jmetal-problem/src/test/resources/pareto_fronts/ZDT1.pf";
         }
 
         problem = (DoubleProblem) ProblemUtils.<DoubleSolution>loadProblem(problemName);
@@ -71,7 +70,7 @@ public class DMOPSOMeasuresRunner extends AbstractAlgorithmRunner {
         algorithm = new DMOPSOMeasures(problem, 100, 150, 0.0, 0.1, 0.0, 1.0, 1.5, 2.5, 1.5, 2.5, 0.1, 0.4, -1.0, -1.0,
                 FunctionType.TCHE, "MOEAD_Weights", 2);
 
-        ((DMOPSOMeasures) algorithm).setReferenceFront(new ArrayFront(referenceParetoFront));
+        algorithm.setReferenceFront(new ArrayFront(referenceParetoFront));
 
         /* Measure management */
         MeasureManager measureManager = ((DMOPSOMeasures) algorithm).getMeasureManager();

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/WASFGAMeasuresRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/WASFGAMeasuresRunner.java
@@ -1,0 +1,162 @@
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package org.uma.jmetal.runner.multiobjective;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.knowm.xchart.BitmapEncoder.BitmapFormat;
+import org.uma.jmetal.algorithm.Algorithm;
+import org.uma.jmetal.algorithm.multiobjective.wasfga.WASFGAMeasures;
+import org.uma.jmetal.measure.MeasureListener;
+import org.uma.jmetal.measure.MeasureManager;
+import org.uma.jmetal.measure.impl.BasicMeasure;
+import org.uma.jmetal.measure.impl.CountingMeasure;
+import org.uma.jmetal.operator.CrossoverOperator;
+import org.uma.jmetal.operator.MutationOperator;
+import org.uma.jmetal.operator.SelectionOperator;
+import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
+import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
+import org.uma.jmetal.operator.impl.selection.BinaryTournamentSelection;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.runner.AbstractAlgorithmRunner;
+import org.uma.jmetal.solution.DoubleSolution;
+import org.uma.jmetal.util.AlgorithmRunner;
+import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.ProblemUtils;
+import org.uma.jmetal.util.chartcontainer.ChartContainer;
+import org.uma.jmetal.util.comparator.RankingAndCrowdingDistanceComparator;
+import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
+
+public class WASFGAMeasuresRunner extends AbstractAlgorithmRunner {
+  /**
+   * @param args Command line arguments.
+   * @throws JMetalException
+ * @throws IOException 
+   */
+  public static void main(String[] args) throws JMetalException, IOException {
+    Problem<DoubleSolution> problem;
+    Algorithm<List<DoubleSolution>> algorithm;
+    CrossoverOperator<DoubleSolution> crossover;
+    MutationOperator<DoubleSolution> mutation;
+    SelectionOperator<List<DoubleSolution>, DoubleSolution> selection;
+    String referenceParetoFront = "" ;
+    List<Double> referencePoint = null;
+
+    String problemName ;
+    if (args.length == 1) {
+      problemName = args[0];
+    } else if (args.length == 2) {
+      problemName = args[0] ;
+      referenceParetoFront = args[1] ;
+    } else {
+      problemName = "org.uma.jmetal.problem.multiobjective.zdt.ZDT1";
+      referenceParetoFront = "../jmetal-problem/src/test/resources/pareto_fronts/ZDT1.pf" ;
+    }
+
+    problem = ProblemUtils.<DoubleSolution> loadProblem(problemName);
+    
+    referencePoint = new ArrayList<>();
+    referencePoint.add(0.5);
+    referencePoint.add(0.6);
+
+    double crossoverProbability = 0.9 ;
+    double crossoverDistributionIndex = 20.0 ;
+    crossover = new SBXCrossover(crossoverProbability, crossoverDistributionIndex) ;
+
+    double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
+    double mutationDistributionIndex = 20.0 ;
+    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+
+    selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
+
+    algorithm = new WASFGAMeasures<DoubleSolution>(problem, 100, 250, crossover, mutation, selection,new SequentialSolutionListEvaluator<DoubleSolution>(),referencePoint) ;
+
+    
+    /* Measure management */
+    MeasureManager measureManager = ((WASFGAMeasures<DoubleSolution>) algorithm).getMeasureManager();
+
+    BasicMeasure<List<DoubleSolution>> solutionListMeasure = (BasicMeasure<List<DoubleSolution>>) measureManager
+            .<List<DoubleSolution>>getPushMeasure("currentPopulation");
+    CountingMeasure iterationMeasure = (CountingMeasure) measureManager.<Long>getPushMeasure("currentEvaluation");
+
+    ChartContainer chart = new ChartContainer(algorithm.getName(), 200);
+    chart.SetFrontChart(0, 1, referenceParetoFront);
+    chart.SetReferencePoint(referencePoint);
+    chart.SetVarChart(0, 1);
+    chart.InitChart();
+
+    solutionListMeasure.register(new ChartListener(chart));
+    iterationMeasure.register(new IterationListener(chart));
+
+    /* End of measure management */
+    
+    
+    AlgorithmRunner algorithmRunner = new AlgorithmRunner.Executor(algorithm)
+            .execute() ;
+
+    chart.SaveChart("WASFGA", BitmapFormat.PNG);
+    List<DoubleSolution> population = algorithm.getResult() ;
+    long computingTime = algorithmRunner.getComputingTime() ;
+
+    JMetalLogger.logger.info("Total execution time: " + computingTime + "ms");
+
+    printFinalSolutionSet(population);
+    if (!referenceParetoFront.equals("")) {
+      printQualityIndicators(population, referenceParetoFront) ;
+    }
+  }
+  
+  private static class ChartListener implements MeasureListener<List<DoubleSolution>> {
+      private ChartContainer chart;
+      private int iteration = 0;
+
+      public ChartListener(ChartContainer chart) {
+          this.chart = chart;
+          this.chart.getFrontChart().setTitle("Iteration: " + this.iteration);
+      }
+
+      private void refreshChart(List<DoubleSolution> solutionList) {
+          if (this.chart != null) {
+              iteration++;
+              this.chart.getFrontChart().setTitle("Iteration: " + this.iteration);
+              this.chart.UpdateFrontCharts(solutionList);
+              this.chart.RefreshCharts();
+          }
+      }
+
+      @Override
+      synchronized public void measureGenerated(List<DoubleSolution> solutions) {
+          refreshChart(solutions);
+      }
+  }
+
+  private static class IterationListener implements MeasureListener<Long> {
+      ChartContainer chart;
+
+      public IterationListener(ChartContainer chart) {
+          this.chart = chart;
+          this.chart.getFrontChart().setTitle("Iteration: " + 0);
+      }
+
+      @Override
+      synchronized public void measureGenerated(Long iteration) {
+          if (this.chart != null) {
+              this.chart.getFrontChart().setTitle("Iteration: " + iteration);
+          }
+      }
+  }
+}


### PR DESCRIPTION
- Fixed a "bug" in MOEAD, population should be reset in the initializePopulation so it is reset when running several independent runs of MOEAD in a experiment.
- A Reference Point can be added to the Front chart, see example in WASFGAMeasuresRunner.
- Tidy up ChartContainer code.