### PR TITLE
Minor edit to JavaDoc / test name

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/GenericSolutionAttribute.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/GenericSolutionAttribute.java
@@ -5,7 +5,7 @@ import org.uma.jmetal.util.solutionattribute.SolutionAttribute;
 
 /**
  * Generic class for implementing {@link SolutionAttribute} classes. By default, the identifier
- * of a {@link SolutionAttribute} is the class name, but it can be set to a different value
+ * of a {@link SolutionAttribute} is the class object, but it can be set to a different value
  * when constructing an instance.
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/solutionattribute/impl/GenericSolutionAttributeTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/solutionattribute/impl/GenericSolutionAttributeTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
  */
 public class GenericSolutionAttributeTest {
   @Test
-  public void shouldDefaultConstructorCreateASolutionAttributedWithAnIdentifierEqualToTheClassName() {
+  public void shouldDefaultConstructorCreateASolutionAttributedWithAnIdentifierEqualToTheClassObject() {
     GenericSolutionAttribute<?, ?> genericSolutionAttribute ;
     genericSolutionAttribute = new GenericSolutionAttribute<>() ;
 


### PR DESCRIPTION
`identifier` is set to the class object `this.getClass()` rather than the class name, `this.getClass().getName()`. Edited the JavaDoc comment and test name to reflect this.