### PR TITLE
Reliability s1452

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/MeasureFactory.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/measure/impl/MeasureFactory.java
@@ -19,9 +19,10 @@ import java.util.logging.Logger;
  * {@link Measure}s.
  * 
  * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * @param <Value>
  * 
  */
-public class MeasureFactory {
+public class MeasureFactory<Value> {
 
 	private final Logger log = Logger.getLogger(MeasureFactory.class.getName());
 
@@ -188,9 +189,9 @@ public class MeasureFactory {
 	 *         and the corresponding {@link PullMeasure} built from them
 	 */
 	@SuppressWarnings("serial")
-	public Map<String, PullMeasure<?>> createPullsFromGetters(
+	public Map<String, PullMeasure<Value>> createPullsFromGetters(
 			final Object object) {
-		Map<String, PullMeasure<?>> measures = new HashMap<String, PullMeasure<?>>();
+		Map<String, PullMeasure<Value>> measures = new HashMap<String, PullMeasure<Value>>();
 		Class<? extends Object> clazz = object.getClass();
 		for (final Method method : clazz.getMethods()) {
 			if (method.getParameterTypes().length == 0
@@ -199,12 +200,12 @@ public class MeasureFactory {
 					&& method.getName().matches("get[^a-z].*")) {
 				String key = method.getName().substring(3);
 				// TODO exploit return type to restrict the generics
-				measures.put(key, new SimplePullMeasure<Object>(key) {
+				measures.put(key, new SimplePullMeasure<Value>(key) {
 
 					@Override
-					public Object get() {
+					public Value get() {
 						try {
-							return method.invoke(object);
+							return (Value) method.invoke(object);
 						} catch (IllegalAccessException
 								| IllegalArgumentException
 								| InvocationTargetException e) {
@@ -234,18 +235,18 @@ public class MeasureFactory {
 	 *         and the corresponding {@link PullMeasure} built from them
 	 */
 	@SuppressWarnings("serial")
-	public Map<String, PullMeasure<?>> createPullsFromFields(final Object object) {
-		Map<String, PullMeasure<?>> measures = new HashMap<String, PullMeasure<?>>();
+	public Map<String, PullMeasure<Value>> createPullsFromFields(final Object object) {
+		Map<String, PullMeasure<Value>> measures = new HashMap<String, PullMeasure<Value>>();
 		Class<? extends Object> clazz = object.getClass();
 		for (final Field field : clazz.getFields()) {
 			String key = field.getName();
 			// TODO exploit return type to restrict the generics
-			measures.put(key, new SimplePullMeasure<Object>(key) {
+			measures.put(key, new SimplePullMeasure<Value>(key) {
 
 				@Override
-				public Object get() {
+				public Value get() {
 					try {
-						return field.get(object);
+						return (Value) field.get(object);
 					} catch (IllegalArgumentException | IllegalAccessException e) {
 						throw new RuntimeException();
 					}

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/SolutionBuilder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/SolutionBuilder.java
@@ -13,8 +13,9 @@ import java.util.Collection;
  * @author Matthieu Vergne <matthieu.vergne@gmail.com>
  * 
  * @param <Solution>
+ * @param <Value>
  */
-public interface SolutionBuilder<Solution> {
+public interface SolutionBuilder<Solution, Value> {
 	/**
 	 * A {@link Variable} represents the fundamental information of a set of
 	 * homogeneous {@link Solution}s (e.g. a population of solutions returned by
@@ -46,7 +47,7 @@ public interface SolutionBuilder<Solution> {
 	 * @return the list of {@link Variable}s managed by this
 	 *         {@link SolutionBuilder}
 	 */
-	public Collection<Variable<Solution, ?>> getVariables();
+	public Collection<Variable<Solution, Value>> getVariables();
 
 	/**
 	 * This method tells which {@link Value} to assign to the next

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/SolutionEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/SolutionEvaluator.java
@@ -12,8 +12,9 @@ import java.util.Collection;
  * @author Matthieu Vergne <matthieu.vergne@gmail.com>
  * 
  * @param <Solution>
+ * @param <Value>
  */
-public interface SolutionEvaluator<Solution> {
+public interface SolutionEvaluator<Solution, Value> {
 
 	/**
 	 * An {@link Objective} represents the evaluation information of a set of
@@ -46,5 +47,5 @@ public interface SolutionEvaluator<Solution> {
 	 * @return the list of {@link Objective}s managed by this
 	 *         {@link SolutionEvaluator}
 	 */
-	public Collection<Objective<Solution, ?>> getObjectives();
+	public Collection<Objective<Solution, Value>> getObjectives();
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/ObjectiveFactory.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/ObjectiveFactory.java
@@ -14,9 +14,10 @@ import java.util.Map.Entry;
  * situations.
  * 
  * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * @param <Value>
  * 
  */
-public class ObjectiveFactory {
+public class ObjectiveFactory<Value> {
 
 	/**
 	 * This method retrieves all the values accessible through a getter (
@@ -33,16 +34,16 @@ public class ObjectiveFactory {
 	 * @return the set of {@link Objective}s retrieved from this class
 	 * @see #createFromLonelyGetters(Class)
 	 */
-	public <Solution> Collection<Objective<Solution, ?>> createFromGetters(
+	public <Solution> Collection<Objective<Solution, Value>> createFromGetters(
 			Class<Solution> solutionClass) {
-		Collection<Objective<Solution, ?>> objectives = new LinkedList<>();
+		Collection<Objective<Solution, Value>> objectives = new LinkedList<>();
 		for (Method method : solutionClass.getMethods()) {
 			if (method.getParameterTypes().length == 0
 					&& method.getReturnType() != null
 					&& !method.getName().equals("getClass")
 					&& method.getName().matches("get[^a-z].*")) {
 				String name = method.getName().substring(3);
-				objectives.add(createObjectiveOn(solutionClass, method, name,
+				objectives.add((Objective<Solution, Value>) createObjectiveOn(solutionClass, method, name,
 						method.getReturnType()));
 			} else {
 				// not a getter, ignore it
@@ -74,7 +75,7 @@ public class ObjectiveFactory {
 	 *            the {@link Solution} class to analyze
 	 * @return the set of {@link Objective}s retrieved from this class
 	 */
-	public <Solution> Collection<Objective<Solution, ?>> createFromGettersWithoutSetters(
+	public <Solution> Collection<Objective<Solution, Value>> createFromGettersWithoutSetters(
 			Class<Solution> solutionClass) {
 		Map<String, Method> getters = new HashMap<>();
 		Map<String, Method> setters = new HashMap<>();
@@ -92,11 +93,11 @@ public class ObjectiveFactory {
 
 		getters.keySet().removeAll(setters.keySet());
 
-		Collection<Objective<Solution, ?>> objectives = new LinkedList<>();
+		Collection<Objective<Solution, Value>> objectives = new LinkedList<>();
 		for (Entry<String, Method> entry : getters.entrySet()) {
 			String name = entry.getKey();
 			Method getter = entry.getValue();
-			objectives.add(createObjectiveOn(solutionClass, getter, name,
+			objectives.add((Objective<Solution, Value>) createObjectiveOn(solutionClass, getter, name,
 					getter.getReturnType()));
 		}
 		return objectives;

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/VariableFactory.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/VariableFactory.java
@@ -18,9 +18,10 @@ import java.util.Set;
  * situations.
  * 
  * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ * @param <Value>
  * 
  */
-public class VariableFactory {
+public class VariableFactory<Value> {
 
 	/**
 	 * This method retrieves all the values accessible through a getter (
@@ -38,13 +39,13 @@ public class VariableFactory {
 	 * @see #createFromGettersAndSetters(Class)
 	 * @see #createFromGettersAndConstructors(Class)
 	 */
-	public <Solution> Collection<Variable<Solution, ?>> createFromGetters(
+	public <Solution> Collection<Variable<Solution, Value>> createFromGetters(
 			Class<Solution> solutionClass) {
-		Collection<Variable<Solution, ?>> variables = new LinkedList<>();
+		Collection<Variable<Solution, Value>> variables = new LinkedList<>();
 		for (Method method : solutionClass.getMethods()) {
 			if (isGetter(method)) {
 				String name = method.getName().substring(3);
-				variables.add(createVariableOn(solutionClass, method, name,
+				variables.add((Variable<Solution, Value>) createVariableOn(solutionClass, method, name,
 						method.getReturnType()));
 			} else {
 				// not a getter, ignore it
@@ -76,7 +77,7 @@ public class VariableFactory {
 	 *            the {@link Solution} class to analyze
 	 * @return the set of {@link Variable}s retrieved from this class
 	 */
-	public <Solution> Collection<Variable<Solution, ?>> createFromGettersAndSetters(
+	public <Solution> Collection<Variable<Solution, Value>> createFromGettersAndSetters(
 			Class<Solution> solutionClass) {
 		Map<String, Method> getters = new HashMap<>();
 		Map<String, Method> setters = new HashMap<>();
@@ -105,11 +106,11 @@ public class VariableFactory {
 			}
 		}
 
-		Collection<Variable<Solution, ?>> variables = new LinkedList<>();
+		Collection<Variable<Solution, Value>> variables = new LinkedList<>();
 		for (Entry<String, Method> entry : getters.entrySet()) {
 			String name = entry.getKey();
 			Method getter = entry.getValue();
-			variables.add(createVariableOn(solutionClass, getter, name,
+			variables.add((Variable<Solution, Value>) createVariableOn(solutionClass, getter, name,
 					getter.getReturnType()));
 		}
 		return variables;
@@ -158,7 +159,7 @@ public class VariableFactory {
 	 *             if the {@link Solution} class to analyze is an interface,
 	 *             thus constructors make no sense
 	 */
-	public <Solution> Collection<Variable<Solution, ?>> createFromGettersAndConstructors(
+	public <Solution> Collection<Variable<Solution, Value>> createFromGettersAndConstructors(
 			Class<Solution> solutionClass) {
 		if (solutionClass.isInterface()) {
 			throw new IsInterfaceException(solutionClass);
@@ -186,7 +187,7 @@ public class VariableFactory {
 				}
 			}
 
-			Collection<Variable<Solution, ?>> variables = new LinkedList<>();
+			Collection<Variable<Solution, Value>> variables = new LinkedList<>();
 			for (Constructor<?> constructor : solutionClass.getConstructors()) {
 				Class<?>[] constructorTypes = constructor.getParameterTypes();
 				Set<Class<?>> uniqueTypes = new HashSet<>(
@@ -202,7 +203,7 @@ public class VariableFactory {
 							// constructor value without getter or already done
 						} else {
 							Method getter = getters.get(name);
-							variables.add(createVariableOn(solutionClass,
+							variables.add((Variable<Solution, Value>) createVariableOn(solutionClass,
 									getter, name, type));
 						}
 					}

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionListUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionListUtils.java
@@ -20,7 +20,7 @@ import java.util.List;
  */
 public class SolutionListUtils {
 
-  public static <S extends Solution<?>> List<S> getNondominatedSolutions(List<S> solutionList) {
+  public static <S extends Solution> List<S> getNondominatedSolutions(List<S> solutionList) {
     Ranking<S> ranking = new DominanceRanking<S>() ;
     return ranking.computeRanking(solutionList).getSubfront(0);
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionListUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionListUtils.java
@@ -129,17 +129,18 @@ public class SolutionListUtils {
   /**
    * This method receives a list of non-dominated solutions and maximum and minimum values of the
    * objectives, and returns a the normalized set of solutions.
+ * @param <Value>
    *
    * @param solutionList A list of non-dominated solutions
    * @param maximumValue The maximum values of the objectives
    * @param minimumValue The minimum values of the objectives
    * @return the normalized list of non-dominated solutions
    */
-  public static List<Solution<?>> getNormalizedFront(List<Solution<?>> solutionList,
+  public static <Value> List<Solution<Value>> getNormalizedFront(List<Solution<?>> solutionList,
     List<Double> maximumValue,
     List<Double> minimumValue) {
 
-    List<Solution<?>> normalizedSolutionSet = new ArrayList<>(solutionList.size()) ;
+    List<Solution<Value>> normalizedSolutionSet = new ArrayList<>(solutionList.size()) ;
 
     int numberOfObjectives = solutionList.get(0).getNumberOfObjectives() ;
     for (int i = 0; i < solutionList.size(); i++) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionListUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/SolutionListUtils.java
@@ -20,7 +20,7 @@ import java.util.List;
  */
 public class SolutionListUtils {
 
-  public static <S extends Solution> List<S> getNondominatedSolutions(List<S> solutionList) {
+  public static <S extends Solution<?>> List<S> getNondominatedSolutions(List<S> solutionList) {
     Ranking<S> ranking = new DominanceRanking<S>() ;
     return ranking.computeRanking(solutionList).getSubfront(0);
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/front/util/FrontNormalizer.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/front/util/FrontNormalizer.java
@@ -4,6 +4,7 @@ import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.front.Front;
 import org.uma.jmetal.util.front.imp.ArrayFront;
+import org.uma.jmetal.util.point.util.PointSolution;
 
 import java.util.List;
 
@@ -64,7 +65,7 @@ public class FrontNormalizer {
    * @param solutionList
    * @return
    */
-  public List<? extends Solution<?>> normalize(List<? extends Solution<?>> solutionList) {
+  public <S extends Solution> List<PointSolution> normalize(List<? extends Solution<?>> solutionList) {
     Front normalizedFront ;
     if (solutionList == null) {
       throw new JMetalException("The front is null") ;


### PR DESCRIPTION
Changes based on the following rules: It is highly recommended not to use wildcard types as return types. Because the type inference rules are fairly complex it is unlikely the user of that API will know how to use it correctly. 