### PR TITLE
Refactor ADMDecisionTree

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
@@ -1,0 +1,29 @@
+package org.uma.jmetal.problem;
+
+/**
+ * A {@link BoundedProblem} is a {@link Problem} for which solution boundaries
+ * exist. Boundaries restrict each variable to be within an interval. This
+ * interval may be different for each variable of the solution.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ *
+ * @param <T>
+ *          Type of boundary, typically {@link Integer} or {@link Double}
+ * @param <S>
+ *          Type of {@link Problem} solutions
+ */
+public interface BoundedProblem<T extends Number, S> extends Problem<S> {
+  /**
+   * @param index
+   *          index of the variable
+   * @return lower bound of the variable
+   */
+  public T getLowerBound(int index);
+
+  /**
+   * @param index
+   *          index of the variable
+   * @return upper bound of the variable
+   */
+  public T getUpperBound(int index);
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/DoubleBinaryProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/DoubleBinaryProblem.java
@@ -5,9 +5,7 @@ package org.uma.jmetal.problem;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface DoubleBinaryProblem<S> extends Problem<S> {
-  public Number getLowerBound(int index) ;
-  public Number getUpperBound(int index) ;
+public interface DoubleBinaryProblem<S> extends BoundedProblem<Number, S> {
   public int getNumberOfDoubleVariables() ;
   public int getNumberOfBits() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/DoubleProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/DoubleProblem.java
@@ -7,7 +7,5 @@ import org.uma.jmetal.solution.DoubleSolution;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface DoubleProblem extends Problem<DoubleSolution> {
-  Double getLowerBound(int index) ;
-  Double getUpperBound(int index) ;
+public interface DoubleProblem extends BoundedProblem<Double, DoubleSolution> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/IntegerDoubleProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/IntegerDoubleProblem.java
@@ -5,9 +5,7 @@ package org.uma.jmetal.problem;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface IntegerDoubleProblem<S> extends Problem<S> {
-  public Number getLowerBound(int index) ;
-  public Number getUpperBound(int index) ;
+public interface IntegerDoubleProblem<S> extends BoundedProblem<Number, S> {
   public int getNumberOfIntegerVariables() ;
   public int getNumberOfDoubleVariables() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/IntegerProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/IntegerProblem.java
@@ -7,7 +7,5 @@ import org.uma.jmetal.solution.IntegerSolution;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface IntegerProblem extends Problem<IntegerSolution> {
-  public Integer getLowerBound(int index) ;
-  public Integer getUpperBound(int index) ;
+public interface IntegerProblem extends BoundedProblem<Integer, IntegerSolution> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/impl/ArtificialDecisionMakerDecisionTree.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/impl/ArtificialDecisionMakerDecisionTree.java
@@ -2,10 +2,8 @@ package org.uma.jmetal.util.artificialdecisionmaker.impl;
 
 
 import org.uma.jmetal.algorithm.InteractiveAlgorithm;
+import org.uma.jmetal.problem.BoundedProblem;
 import org.uma.jmetal.problem.Problem;
-import org.uma.jmetal.problem.impl.AbstractDoubleProblem;
-import org.uma.jmetal.problem.impl.AbstractIntegerDoubleProblem;
-import org.uma.jmetal.problem.impl.AbstractIntegerProblem;
 import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.artificialdecisionmaker.ArtificialDecisionMaker;
@@ -85,20 +83,8 @@ public class ArtificialDecisionMakerDecisionTree<S extends Solution<?>> extends 
       idealOjectiveVector.add(objetiveMinn);
       nadirObjectiveVector.add(objetiveMaxn);
     }
-    if(problem instanceof AbstractDoubleProblem){
-      AbstractDoubleProblem aux =(AbstractDoubleProblem)problem;
-      for (int i = 0; i < numberOfObjectives ; i++) {
-        idealOjectiveVector.add(aux.getLowerBound(i));
-        nadirObjectiveVector.add(aux.getUpperBound(i));
-      }
-    }else if(problem instanceof AbstractIntegerProblem){
-      AbstractIntegerProblem aux =(AbstractIntegerProblem)problem;
-      for (int i = 0; i < numberOfObjectives ; i++) {
-        idealOjectiveVector.add(new Double(aux.getLowerBound(i)));
-        nadirObjectiveVector.add(new Double(aux.getUpperBound(i)));
-      }
-    }else if(problem instanceof AbstractIntegerDoubleProblem){
-      AbstractIntegerDoubleProblem aux =(AbstractIntegerDoubleProblem)problem;
+    if(problem instanceof BoundedProblem){
+      BoundedProblem<?, ?> aux =(BoundedProblem<?, ?>)problem;
       for (int i = 0; i < numberOfObjectives ; i++) {
         idealOjectiveVector.add(aux.getLowerBound(i).doubleValue());
         nadirObjectiveVector.add(aux.getUpperBound(i).doubleValue());


### PR DESCRIPTION
# Context

ADMDT retrieves differently the solution boundaries depending on the type of problem to identify its ideal and nadir objectives.

# Problem

These pieces of code are highly similar, which makes a lot of redundancy. In particular, at the end they all retrieve `double` values from lower and upper bounds.

# Changes

I factored the `getXxxBound(i)` methods in a generic interface, which is then applied to existing interfaces to reduce them. Then I exploited this genericity to factor the code of ADMDT into a single case.