### PR TITLE
Maintainability s1186

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/mutation/NullMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/mutation/NullMutation.java
@@ -11,6 +11,7 @@ import org.uma.jmetal.operator.MutationOperator;
 @SuppressWarnings("serial")
 public class NullMutation<S> implements MutationOperator<S> {
   public NullMutation() {
+	  //This method is intended to perform no mutation.
   }
 
   /** Execute() method */

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/MultithreadedSolutionListEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/MultithreadedSolutionListEvaluator.java
@@ -44,6 +44,7 @@ public class MultithreadedSolutionListEvaluator<S> implements SolutionListEvalua
   }
   
   @Override public void shutdown() {
+	  //This method is an intentionally-blank override.
     ;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/MultithreadedSolutionListEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/MultithreadedSolutionListEvaluator.java
@@ -45,7 +45,6 @@ public class MultithreadedSolutionListEvaluator<S> implements SolutionListEvalua
   
   @Override public void shutdown() {
 	  //This method is an intentionally-blank override.
-    ;
   }
 
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/SequentialSolutionListEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/SequentialSolutionListEvaluator.java
@@ -28,7 +28,6 @@ public class SequentialSolutionListEvaluator<S> implements SolutionListEvaluator
   }
 
   @Override public void shutdown() {
-	  //This method is an intentionally-blank override.
-	  ;
+	  // This method is an intentionally-blank override.
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/SequentialSolutionListEvaluator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/evaluator/impl/SequentialSolutionListEvaluator.java
@@ -28,6 +28,7 @@ public class SequentialSolutionListEvaluator<S> implements SolutionListEvaluator
   }
 
   @Override public void shutdown() {
-    ;
+	  //This method is an intentionally-blank override.
+	  ;
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoSetAndFrontFromDoubleSolutions.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateReferenceParetoSetAndFrontFromDoubleSolutions.java
@@ -227,6 +227,7 @@ public class GenerateReferenceParetoSetAndFrontFromDoubleSolutions implements Ex
     }
 
     @Override public void evaluate(DoubleSolution solution) {
+    	//This method is an intentionally-blank override.
     }
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/point/util/PointSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/point/util/PointSolution.java
@@ -83,6 +83,7 @@ public class PointSolution implements Solution<Double> {
   }
 
   @Override public void setVariableValue(int index, Double value) {
+	  //This method is an intentionally-blank override.
   }
 
   @Override public String getVariableValueString(int index) {


### PR DESCRIPTION
Changes based on the following rules:
There are several reasons for a method not to have a method body:

-     It is an unintentional omission, and should be fixed to prevent an unexpected behavior in production.
-     It is not yet, or never will be, supported. In this case an UnsupportedOperationException should be thrown.
-     The method is an intentionally-blank override. In this case a nested comment should explain the reason for the blank override.
