### PR TITLE
Fixing bugs in the experiment framework and in the AbstractGenericSolution

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/Experiment.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/Experiment.java
@@ -23,7 +23,6 @@ public class Experiment<S extends Solution<?>, Result> {
 	private String outputParetoSetFileName;
 	private int independentRuns;
 
-  private List<String> referenceFrontFileNames ;
   private String referenceFrontDirectory;
 
   private List<GenericIndicator<S>> indicatorList ;
@@ -41,7 +40,6 @@ public class Experiment<S extends Solution<?>, Result> {
     this.outputParetoSetFileName = builder.getOutputParetoSetFileName() ;
     this.numberOfCores = builder.getNumberOfCores() ;
     this.referenceFrontDirectory = builder.getReferenceFrontDirectory() ;
-    this.referenceFrontFileNames = builder.getReferenceFrontFileNames() ;
     this.indicatorList = builder.getIndicatorList() ;
   }
 
@@ -78,10 +76,6 @@ public class Experiment<S extends Solution<?>, Result> {
     return numberOfCores ;
   }
 
-  public List<String> getReferenceFrontFileNames() {
-    return referenceFrontFileNames;
-  }
-
   public String getReferenceFrontDirectory() {
     return referenceFrontDirectory;
   }
@@ -93,10 +87,6 @@ public class Experiment<S extends Solution<?>, Result> {
   /* Setters */
   public void setReferenceFrontDirectory(String referenceFrontDirectory) {
     this.referenceFrontDirectory = referenceFrontDirectory ;
-  }
-
-  public void setReferenceFrontFileNames(List<String> referenceFrontFileNames) {
-    this.referenceFrontFileNames = referenceFrontFileNames ;
   }
 
   public void setAlgorithmList(List<ExperimentAlgorithm<S, Result>> algorithmList) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentBuilder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentBuilder.java
@@ -17,7 +17,6 @@ public class ExperimentBuilder<S extends Solution<?>, Result> {
   private final String experimentName ;
   private List<ExperimentAlgorithm<S, Result>> algorithmList;
   private List<ExperimentProblem<S>> problemList;
-  private List<String> referenceFrontFileNames ;
   private String referenceFrontDirectory;
   private String experimentBaseDirectory;
   private String outputParetoFrontFileName;
@@ -32,7 +31,6 @@ public class ExperimentBuilder<S extends Solution<?>, Result> {
     this.experimentName = experimentName ;
     this.independentRuns = 1 ;
     this.numberOfCores = 1 ;
-    this.referenceFrontFileNames = null ;
     this.referenceFrontDirectory = null ;
   }
 
@@ -56,12 +54,6 @@ public class ExperimentBuilder<S extends Solution<?>, Result> {
 
   public ExperimentBuilder<S, Result> setReferenceFrontDirectory(String referenceFrontDirectory) {
     this.referenceFrontDirectory = referenceFrontDirectory ;
-
-    return this ;
-  }
-
-  public ExperimentBuilder<S, Result> setReferenceFrontFileNames(List<String> referenceFrontFileNames) {
-    this.referenceFrontFileNames = referenceFrontFileNames ;
 
     return this ;
   }
@@ -132,10 +124,6 @@ public class ExperimentBuilder<S extends Solution<?>, Result> {
 
   public int getNumberOfCores() {
     return numberOfCores;
-  }
-
-  public List<String> getReferenceFrontFileNames() {
-    return referenceFrontFileNames;
   }
 
   public String getReferenceFrontDirectory() {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoFront.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoFront.java
@@ -79,7 +79,6 @@ public class GenerateReferenceParetoFront implements ExperimentComponent{
           nonDominatedSolutionArchive.getSolutionList()) ;
     }
 
-    experiment.setReferenceFrontFileNames(referenceFrontFileNames);
   }
 
   private File createOutputDirectory(String outputDirectoryName) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoSetAndFrontFromDoubleSolutions.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoSetAndFrontFromDoubleSolutions.java
@@ -77,7 +77,6 @@ public class GenerateReferenceParetoSetAndFrontFromDoubleSolutions implements Ex
       writeFilesWithTheSolutionsContributedByEachAlgorithm(outputDirectoryName, problem, nonDominatedSolutions) ;
     }
 
-    experiment.setReferenceFrontFileNames(referenceFrontFileNames);
   }
 
   private void writeFilesWithTheSolutionsContributedByEachAlgorithm(

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/util/ExperimentAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/util/ExperimentAlgorithm.java
@@ -1,6 +1,7 @@
 package org.uma.jmetal.util.experiment.util;
 
 import org.uma.jmetal.algorithm.Algorithm;
+import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.experiment.Experiment;
@@ -19,6 +20,7 @@ public class ExperimentAlgorithm<S extends Solution<?>, Result>  {
   private Algorithm<Result> algorithm;
   private String algorithmTag;
   private String problemTag;
+  private String referenceParetoFront;
   private int runId ;
 
   /**
@@ -27,19 +29,22 @@ public class ExperimentAlgorithm<S extends Solution<?>, Result>  {
   public ExperimentAlgorithm(
           Algorithm<Result> algorithm,
           String algorithmTag,
-          String problemTag,
+          ExperimentProblem<S> problem,
           int runId) {
     this.algorithm = algorithm;
     this.algorithmTag = algorithmTag;
-    this.problemTag = problemTag;
+    this.problemTag = problem.getTag();
+    this.referenceParetoFront = problem.getReferenceFront();
     this.runId = runId ;
   }
 
   public ExperimentAlgorithm(
           Algorithm<Result> algorithm,
-          String problemTag,
+          ExperimentProblem<S> problem,
           int runId) {
-    this(algorithm, algorithm.getName(), problemTag, runId) ;
+
+    this(algorithm,algorithm.getName(),problem,runId);
+
   }
 
   public void runAlgorithm(Experiment<?, ?> experimentData) {
@@ -89,4 +94,8 @@ public class ExperimentAlgorithm<S extends Solution<?>, Result>  {
   public String getProblemTag() {
     return problemTag;
   }
+
+  public String getReferenceParetoFront() { return referenceParetoFront; }
+
+  public int getRunId() { return this.runId;}
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/util/ExperimentProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/util/ExperimentProblem.java
@@ -11,15 +11,22 @@ import org.uma.jmetal.solution.Solution;
 public class ExperimentProblem<S extends Solution<?>> {
   private Problem<S> problem ;
   private String tag ;
+  private String referenceFront;
 
   public ExperimentProblem(Problem<S> problem, String tag) {
     this.problem = problem;
     this.tag = tag;
+    this.referenceFront = this.problem.getName() + ".rf";
+
   }
 
   public ExperimentProblem(Problem<S> problem) {
-    this.problem = problem;
-    this.tag = problem.getName() ;
+    this(problem,problem.getName());
+  }
+
+  public ExperimentProblem<S> changeReferenceFrontTo(String referenceFront) {
+    this.referenceFront = referenceFront;
+    return this;
   }
 
   public Problem<S> getProblem() {
@@ -29,4 +36,6 @@ public class ExperimentProblem<S extends Solution<?>> {
   public String getTag() {
     return tag ;
   }
+
+  public String getReferenceFront() {return referenceFront;}
 }

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/BinaryProblemsStudy.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/BinaryProblemsStudy.java
@@ -134,7 +134,7 @@ public class BinaryProblemsStudy {
               .setMaxEvaluations(25000)
               .setPopulationSize(100)
               .build();
-      algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+      algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
     }
 
     for (int i = 0; i < problemList.size(); i++) {
@@ -145,7 +145,7 @@ public class BinaryProblemsStudy {
               .setMaxIterations(250)
               .setPopulationSize(100)
               .build();
-      algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+      algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
     }
 
     for (int i = 0; i < problemList.size(); i++) {
@@ -156,7 +156,7 @@ public class BinaryProblemsStudy {
               .setMaxEvaluations(25000)
               .setPopulationSize(100)
               .build();
-      algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+      algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
     }
 
     for (int i = 0; i < problemList.size(); i++) {
@@ -182,7 +182,7 @@ public class BinaryProblemsStudy {
               .setParentSelection(parentsSelection)
               .setEvaluator(new SequentialSolutionListEvaluator<BinarySolution>())
               .build();
-      algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+      algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
     }
 }
     return algorithms;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ConstraintProblemsStudy.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ConstraintProblemsStudy.java
@@ -127,7 +127,7 @@ public class ConstraintProblemsStudy {
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i),run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -136,7 +136,7 @@ public class ConstraintProblemsStudy {
                 new SBXCrossover(1.0, 10.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -149,7 +149,7 @@ public class ConstraintProblemsStudy {
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
       for (int i = 0; i < problemList.size(); i++) {
         double cr = 0.5;
@@ -162,7 +162,7 @@ public class ConstraintProblemsStudy {
                 .setPopulationSize(100)
                 .setSolutionSetEvaluator(new SequentialSolutionListEvaluator<>())
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -175,7 +175,7 @@ public class ConstraintProblemsStudy {
                 .setPopulationSize(100)
                 .setArchive(new CrowdingDistanceArchive<DoubleSolution>(100))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
     }
     return algorithms;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/DTLZStudy.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/DTLZStudy.java
@@ -1,0 +1,152 @@
+package org.uma.jmetal.experiment;
+
+import org.uma.jmetal.algorithm.Algorithm;
+import org.uma.jmetal.algorithm.multiobjective.nsgaii.NSGAIIBuilder;
+import org.uma.jmetal.algorithm.multiobjective.smpso.SMPSOBuilder;
+import org.uma.jmetal.algorithm.multiobjective.spea2.SPEA2Builder;
+import org.uma.jmetal.operator.impl.crossover.SBXCrossover;
+import org.uma.jmetal.operator.impl.mutation.PolynomialMutation;
+import org.uma.jmetal.problem.DoubleProblem;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.problem.multiobjective.dtlz.*;
+import org.uma.jmetal.problem.multiobjective.zdt.ZDT1;
+import org.uma.jmetal.problem.multiobjective.zdt.ZDT2;
+import org.uma.jmetal.problem.multiobjective.zdt.ZDT3;
+import org.uma.jmetal.problem.multiobjective.zdt.ZDT4;
+import org.uma.jmetal.problem.multiobjective.zdt.ZDT6;
+import org.uma.jmetal.qualityindicator.impl.Epsilon;
+import org.uma.jmetal.qualityindicator.impl.GenerationalDistance;
+import org.uma.jmetal.qualityindicator.impl.InvertedGenerationalDistance;
+import org.uma.jmetal.qualityindicator.impl.InvertedGenerationalDistancePlus;
+import org.uma.jmetal.qualityindicator.impl.Spread;
+import org.uma.jmetal.qualityindicator.impl.hypervolume.PISAHypervolume;
+import org.uma.jmetal.solution.DoubleSolution;
+import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.archive.impl.CrowdingDistanceArchive;
+import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
+import org.uma.jmetal.util.experiment.Experiment;
+import org.uma.jmetal.util.experiment.ExperimentBuilder;
+import org.uma.jmetal.util.experiment.component.ComputeQualityIndicators;
+import org.uma.jmetal.util.experiment.component.ExecuteAlgorithms;
+import org.uma.jmetal.util.experiment.component.GenerateBoxplotsWithR;
+import org.uma.jmetal.util.experiment.component.GenerateFriedmanTestTables;
+import org.uma.jmetal.util.experiment.component.GenerateLatexTablesWithStatistics;
+import org.uma.jmetal.util.experiment.component.GenerateWilcoxonTestTablesWithR;
+import org.uma.jmetal.util.experiment.util.ExperimentAlgorithm;
+import org.uma.jmetal.util.experiment.util.ExperimentProblem;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Example of experimental study based on solving the ZDT problems with the algorithms NSGAII,
+ * SPEA2, and SMPSO
+ *
+ * This experiment assumes that the reference Pareto front are known, so the names of files
+ * containing them and the directory where they are located must be specified.
+ *
+ * Six quality indicators are used for performance assessment.
+ *
+ * The steps to carry out the experiment are: 1. Configure the experiment 2. Execute the algorithms
+ * 3. Compute que quality indicators 4. Generate Latex tables reporting means and medians 5.
+ * Generate R scripts to produce latex tables with the result of applying the Wilcoxon Rank Sum Test
+ * 6. Generate Latex tables with the ranking obtained by applying the Friedman test 7. Generate R
+ * scripts to obtain boxplots
+ *
+ * @author Antonio J. Nebro <antonio@lcc.uma.es>
+ */
+
+public class DTLZStudy {
+    private static final int INDEPENDENT_RUNS = 5;
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 1) {
+            throw new JMetalException("Missing argument: experimentBaseDirectory");
+        }
+        String experimentBaseDirectory = args[0];
+
+        List<ExperimentProblem<DoubleSolution>> problemList = new ArrayList<>();
+        problemList.add(new ExperimentProblem<>(new DTLZ1()).changeReferenceFrontTo("DTLZ1.3D.pf"));
+        problemList.add(new ExperimentProblem<>(new DTLZ2()).changeReferenceFrontTo("DTLZ1.3D.pf"));
+        problemList.add(new ExperimentProblem<>(new DTLZ3()).changeReferenceFrontTo("DTLZ1.3D.pf"));
+        problemList.add(new ExperimentProblem<>(new DTLZ4()).changeReferenceFrontTo("DTLZ1.3D.pf"));
+        problemList.add(new ExperimentProblem<>(new DTLZ5()).changeReferenceFrontTo("DTLZ1.3D.pf"));
+        problemList.add(new ExperimentProblem<>(new DTLZ6()).changeReferenceFrontTo("DTLZ1.3D.pf"));
+        problemList.add(new ExperimentProblem<>(new DTLZ7()).changeReferenceFrontTo("DTLZ1.3D.pf"));
+
+
+        List<ExperimentAlgorithm<DoubleSolution, List<DoubleSolution>>> algorithmList =
+                configureAlgorithmList(problemList);
+
+        Experiment<DoubleSolution, List<DoubleSolution>> experiment =
+                new ExperimentBuilder<DoubleSolution, List<DoubleSolution>>("DTLZtudy")
+                        .setAlgorithmList(algorithmList)
+                        .setProblemList(problemList)
+                        .setReferenceFrontDirectory("/pareto_fronts")
+                        .setExperimentBaseDirectory(experimentBaseDirectory)
+                        .setOutputParetoFrontFileName("FUN")
+                        .setOutputParetoSetFileName("VAR")
+                        .setIndicatorList(Arrays.asList(
+                                new Epsilon<DoubleSolution>(),
+                                new Spread<DoubleSolution>(),
+                                new GenerationalDistance<DoubleSolution>(),
+                                new PISAHypervolume<DoubleSolution>(),
+                                new InvertedGenerationalDistance<DoubleSolution>(),
+                                new InvertedGenerationalDistancePlus<DoubleSolution>()))
+                        .setIndependentRuns(INDEPENDENT_RUNS)
+                        .setNumberOfCores(8)
+                        .build();
+
+        new ExecuteAlgorithms<>(experiment).run();
+        new ComputeQualityIndicators<>(experiment).run();
+        new GenerateLatexTablesWithStatistics(experiment).run();
+        new GenerateWilcoxonTestTablesWithR<>(experiment).run();
+        new GenerateFriedmanTestTables<>(experiment).run();
+        new GenerateBoxplotsWithR<>(experiment).setRows(3).setColumns(3).setDisplayNotch().run();
+    }
+
+    /**
+     * The algorithm list is composed of pairs {@link Algorithm} + {@link Problem} which form part of
+     * a {@link ExperimentAlgorithm}, which is a decorator for class {@link Algorithm}.
+     */
+    static List<ExperimentAlgorithm<DoubleSolution, List<DoubleSolution>>> configureAlgorithmList(
+            List<ExperimentProblem<DoubleSolution>> problemList) {
+        List<ExperimentAlgorithm<DoubleSolution, List<DoubleSolution>>> algorithms = new ArrayList<>();
+        for (int run = 0; run < INDEPENDENT_RUNS; run++) {
+
+           for (int i = 0; i < problemList.size(); i++) {
+                double mutationProbability = 1.0 / problemList.get(i).getProblem().getNumberOfVariables();
+                double mutationDistributionIndex = 20.0;
+                Algorithm<List<DoubleSolution>> algorithm = new SMPSOBuilder((DoubleProblem) problemList.get(i).getProblem(),
+                        new CrowdingDistanceArchive<DoubleSolution>(100))
+                        .setMutation(new PolynomialMutation(mutationProbability, mutationDistributionIndex))
+                        .setMaxIterations(250)
+                        .setSwarmSize(100)
+                        .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
+                        .build();
+                algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
+            }
+
+            for (int i = 0; i < problemList.size(); i++) {
+                Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<DoubleSolution>(
+                        problemList.get(i).getProblem(),
+                        new SBXCrossover(1.0, 20.0),
+                        new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
+                        .build();
+                algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
+            }
+
+            for (int i = 0; i < problemList.size(); i++) {
+                Algorithm<List<DoubleSolution>> algorithm = new SPEA2Builder<DoubleSolution>(
+                        problemList.get(i).getProblem(),
+                        new SBXCrossover(1.0, 10.0),
+                        new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
+                        .build();
+                algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
+            }
+        }
+        return algorithms;
+    }
+}

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/NSGAIIStudy.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/NSGAIIStudy.java
@@ -67,10 +67,10 @@ public class NSGAIIStudy {
     problemList.add(new ExperimentProblem<>(new ZDT4()));
     problemList.add(new ExperimentProblem<>(new ZDT6()));
 
+
     List<ExperimentAlgorithm<DoubleSolution, List<DoubleSolution>>> algorithmList =
             configureAlgorithmList(problemList);
 
-    List<String> referenceFrontFileNames = Arrays.asList("ZDT1.pf", "ZDT2.pf", "ZDT3.pf", "ZDT4.pf", "ZDT6.pf");
 
     Experiment<DoubleSolution, List<DoubleSolution>> experiment =
             new ExperimentBuilder<DoubleSolution, List<DoubleSolution>>("NSGAIIStudy")
@@ -80,7 +80,6 @@ public class NSGAIIStudy {
                     .setOutputParetoFrontFileName("FUN")
                     .setOutputParetoSetFileName("VAR")
                     .setReferenceFrontDirectory("/pareto_fronts")
-                    .setReferenceFrontFileNames(referenceFrontFileNames)
                     .setIndicatorList(Arrays.asList(
                             new Epsilon<DoubleSolution>(),
                             new Spread<DoubleSolution>(),
@@ -119,7 +118,7 @@ public class NSGAIIStudy {
                   .setMaxEvaluations(25000)
                   .setPopulationSize(100)
                   .build();
-          algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIa", problemList.get(i).getTag(), run));
+          algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIa", problemList.get(i),run));
         }
 
         for (int i = 0; i < problemList.size(); i++) {
@@ -130,7 +129,7 @@ public class NSGAIIStudy {
                   .setMaxEvaluations(25000)
                   .setPopulationSize(100)
                   .build();
-          algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIb", problemList.get(i).getTag(), run));
+          algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIb", problemList.get(i),run));
         }
 
         for (int i = 0; i < problemList.size(); i++) {
@@ -139,7 +138,7 @@ public class NSGAIIStudy {
                   .setMaxEvaluations(25000)
                   .setPopulationSize(100)
                   .build();
-          algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIc", problemList.get(i).getTag(), run));
+          algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIc", problemList.get(i),run));
         }
 
         for (int i = 0; i < problemList.size(); i++) {
@@ -148,7 +147,7 @@ public class NSGAIIStudy {
                   .setMaxEvaluations(25000)
                   .setPopulationSize(100)
                   .build();
-          algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIId", problemList.get(i).getTag(), run));
+          algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIId", problemList.get(i),run));
         }
       }
     return algorithms;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/NSGAIIStudy2.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/NSGAIIStudy2.java
@@ -119,7 +119,7 @@ public class NSGAIIStudy2 {
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIa", problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIa", problemList.get(i),run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -130,7 +130,7 @@ public class NSGAIIStudy2 {
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIb", problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIb", problemList.get(i), run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -139,7 +139,7 @@ public class NSGAIIStudy2 {
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIc", problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIIc", problemList.get(i),run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -148,7 +148,7 @@ public class NSGAIIStudy2 {
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIId", problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, "NSGAIId", problemList.get(i),run));
       }
     }
     return algorithms;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ZDTScalabilityIStudy.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ZDTScalabilityIStudy.java
@@ -71,11 +71,10 @@ public class ZDTScalabilityIStudy {
     problemList.add(new ExperimentProblem<>(new ZDT1(30), "ZDT130"));
     problemList.add(new ExperimentProblem<>(new ZDT1(40), "ZDT140"));
     problemList.add(new ExperimentProblem<>(new ZDT1(50), "ZDT150"));
-
     List<ExperimentAlgorithm<DoubleSolution, List<DoubleSolution>>> algorithmList =
             configureAlgorithmList(problemList);
 
-    List<String> referenceFrontFileNames = Arrays.asList("ZDT1.pf", "ZDT1.pf", "ZDT1.pf", "ZDT1.pf", "ZDT1.pf");
+
 
     Experiment<DoubleSolution, List<DoubleSolution>> experiment =
             new ExperimentBuilder<DoubleSolution, List<DoubleSolution>>("ZDTScalabilityStudy")
@@ -85,7 +84,6 @@ public class ZDTScalabilityIStudy {
                     .setOutputParetoFrontFileName("FUN")
                     .setOutputParetoSetFileName("VAR")
                     .setReferenceFrontDirectory("/pareto_fronts")
-                    .setReferenceFrontFileNames(referenceFrontFileNames)
                     .setIndicatorList(Arrays.asList(
                             new Epsilon<DoubleSolution>(),
                             new Spread<DoubleSolution>(),
@@ -126,7 +124,7 @@ public class ZDTScalabilityIStudy {
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i),run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -135,7 +133,7 @@ public class ZDTScalabilityIStudy {
                 new SBXCrossover(1.0, 20.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i),run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -144,7 +142,7 @@ public class ZDTScalabilityIStudy {
                 new SBXCrossover(1.0, 10.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
     }
     return algorithms ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ZDTScalabilityIStudy2.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ZDTScalabilityIStudy2.java
@@ -125,7 +125,7 @@ public class ZDTScalabilityIStudy2 {
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -134,7 +134,7 @@ public class ZDTScalabilityIStudy2 {
                 new SBXCrossover(1.0, 20.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i),run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -143,7 +143,7 @@ public class ZDTScalabilityIStudy2 {
                 new SBXCrossover(1.0, 10.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i),run));
       }
     }
     return algorithms ;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ZDTStudy.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ZDTStudy.java
@@ -76,14 +76,13 @@ public class ZDTStudy {
     List<ExperimentAlgorithm<DoubleSolution, List<DoubleSolution>>> algorithmList =
             configureAlgorithmList(problemList);
 
-    List<String> referenceFrontFileNames = Arrays.asList("ZDT1.pf", "ZDT2.pf", "ZDT3.pf", "ZDT4.pf", "ZDT6.pf");
+
 
     Experiment<DoubleSolution, List<DoubleSolution>> experiment =
             new ExperimentBuilder<DoubleSolution, List<DoubleSolution>>("ZDTStudy")
                     .setAlgorithmList(algorithmList)
                     .setProblemList(problemList)
                     .setReferenceFrontDirectory("/pareto_fronts")
-                    .setReferenceFrontFileNames(referenceFrontFileNames)
                     .setExperimentBaseDirectory(experimentBaseDirectory)
                     .setOutputParetoFrontFileName("FUN")
                     .setOutputParetoSetFileName("VAR")
@@ -111,7 +110,7 @@ public class ZDTStudy {
    * a {@link ExperimentAlgorithm}, which is a decorator for class {@link Algorithm}.
    */
   static List<ExperimentAlgorithm<DoubleSolution, List<DoubleSolution>>> configureAlgorithmList(
-          List<ExperimentProblem<DoubleSolution>> problemList) {
+          List<ExperimentProblem<DoubleSolution>> problemList ) {
     List<ExperimentAlgorithm<DoubleSolution, List<DoubleSolution>>> algorithms = new ArrayList<>();
     for (int run = 0; run < INDEPENDENT_RUNS; run++) {
 
@@ -125,7 +124,7 @@ public class ZDTStudy {
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -134,7 +133,7 @@ public class ZDTStudy {
                 new SBXCrossover(1.0, 20.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -143,7 +142,7 @@ public class ZDTStudy {
                 new SBXCrossover(1.0, 10.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
     }
     return algorithms;

--- a/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ZDTStudy2.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/experiment/ZDTStudy2.java
@@ -134,7 +134,7 @@ public class ZDTStudy2 {
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -143,7 +143,7 @@ public class ZDTStudy2 {
                 new SBXCrossover(1.0, 20.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
 
       for (int i = 0; i < problemList.size(); i++) {
@@ -152,7 +152,7 @@ public class ZDTStudy2 {
                 new SBXCrossover(1.0, 10.0),
                 new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
-        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i).getTag(), run));
+        algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
     }
     return algorithms ;


### PR DESCRIPTION
This pull request fixed two main bugs:
- A bug in the experiment framework which led to recompute quality indicators more times than needed
- A bug in AbstractGenericSolution caused by solutions stored as attributes. This issue might lead to infinite recursive calls when two solutions are compared

In addition the pull request also slightly changes the Experiment framework. Particularly, It changes the way reference fronts are indicated for every problem in a experiment.