### PR TITLE
Performance s2095

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/R2.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/qualityindicator/impl/R2.java
@@ -97,7 +97,7 @@ public class R2<Evaluate extends List<? extends Solution<?>>>
 	private static double[][] readWeightsFrom(String file) throws java.io.IOException {
 		FileInputStream fis = new FileInputStream(file);
         InputStreamReader isr = new InputStreamReader(fis);
-        BufferedReader br = new BufferedReader(isr);
+      try(BufferedReader br = new BufferedReader(isr)){
 
         String line = br.readLine();
         double[][] lambda;
@@ -118,9 +118,10 @@ public class R2<Evaluate extends List<? extends Solution<?>>>
             line = br.readLine();
           }
 
-          br.close();
+          
         }
         return lambda;
+      }
 	}
 
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java
@@ -91,11 +91,9 @@ public class ComputeQualityIndicators<S extends Solution<?>, Result> implements 
   }
 
   private void writeQualityIndicatorValueToFile(Double indicatorValue, String qualityIndicatorFile) {
-    FileWriter os;
-    try {
-      os = new FileWriter(qualityIndicatorFile, true);
+     
+    try(FileWriter os = new FileWriter(qualityIndicatorFile, true)) { 
       os.write("" + indicatorValue + "\n");
-      os.close();
     } catch (IOException ex) {
       throw new JMetalException("Error writing indicator file" + ex) ;
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateBoxplotsWithR.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateBoxplotsWithR.java
@@ -68,9 +68,9 @@ public class GenerateBoxplotsWithR<Result> implements ExperimentComponent {
       System.out.println("Creating " + rDirectoryName + " directory");
     }
     for (GenericIndicator<? extends Solution<?>> indicator : experiment.getIndicatorList()) {
-      String rFileName = rDirectoryName + "/" + indicator.getName() + ".Boxplot" + ".R";
+     String rFileName = rDirectoryName + "/" + indicator.getName() + ".Boxplot" + ".R";
 
-      FileWriter os = new FileWriter(rFileName, false);
+     try(FileWriter os = new FileWriter(rFileName, false)){
       os.write("postscript(\"" +
                indicator.getName() +
               ".Boxplot.eps\", horizontal=FALSE, onefile=FALSE, height=8, width=12, pointsize=10)" +
@@ -116,8 +116,7 @@ public class GenerateBoxplotsWithR<Result> implements ExperimentComponent {
       for (ExperimentProblem<?> problem : experiment.getProblemList()) {
         os.write("qIndicator(indicator, \"" + problem.getTag() + "\")" + "\n");
       }
-
-      os.close();
+     }
     }
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateFriedmanTestTables.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateFriedmanTestTables.java
@@ -92,8 +92,8 @@ public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
   private void readDataFromFile(String path, Vector<Vector<Double>> data, int algorithmIndex) {
     String string = "";
 
-    try {
-      FileInputStream fis = new FileInputStream(path);
+    try(FileInputStream fis = new FileInputStream(path)) {
+      
 
       byte[] bytes = new byte[4096];
       int readBytes = 0;
@@ -106,7 +106,6 @@ public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
         }
       }
 
-      fis.close();
     } catch (IOException e) {
       throw new JMetalException("Error reading data ", e) ;
     }
@@ -236,19 +235,16 @@ public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
   private void writeLatexFile(GenericIndicator<?> indicator, String fileContents) {
     String outputFile = latexDirectoryName +"/FriedmanTest"+indicator.getName()+".tex";
 
-    try {
+    try( FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
+    		DataOutputStream dataOutputStream = new DataOutputStream(fileOutputStream);	) {
       File latexOutput;
       latexOutput = new File(latexDirectoryName);
       if(!latexOutput.exists()){
         latexOutput.mkdirs();
       }
-      FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
-      DataOutputStream dataOutputStream = new DataOutputStream(fileOutputStream);
-
+     
       dataOutputStream.writeBytes(fileContents);
 
-      dataOutputStream.close();
-      fileOutputStream.close();
     }
     catch (IOException e) {
       throw new JMetalException("Error writing data ", e) ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateLatexTablesWithStatistics.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateLatexTablesWithStatistics.java
@@ -78,13 +78,13 @@ public class GenerateLatexTablesWithStatistics implements ExperimentComponent {
           // Read values from data files
           FileInputStream fis = new FileInputStream(directory);
           InputStreamReader isr = new InputStreamReader(fis);
-          BufferedReader br = new BufferedReader(isr);
+          try(BufferedReader br = new BufferedReader(isr)){
           String aux = br.readLine();
           while (aux != null) {
             data.get(indicator).get(problem).get(algorithm).add(Double.parseDouble(aux));
             aux = br.readLine();
           }
-          br.close();
+          }
         }
       }
     }
@@ -183,7 +183,7 @@ public class GenerateLatexTablesWithStatistics implements ExperimentComponent {
   }
 
   void printHeaderLatexCommands(String fileName) throws IOException {
-    FileWriter os = new FileWriter(fileName, false);
+    try(FileWriter os = new FileWriter(fileName, false)){
     os.write("\\documentclass{article}" + "\n");
     os.write("\\title{" + experiment.getExperimentName() + "}" + "\n");
     os.write("\\usepackage{colortbl}" + "\n");
@@ -194,19 +194,18 @@ public class GenerateLatexTablesWithStatistics implements ExperimentComponent {
     os.write("\\begin{document}" + "\n");
     os.write("\\maketitle" + "\n");
     os.write("\\section{Tables}" + "\n");
-
-    os.close();
+    }
   }
 
   void printEndLatexCommands(String fileName) throws IOException {
-    FileWriter os = new FileWriter(fileName, true);
+    try(FileWriter os = new FileWriter(fileName, true)){
     os.write("\\end{document}" + "\n");
-    os.close();
+    }
   }
 
   private void printData(String latexFile, int indicatorIndex, double[][][] centralTendency, double[][][] dispersion, String caption) throws IOException {
     // Generate header of the table
-    FileWriter os = new FileWriter(latexFile, true);
+    try(FileWriter os = new FileWriter(latexFile, true)){
     os.write("\n");
     os.write("\\begin{table}" + "\n");
     os.write("\\caption{" + experiment.getIndicatorList().get(indicatorIndex).getName() + ". " + caption + "}" + "\n");
@@ -321,7 +320,7 @@ public class GenerateLatexTablesWithStatistics implements ExperimentComponent {
     os.write("\\end{tabular}" + "\n");
     os.write("\\end{scriptsize}" + "\n");
     os.write("\\end{table}" + "\n");
-    os.close();
+    }
   }
 
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateWilcoxonTestTablesWithR.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateWilcoxonTestTablesWithR.java
@@ -60,7 +60,7 @@ public class GenerateWilcoxonTestTablesWithR<Result> implements ExperimentCompon
   }
 
   private void printHeaderLatexCommands(String rFileName, String latexFileName) throws IOException {
-    FileWriter os = new FileWriter(rFileName, false);
+    try(FileWriter os = new FileWriter(rFileName, false)){
     String output = "write(\"\", \"" + latexFileName + "\",append=FALSE)";
     os.write(output + "\n");
 
@@ -77,19 +77,19 @@ public class GenerateWilcoxonTestTablesWithR<Result> implements ExperimentCompon
         "  write(\"\\\\\", \"" + latexFileName + "\", append=TRUE)" + "\n" + "}" + "\n";
     os.write(output + "\n");
 
-    os.close();
+    }
   }
 
   private void printEndLatexCommands(String rFileName, String latexFileName) throws IOException {
-    FileWriter os = new FileWriter(rFileName, true);
+    try(FileWriter os = new FileWriter(rFileName, true)){
     String output = "latexTail <- function() { " + "\n" +
         "  write(\"\\\\end{document}\", \"" + latexFileName + "\", append=TRUE)" + "\n" + "}" + "\n";
     os.write(output + "\n");
-    os.close();
+    }
   }
 
   private void printTableHeader(GenericIndicator<?> indicator, String rFileName, String latexFileName) throws IOException {
-    FileWriter os = new FileWriter(rFileName, true);
+    try(FileWriter os = new FileWriter(rFileName, true)){
 
     String latexTableLabel = "";
     String latexTableCaption = "";
@@ -117,12 +117,12 @@ public class GenerateWilcoxonTestTablesWithR<Result> implements ExperimentCompon
         "  write(latexTableFirstLine, \"" + latexFileName + "\", append=TRUE)" + "\n" +
         "  write(\"\\\\hline \", \"" + latexFileName + "\", append=TRUE)" + "\n" + "}" + "\n";
     os.write(output + "\n");
-    os.close();
+    }
   }
 
   private void printTableTail(String rFileName, String latexFileName) throws IOException {
     // Generate function latexTableTail()
-    FileWriter os = new FileWriter(rFileName, true);
+    try(FileWriter os = new FileWriter(rFileName, true)){
 
     String output = "latexTableTail <- function() { " + "\n" +
         "  write(\"\\\\hline\", \"" + latexFileName + "\", append=TRUE)" + "\n" +
@@ -131,11 +131,11 @@ public class GenerateWilcoxonTestTablesWithR<Result> implements ExperimentCompon
         "  write(\"\\\\end{table}\", \"" + latexFileName + "\", append=TRUE)" + "\n" + "}" + "\n";
     os.write(output + "\n");
 
-    os.close();
+    }
   }
 
   private void printLines(GenericIndicator<?> indicator, String rFileName, String latexFileName) throws IOException {
-    FileWriter os = new FileWriter(rFileName, true);
+    try(FileWriter os = new FileWriter(rFileName, true)){
 
     String output ;
     if (indicator.isTheLowerTheIndicatorValueTheBetter()) {
@@ -199,13 +199,13 @@ public class GenerateWilcoxonTestTablesWithR<Result> implements ExperimentCompon
           "    write(\" \", \"" + latexFileName + "\", append=TRUE)" + "\n" +
           "  }" + "\n" +
           "}" + "\n";
+      }
+      os.write(output + "\n");
     }
-    os.write(output + "\n");
-    os.close();
   }
 
   private void printGenerateMainScript(GenericIndicator<?> indicator, String rFileName, String latexFileName) throws IOException {
-    FileWriter os = new FileWriter(rFileName, true);
+    try(FileWriter os = new FileWriter(rFileName, true)){
 
     // Start of the R script
     String output = "### START OF SCRIPT ";
@@ -320,6 +320,6 @@ public class GenerateWilcoxonTestTablesWithR<Result> implements ExperimentCompon
         "latexTail()" + "\n";
     os.write(output + "\n");
 
-    os.close();
+    }
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/fileinput/util/ReadDoubleDataFile.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/fileinput/util/ReadDoubleDataFile.java
@@ -26,11 +26,11 @@ public class ReadDoubleDataFile {
       inputStream = new FileInputStream(fileName);
     }
     InputStreamReader isr = new InputStreamReader(inputStream);
-    BufferedReader br = new BufferedReader(isr);
+    
 
     List<Double> list = new ArrayList<>();
     String line ;
-    try {
+    try(BufferedReader br = new BufferedReader(isr)) {
       line = br.readLine();
 
       while (line != null) {
@@ -41,7 +41,7 @@ public class ReadDoubleDataFile {
         }
         line = br.readLine();
       }
-      br.close();
+      
     } catch (IOException e) {
       throw new JMetalException("Error reading file", e);
     } catch (NumberFormatException e) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/WeightVectorNeighborhood.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/WeightVectorNeighborhood.java
@@ -64,9 +64,8 @@ public class WeightVectorNeighborhood<S> implements Neighborhood<S> {
       inputStream = new FileInputStream(vectorFileName);
     }
     InputStreamReader isr = new InputStreamReader(inputStream);
-    BufferedReader br = new BufferedReader(isr);
 
-    try {
+    try(BufferedReader br = new BufferedReader(isr)) {
       int i = 0;
       int j;
       String aux = br.readLine();
@@ -81,7 +80,6 @@ public class WeightVectorNeighborhood<S> implements Neighborhood<S> {
         aux = br.readLine();
         i++;
       }
-      br.close();
     } catch (IOException e) {
       throw new JMetalException("readWeightsFromFile: failed when reading for file: "
               + vectorFileName, e);

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/point/impl/ArrayPoint.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/point/impl/ArrayPoint.java
@@ -96,9 +96,9 @@ public class ArrayPoint implements Point {
    * @param fileName
    */
   public ArrayPoint(String fileName) throws IOException {
-    FileInputStream fis = new FileInputStream(fileName);
-    InputStreamReader isr = new InputStreamReader(fis);
-    BufferedReader br = new BufferedReader(isr);
+   FileInputStream fis = new FileInputStream(fileName);
+   InputStreamReader isr = new InputStreamReader(fis);
+   try(BufferedReader br = new BufferedReader(isr)){
 
     List<Double> auxiliarPoint = new ArrayList<Double>();
     String aux = br.readLine();
@@ -117,7 +117,7 @@ public class ArrayPoint implements Point {
       point[i] = auxiliarPoint.get(i) ;
     }
 
-    br.close();
+   }
   }
 
   @Override


### PR DESCRIPTION
The changes are based on the following rule: 

Connections, streams, files, and other classes that implement the Closeable interface or its super-interface, AutoCloseable, needs to be closed after use. Further, that close call must be made in a finally block otherwise an exception could keep the call from being made. Preferably, when class implements AutoCloseable, resource should be created using "try-with-resources" pattern and will be closed automatically.

Failure to properly close resources will result in a resource leak which could bring first the application and then perhaps the box it's on to their knees.