### PR TITLE
Utilities

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/util/StoredSolutionsUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/StoredSolutionsUtils.java
@@ -1,0 +1,85 @@
+package org.uma.jmetal.util;
+
+import org.uma.jmetal.problem.impl.AbstractDoubleProblem;
+import org.uma.jmetal.solution.DoubleSolution;
+import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.impl.DefaultDoubleSolution;
+import org.uma.jmetal.util.archive.impl.NonDominatedSolutionListArchive;
+import org.uma.jmetal.util.fileoutput.FileOutputContext;
+import org.uma.jmetal.util.solutionattribute.impl.GenericSolutionAttribute;
+import org.uma.jmetal.util.solutionattribute.impl.SolutionTextRepresentation;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class StoredSolutionsUtils {
+  private static final String DEFAULT_REGEX = "[ \t,]";
+  private static final GenericSolutionAttribute<Solution<?>, String> textRepresentation = SolutionTextRepresentation.getAttribute();
+
+
+  public static List<Solution<?>> readSolutionsFromFile(String inputFileName, int numberOfObjectives) {
+    Stream<String> lines;
+
+    try {
+      lines = Files.lines(Paths.get(inputFileName), Charset.defaultCharset());
+    } catch (IOException e) {
+      throw new JMetalException(e);
+    }
+
+    DummyProblem dummyProblem = new DummyProblem(numberOfObjectives);
+
+    List<Solution<?>> solutions = lines
+      .map(line -> {
+        String[] textNumbers = line.split(DEFAULT_REGEX, numberOfObjectives + 1);
+        DoubleSolution solution = new DefaultDoubleSolution(dummyProblem);
+        for (int i = 0; i < numberOfObjectives; i++) {
+          solution.setObjective(i, Double.parseDouble(textNumbers[i]));
+        }
+        solution.setAttribute(textRepresentation, line);
+
+        return solution;
+      })
+      .collect(toList());
+
+    return solutions;
+  }
+
+  public static void writeToOutput(NonDominatedSolutionListArchive<Solution<?>> archive, FileOutputContext context) {
+    BufferedWriter bufferedWriter = context.getFileWriter();
+
+    try {
+      for (Solution<?> s : archive.getSolutionList()) {
+        String formatedTextRepresentation = (String)s.getAttribute(SolutionTextRepresentation.getAttribute());
+        if (formatedTextRepresentation != null) {
+          bufferedWriter.write((String) s.getAttribute(SolutionTextRepresentation.getAttribute()));
+          bufferedWriter.newLine();
+        } else {
+          throw new JMetalException("Formated text representation of the solution not stored as attribute");
+        }
+      }
+      bufferedWriter.close();
+    } catch (IOException e) {
+      throw new JMetalException("Error printing objecives to file: ", e);
+    }
+  }
+
+
+  private static class DummyProblem extends AbstractDoubleProblem {
+
+    public DummyProblem(int numberOfObjectives) {
+      this.setNumberOfObjectives(numberOfObjectives);
+    }
+
+    @Override
+    public void evaluate(DoubleSolution solution) {
+
+    }
+  }
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/NonDominatedSolutionListArchive.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archive/impl/NonDominatedSolutionListArchive.java
@@ -88,12 +88,17 @@ public class NonDominatedSolutionListArchive<S extends Solution<?>> implements A
   }
 
   public Archive<S> join(Archive<S> archive) {
-    for (S solution : archive.getSolutionList()) {
+    return this.addAll(archive.getSolutionList());
+  }
+
+  public Archive<S> addAll(List<S> list) {
+    for (S solution : list) {
       this.add(solution) ;
     }
 
     return this ;
   }
+
 
   @Override
   public List<S> getSolutionList() {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/SolutionTextRepresentation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/SolutionTextRepresentation.java
@@ -3,4 +3,13 @@ package org.uma.jmetal.util.solutionattribute.impl;
 import org.uma.jmetal.solution.Solution;
 
 public class SolutionTextRepresentation extends GenericSolutionAttribute<Solution<?>,String>{
+
+  private static SolutionTextRepresentation singleInstance = null;
+  private SolutionTextRepresentation() {}
+
+  public static SolutionTextRepresentation getAttribute() {
+    if (singleInstance == null)
+      singleInstance = new SolutionTextRepresentation();
+    return singleInstance;
+  }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/SolutionTextRepresentation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/SolutionTextRepresentation.java
@@ -1,0 +1,6 @@
+package org.uma.jmetal.util.solutionattribute.impl;
+
+import org.uma.jmetal.solution.Solution;
+
+public class SolutionTextRepresentation extends GenericSolutionAttribute<Solution<?>,String>{
+}

--- a/jmetal-exec/src/main/java/org/uma/jmetal/utility/ExtractParetoDominatingSolutionsFromFile.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/utility/ExtractParetoDominatingSolutionsFromFile.java
@@ -1,0 +1,129 @@
+package org.uma.jmetal.utility;
+
+import org.uma.jmetal.problem.impl.AbstractDoubleProblem;
+import org.uma.jmetal.solution.DoubleSolution;
+import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.impl.DefaultDoubleSolution;
+import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.archive.impl.NonDominatedSolutionListArchive;
+import org.uma.jmetal.util.fileoutput.FileOutputContext;
+import org.uma.jmetal.util.fileoutput.impl.DefaultFileOutputContext;
+import org.uma.jmetal.util.solutionattribute.impl.GenericSolutionAttribute;
+import org.uma.jmetal.util.solutionattribute.impl.SolutionTextRepresentation;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * This utility takes an input file and produces an output file containing only the non-dominated solutions in the
+ * input file
+ *
+ * Each line of the file represents a solution. The format of each of these solutions is rather flexible and the
+ * only requirement is that for an n-objective problem, at least the first n columns must be numerical values
+ * representing these objectives values. By default columns can be separated by blank spaces, tabs, or commas (cvs)
+ *
+ * The program receives three parameters:
+ * 1. the name of the file containing the data
+ * 2. the output file name which will contain the generated front
+ * 3. the number of objectives
+ *
+ */
+public class ExtractParetoDominatingSolutionsFromFile {
+
+  private static final String DEFAULT_REGEX = "[ \t,]";
+  private static final GenericSolutionAttribute<Solution<?>, String> textRepresentation = new SolutionTextRepresentation();
+
+  public static void main(String[] args) throws IOException {
+    if (args.length != 3) {
+      throw new JMetalException("Wrong number of arguments: " + args.length +
+        "\nThis program should be called with three arguments:" +
+        "\nThe first argument is the name of the file containing the input solutions." +
+        "\nThe second argument is the name of the file containing the computed output." +
+        "\nThe third argument is the number of objectives of the problem whose front is to be extracted.");
+    }
+
+    String inputFileName = args[0];
+    String outputFileName = args[1];
+    Integer numberOfObjectives = Integer.parseInt(args[2]);
+
+    NonDominatedSolutionListArchive<Solution<?>> archive = null;
+
+    if (Files.isRegularFile(Paths.get(inputFileName))) {
+      archive = nonDominatedFromList(readSolutionsFromFile(inputFileName, numberOfObjectives));
+    } else {
+      throw new JMetalException("Error opening file " + inputFileName);
+    }
+
+    writeToOutput(archive, new DefaultFileOutputContext(outputFileName));
+  }
+
+  public static List<Solution<?>> readSolutionsFromFile(String inputFileName, int numberOfObjectives) {
+    Stream<String> lines;
+
+    try {
+      lines = Files.lines(Paths.get(inputFileName), Charset.defaultCharset());
+    } catch (IOException e) {
+      throw new JMetalException(e);
+    }
+
+    DummyProblem dummyProblem = new DummyProblem(numberOfObjectives);
+
+    List<Solution<?>> solutions = lines
+      .map(line -> {
+        String[] textNumbers = line.split(DEFAULT_REGEX, numberOfObjectives + 1);
+        DoubleSolution solution = new DefaultDoubleSolution(dummyProblem);
+        for (int i = 0; i < numberOfObjectives; i++) {
+          solution.setObjective(i, Double.parseDouble(textNumbers[i]));
+        }
+        solution.setAttribute(textRepresentation, line);
+
+        return solution;
+      })
+      .collect(toList());
+
+    return solutions;
+  }
+
+
+  public static NonDominatedSolutionListArchive<Solution<?>> nonDominatedFromList(List<Solution<?>> list) {
+    NonDominatedSolutionListArchive<Solution<?>> archive = new NonDominatedSolutionListArchive<>();
+
+    for (Solution<?> s : list)
+      archive.add(s);
+
+    return archive;
+  }
+
+  public static void writeToOutput(NonDominatedSolutionListArchive<Solution<?>> archive, FileOutputContext context) {
+    BufferedWriter bufferedWriter = context.getFileWriter();
+
+    try {
+      for (Solution<?> s : archive.getSolutionList()) {
+        bufferedWriter.write((String) s.getAttribute(textRepresentation));
+        bufferedWriter.newLine();
+      }
+      bufferedWriter.close();
+    } catch (IOException e) {
+      throw new JMetalException("Error printing objecives to file: ", e);
+    }
+  }
+
+  private static class DummyProblem extends AbstractDoubleProblem {
+
+    public DummyProblem(int numberOfObjectives) {
+      this.setNumberOfObjectives(numberOfObjectives);
+    }
+
+    @Override
+    public void evaluate(DoubleSolution solution) {
+
+    }
+  }
+}


### PR DESCRIPTION
Add support for extracting Pareto fronts also from csv and tsv files. It also adds support for extracting non-dominated solutions out of files containing more than only objective values. The extra information is preserved when written the non-dominated solutions to file. 