### PR TITLE
GWASFGA and WASFGA issues.

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/GWASFGA.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/GWASFGA.java
@@ -62,7 +62,6 @@ public class GWASFGA<S extends Solution<?>> extends WASFGA<S> {
   }
 
   public AbstractUtilityFunctionsSet<S> createUtilityFunction(List<Double> referencePoint, double [][] weights) {
-    weights = WeightVector.invertWeights(weights,true);
     ASFWASFGA<S> aux = new ASFWASFGA<>(weights,referencePoint);
 
     return aux;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/GWASFGA.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/GWASFGA.java
@@ -30,32 +30,35 @@ public class GWASFGA<S extends Solution<?>> extends WASFGA<S> {
 
   public GWASFGA(Problem<S> problem, int populationSize, int maxIterations, CrossoverOperator<S> crossoverOperator,
                  MutationOperator<S> mutationOperator, SelectionOperator<List<S>, S> selectionOperator,
-                 SolutionListEvaluator<S> evaluator, double epsilon) {
+                 SolutionListEvaluator<S> evaluator, double epsilon, String weightVectorsFileName) {
     super(problem, populationSize, maxIterations, crossoverOperator, mutationOperator, selectionOperator, evaluator, epsilon,
-        null);
+            null, weightVectorsFileName);
+
     setMaxPopulationSize(populationSize);
 
-    WeightVector weightVector = new WeightVector() ;
-    double [][] weights =  weightVector.initUniformWeights2D(0.005, getMaxPopulationSize());
-
-    int halfVectorSize = weights.length  / 2;
-    int evenVectorsSize    = (weights.length%2==0) ? halfVectorSize : (halfVectorSize+1);
-    int oddVectorsSize     = halfVectorSize;
+    int halfVectorSize = super.weights.length  / 2;
+    int evenVectorsSize    = (super.weights.length%2==0) ? halfVectorSize : (halfVectorSize+1);
 
     double [][] evenVectors = new double[evenVectorsSize][getProblem().getNumberOfObjectives()];
-    double [][] oddVectors = new double[oddVectorsSize][getProblem().getNumberOfObjectives()];
+    double [][] oddVectors = new double[halfVectorSize][getProblem().getNumberOfObjectives()];
 
     int index = 0;
-    for (int i = 0; i < weights.length; i = i + 2)
-      evenVectors[index++] = weights[i];
+    for (int i = 0; i < super.weights.length; i = i + 2)
+      evenVectors[index++] = super.weights[i];
 
     index = 0;
-    for (int i = 1; i < weights.length; i = i + 2)
-      oddVectors[index++] = weights[i];
+    for (int i = 1; i < super.weights.length; i = i + 2)
+      oddVectors[index++] = super.weights[i];
 
     this.achievementScalarizingNadir  =  createUtilityFunction(this.getNadirPoint(), evenVectors);
     this.achievementScalarizingUtopia =  createUtilityFunction(this.getReferencePoint(), oddVectors);
+  }
 
+  public GWASFGA(Problem<S> problem, int populationSize, int maxIterations, CrossoverOperator<S> crossoverOperator,
+                 MutationOperator<S> mutationOperator, SelectionOperator<List<S>, S> selectionOperator,
+                 SolutionListEvaluator<S> evaluator, double epsilon) {
+    this(problem, populationSize, maxIterations, crossoverOperator, mutationOperator, selectionOperator, evaluator, epsilon,
+             "");
   }
 
   public AbstractUtilityFunctionsSet<S> createUtilityFunction(List<Double> referencePoint, double [][] weights) {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/util/GWASFGARanking.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/util/GWASFGARanking.java
@@ -25,7 +25,7 @@ public class GWASFGARanking<S extends Solution<?>> extends GenericSolutionAttrib
 
   @Override
   public Ranking<S> computeRanking(List<S> population) {
-
+	//TO REFACTOR
 	this.numberOfRanks 		= (population.size() + 1) / (this.utilityFunctionsUtopia.getSize() + this.utilityFunctionsNadir.getSize());	
 	
 	this.rankedSubpopulations = new ArrayList<>(this.numberOfRanks);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/util/GWASFGARanking.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/util/GWASFGARanking.java
@@ -25,54 +25,54 @@ public class GWASFGARanking<S extends Solution<?>> extends GenericSolutionAttrib
 
   @Override
   public Ranking<S> computeRanking(List<S> population) {
-	//TO REFACTOR
-	this.numberOfRanks 		= (population.size() + 1) / (this.utilityFunctionsUtopia.getSize() + this.utilityFunctionsNadir.getSize());	
-	
-	this.rankedSubpopulations = new ArrayList<>(this.numberOfRanks);
-	
-	for (int i = 0; i < this.numberOfRanks; i++) {
-		this.rankedSubpopulations.add(new ArrayList<S>());
-	}
-	List<S> temporalList 	= new LinkedList<>();
-	temporalList.addAll(population);
-	  
-	
-	for (int idx = 0; idx < this.numberOfRanks; idx++) {
-		for (int weigth = 0; weigth < this.utilityFunctionsUtopia.getSize(); weigth++) {
-			int toRemoveIdx = 0;
-			double minimumValue = this.utilityFunctionsUtopia.evaluate(temporalList.get(0), weigth);			
-			for (int solutionIdx = 1; solutionIdx < temporalList.size(); solutionIdx++) {
-				double value = this.utilityFunctionsUtopia.evaluate(temporalList.get(solutionIdx), weigth);
-				
-				if (value < minimumValue) {
-					minimumValue = value;
-					toRemoveIdx = solutionIdx;
-				}
-			}
-		
-			S solutionToInsert = temporalList.remove(toRemoveIdx);
-			setAttribute(solutionToInsert, idx);
-			this.rankedSubpopulations.get(idx).add(solutionToInsert);
-		}
-		for (int weigth = 0; weigth < this.utilityFunctionsNadir.getSize(); weigth++) {
-			int toRemoveIdx = 0;
-			double minimumValue = this.utilityFunctionsNadir.evaluate(temporalList.get(0), weigth);			
-			for (int solutionIdx = 1; solutionIdx < temporalList.size(); solutionIdx++) {
-				double value = this.utilityFunctionsNadir.evaluate(temporalList.get(solutionIdx), weigth);
-				
-				if (value < minimumValue) {
-					minimumValue = value;
-					toRemoveIdx = solutionIdx;
-				}
-			}
-		
-			S solutionToInsert = temporalList.remove(toRemoveIdx);
-			setAttribute(solutionToInsert, idx);
-			this.rankedSubpopulations.get(idx).add(solutionToInsert);
-		}
-		
-	}
-	return this;
+      int toRemoveIdx, numberOfWeights;
+      double minimumValue, value;
+      S solutionToInsert;
+      List<S> temporalList;
+
+      this.numberOfRanks = (population.size() + 1) / (this.utilityFunctionsUtopia.getSize() + this.utilityFunctionsNadir.getSize());
+
+      this.rankedSubpopulations = new ArrayList<>(this.numberOfRanks);
+
+      for (int i = 0; i < this.numberOfRanks; i++) {
+          this.rankedSubpopulations.add(new ArrayList<S>());
+      }
+      temporalList = new LinkedList<>();
+      temporalList.addAll(population);
+
+      numberOfWeights = this.utilityFunctionsUtopia.getSize() + this.utilityFunctionsNadir.getSize();
+      for (int idx = 0; idx < this.numberOfRanks; idx++) {
+          for (int weight = 0; weight < numberOfWeights/2; weight++) {
+              toRemoveIdx = 0;
+              minimumValue = this.utilityFunctionsUtopia.evaluate(temporalList.get(0), weight);
+              for (int solutionIdx = 1; solutionIdx < temporalList.size(); solutionIdx++) {
+                  value = this.utilityFunctionsUtopia.evaluate(temporalList.get(solutionIdx), weight);
+
+                  if (value < minimumValue) {
+                      minimumValue = value;
+                      toRemoveIdx = solutionIdx;
+                  }
+              }
+              solutionToInsert = temporalList.remove(toRemoveIdx);
+              setAttribute(solutionToInsert, idx);
+              this.rankedSubpopulations.get(idx).add(solutionToInsert);
+
+              toRemoveIdx = 0;
+              minimumValue = this.utilityFunctionsNadir.evaluate(temporalList.get(0), weight);
+              for (int solutionIdx = 1; solutionIdx < temporalList.size(); solutionIdx++) {
+                  value = this.utilityFunctionsNadir.evaluate(temporalList.get(solutionIdx), weight);
+
+                  if (value < minimumValue) {
+                      minimumValue = value;
+                      toRemoveIdx = solutionIdx;
+                  }
+              }
+              solutionToInsert = temporalList.remove(toRemoveIdx);
+              setAttribute(solutionToInsert, idx);
+              this.rankedSubpopulations.get(idx).add(solutionToInsert);
+          }
+      }
+      return this;
   }
 
   @Override

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/WASFGA.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/WASFGA.java
@@ -39,10 +39,10 @@ public class WASFGA<S extends Solution<?>> extends AbstractMOMBI<S> implements
 	protected int evaluations;
 	protected Normalizer normalizer;
 	protected double epsilon ;
+	protected double[][] weights;
 	
-	final AbstractUtilityFunctionsSet<S> achievementScalarizingFunction;
-	List<Double> interestPoint = null;
-
+	private final AbstractUtilityFunctionsSet<S> achievementScalarizingFunction;
+	private List<Double> interestPoint = null;
 	private String weightVectorsFileName = "" ;
 
 	/**
@@ -98,10 +98,19 @@ public class WASFGA<S extends Solution<?>> extends AbstractMOMBI<S> implements
 
 	public AbstractUtilityFunctionsSet<S> createUtilityFunction() {
 		WeightVector weightVector = new WeightVector() ;
-		double [][] weights ;
+
+		//If a file with weight vectors is not given as parameter, weights are calculated or read from the resources file of jMetal
 		if ("".equals(this.weightVectorsFileName)) {
-			weights = weightVector.initUniformWeights2D(epsilon, getMaxPopulationSize());
-		} else {
+			//For two biobjective problems weights are computed
+			if (problem.getNumberOfObjectives() == 2) {
+				weights = weightVector.initUniformWeights2D(epsilon, getMaxPopulationSize());
+			}
+			//For more than two objectives, weights are read from the resources file of jMetal
+			else {
+				String dataFileName = "W" + problem.getNumberOfObjectives() + "D_" + getMaxPopulationSize() + ".dat";
+				weights = weightVector.getWeightsFromResourcesInJMetal("MOEAD_Weights/" + dataFileName);
+			}
+		} else { //If a file with weight vectors is given as parameter, weights are read from that file
 			weights = weightVector.getWeightsFromFile(this.weightVectorsFileName) ;
 		}
 		weights = WeightVector.invertWeights(weights,true);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/util/WeightVector.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/util/WeightVector.java
@@ -3,6 +3,7 @@ package org.uma.jmetal.algorithm.multiobjective.wasfga.util;
 import org.uma.jmetal.util.JMetalException;
 
 import java.io.BufferedReader;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.StringTokenizer;
@@ -47,6 +48,52 @@ public class WeightVector {
 		
 		return weights;
 	}
+
+	/**
+	 * Read a set of weight vector from a file in the resources folder in jMetal
+	 *
+	 * @param filePath The name of file in the resources folder of jMetal
+	 * @return A set of weight vectors
+	 */
+	public double[][] getWeightsFromResourcesInJMetal(String filePath) {
+		double[][] weights = new double[0][0];
+
+		Vector<double[]> listOfWeights = new Vector<double[]>();
+
+		try {
+			InputStream in = getClass().getResourceAsStream("/" + filePath);
+			InputStreamReader isr = new InputStreamReader(in);
+			BufferedReader br = new BufferedReader(isr);
+
+			int numberOfObjectives = 0;
+			int j = 0;
+			String aux = br.readLine();
+			while (aux != null) {
+				StringTokenizer st = new StringTokenizer(aux);
+				j = 0;
+				numberOfObjectives = st.countTokens();
+				double[] weight = new double[numberOfObjectives];
+
+				while (st.hasMoreTokens()) {
+					weight[j] = new Double(st.nextToken());
+					j++;
+				}
+
+				listOfWeights.add(weight);
+				aux = br.readLine();
+			}
+			br.close();
+
+			weights = new double[listOfWeights.size()][numberOfObjectives];
+			for (int indexWeight = 0; indexWeight < listOfWeights.size(); indexWeight++) {
+				System.arraycopy(listOfWeights.get(indexWeight), 0, weights[indexWeight], 0, numberOfObjectives);
+			}
+		} catch (Exception e) {
+			throw new JMetalException("getWeightsFromResourcesInJMetal: failed when reading for file: " + filePath + "", e);
+		}
+
+		return weights;
+	}
 	
 	/**
 	 * Read a set of weight vector from a file
@@ -60,16 +107,11 @@ public class WeightVector {
 		Vector<double[]> listOfWeights = new Vector<double[]>();
 		
 		try {
-			InputStream in = getClass().getResourceAsStream("/" + filePath);
-			InputStreamReader isr = new InputStreamReader(in);
-			BufferedReader br = new BufferedReader(isr);
-			
-    	/*
-      // Open the file
-      FileInputStream fis = new FileInputStream(filePath);
-      InputStreamReader isr = new InputStreamReader(fis);
-      BufferedReader br = new BufferedReader(isr);
-      */
+
+			  // Open the file
+			  FileInputStream fis = new FileInputStream(filePath);
+			  InputStreamReader isr = new InputStreamReader(fis);
+			  BufferedReader br = new BufferedReader(isr);
 			
 			int numberOfObjectives = 0;
 			int j = 0;
@@ -81,7 +123,7 @@ public class WeightVector {
 				double[] weight = new double[numberOfObjectives];
 				
 				while (st.hasMoreTokens()) {
-					weight[j] = (new Double(st.nextToken())).doubleValue();
+					weight[j] = new Double(st.nextToken());
 					j++;
 				}
 				
@@ -92,9 +134,7 @@ public class WeightVector {
 			
 			weights = new double[listOfWeights.size()][numberOfObjectives];
 			for (int indexWeight = 0; indexWeight < listOfWeights.size(); indexWeight++) {
-				for (int indexOfObjective = 0; indexOfObjective < numberOfObjectives; indexOfObjective++) {
-					weights[indexWeight][indexOfObjective] = listOfWeights.get(indexWeight)[indexOfObjective];
-				}
+				System.arraycopy(listOfWeights.get(indexWeight), 0, weights[indexWeight], 0, numberOfObjectives);
 			}
 		} catch (Exception e) {
 			throw new JMetalException("getWeightsFromFile: failed when reading for file: " + filePath + "", e);


### PR DESCRIPTION
I am applying a pull request because I have fixed some small issues in the GWASFGA and WASFGA algorithms. 

- GWASFGA classified individuals regarding the odd weight vectors using the utopian point and, after that, regarding the even weight vectors and the nadir point. However, in order to perform as it is described in the original paper, the algorithm has to alternate between the utopian and the nadir points when classifying individuals into fronts. I have modified GWASFGA accordingly.

- The previous implementation of WASFGA always generated two-dimensional weight vectors whether a file with weight vectors was not given as parameter. Therefore, it did not solve correctly problems with three or more objectives when a file containing weight vectors was not specified. After minor changes, now, by default, WASFGA (1) generates weight vectors for biobjective problems and (2) reads weight vectors from the resources folder of jMetal for problems with more than two objective functions. If a file containing weight vectors is given as parameter, WASFGA reads weight vectors from that file.

- GWASFGA extends WASFGA, and WASFGA loads the weight vectors in their constructor. However, GWASFGA also loaded weight vectors in their constructor what was already done by the extended class. I have removed the generation/load of weight vectors from GWASFGA.

- I also have updated the constructors of GWASFGA to add an optional parameter. This parameter is similar to the existing in WASFGA and it allows to load weight vectors from an external file.


I have carried out some tests for two and three objectives problems and both algorithms are working fine.

Cheers,
Rubén.