### PR TITLE
Restrict experiments to fulfill the requirements of ExperimentAlgorithm.

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/Experiment.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/Experiment.java
@@ -13,7 +13,7 @@ import java.util.List;
  *
  * Created by Antonio J. Nebro on 17/07/14.
  */
-public class Experiment<S extends Solution<?>, Result> {
+public class Experiment<S extends Solution<?>, Result extends List<S>> {
 	private String experimentName;
 	private List<ExperimentAlgorithm<S, Result>> algorithmList;
 	private List<ExperimentProblem<S>> problemList;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentBuilder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/ExperimentBuilder.java
@@ -13,7 +13,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class ExperimentBuilder<S extends Solution<?>, Result> {
+public class ExperimentBuilder<S extends Solution<?>, Result extends List<S>> {
   private final String experimentName ;
   private List<ExperimentAlgorithm<S, Result>> algorithmList;
   private List<ExperimentProblem<S>> problemList;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java
@@ -41,7 +41,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class ComputeQualityIndicators<S extends Solution<?>, Result> implements ExperimentComponent {
+public class ComputeQualityIndicators<S extends Solution<?>, Result extends List<S>> implements ExperimentComponent {
   private final Experiment<S, Result> experiment;
 
   public ComputeQualityIndicators(Experiment<S, Result> experiment) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ExecuteAlgorithms.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ExecuteAlgorithms.java
@@ -7,6 +7,7 @@ import org.uma.jmetal.util.experiment.Experiment;
 import org.uma.jmetal.util.experiment.ExperimentComponent;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * This class executes the algorithms the have been configured with a instance of class
@@ -18,7 +19,7 @@ import java.io.File;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class ExecuteAlgorithms<S extends Solution<?>, Result> implements ExperimentComponent {
+public class ExecuteAlgorithms<S extends Solution<?>, Result extends List<S>> implements ExperimentComponent {
   private Experiment<S, Result> experiment;
 
   /**

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateBoxplotsWithR.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateBoxplotsWithR.java
@@ -9,6 +9,7 @@ import org.uma.jmetal.util.experiment.util.ExperimentProblem;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * This class generates a R script that generates an eps file containing boxplots
@@ -22,7 +23,7 @@ import java.io.IOException;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class GenerateBoxplotsWithR<Result> implements ExperimentComponent {
+public class GenerateBoxplotsWithR<Result extends List<? extends Solution<?>>> implements ExperimentComponent {
   private static final String DEFAULT_R_DIRECTORY = "R";
 
   private final Experiment<?, Result> experiment;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateFriedmanTestTables.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateFriedmanTestTables.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.uma.jmetal.qualityindicator.impl.GenericIndicator;
+import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.experiment.Experiment;
 import org.uma.jmetal.util.experiment.ExperimentComponent;
@@ -28,7 +29,7 @@ import java.util.*;
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
 
-public class GenerateFriedmanTestTables<Result> implements ExperimentComponent {
+public class GenerateFriedmanTestTables<Result extends List<? extends Solution<?>>> implements ExperimentComponent {
   private static final String DEFAULT_LATEX_DIRECTORY = "latex";
 
   private final Experiment<?, Result> experiment;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateWilcoxonTestTablesWithR.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/GenerateWilcoxonTestTablesWithR.java
@@ -10,6 +10,7 @@ import org.uma.jmetal.util.experiment.util.ExperimentProblem;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * This class generates a R script that computes the Wilcoxon Signed Rank Test and generates a Latex script
@@ -25,7 +26,7 @@ import java.io.IOException;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class GenerateWilcoxonTestTablesWithR<Result> implements ExperimentComponent {
+public class GenerateWilcoxonTestTablesWithR<Result extends List<? extends Solution<?>>> implements ExperimentComponent {
   private static final String DEFAULT_R_DIRECTORY = "R";
   private static final String APPEND_STRING = "\", append=TRUE)\n";
   private static final String END_JUMP_STRING = "}\n";

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/util/ExperimentAlgorithm.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/util/ExperimentAlgorithm.java
@@ -15,7 +15,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class ExperimentAlgorithm<S extends Solution<?>, Result>  {
+public class ExperimentAlgorithm<S extends Solution<?>, Result extends List<S>>  {
   private Algorithm<Result> algorithm;
   private String algorithmTag;
   private String problemTag;
@@ -75,7 +75,7 @@ public class ExperimentAlgorithm<S extends Solution<?>, Result>  {
     algorithm.run();
     Result population = algorithm.getResult();
 
-    new SolutionListOutput((List<S>) population)
+    new SolutionListOutput(population)
             .setSeparator("\t")
             .setVarFileOutputContext(new DefaultFileOutputContext(varFile))
             .setFunFileOutputContext(new DefaultFileOutputContext(funFile))


### PR DESCRIPTION
# Context

`ExperimentAlgorithm` accepts any type of `Algorithm`, in the sense that it does not constrain its type of `Result`.

# Problem

This openness is not genuine, since it does cast the result into a list of solutions:
```java
new SolutionListOutput((List<S>) population) // <- Only List<S> is accepted
        .setSeparator("\t")
        .setVarFileOutputContext(new DefaultFileOutputContext(varFile))
        .setFunFileOutputContext(new DefaultFileOutputContext(funFile))
```

# Changes

I constrain the generics to ask for results in the form a of a list of solution. It allows to remove the cast, since it is now guaranteed to have the right type.

However, the indirect consequence is to break many experiment-related classes which did not assume such restriction. I spread this constraint all over the concerned classes to fix that, aligning it with the type of solution provided when relevant. Thus, most of the changes are about adding constraints to experiment.

As a consequence, all the jMetal experiments (`Experiment` class) make the assumption of dealing with algorithms generating a list of solution. Indeed, this root class directly builds on `ExperimentAlgorithm`, so it seems hard to assume that it can do without this constraint.

# Question

@ajnebro can you confirm that you only used these experiments with lists of solutions? If it is the case, then it should be OK to merge this change. Otherwise, could you please share an example of experiment on an algorithm providing a different type of result? This way I could see how to reduce the impact in a pragmatical way.