### PR TITLE
Fix warnings

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/espea/util/ScalarizationWrapper.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/espea/util/ScalarizationWrapper.java
@@ -105,11 +105,6 @@ public class ScalarizationWrapper {
      * they are computed on the fly.
      */
     private double[][] extremePoints;
-
-    /**
-     * A reference set.
-     */
-    private double[][] referenceSet;
   }
 
   /**

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/util/GWASFGARanking.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gwasfga/util/GWASFGARanking.java
@@ -28,6 +28,7 @@ import java.util.List;
  * - If two solutions have equal overall constraint values it compares de values of the utility function.
  *
  */
+@SuppressWarnings("serial")
 public class GWASFGARanking<S extends Solution<?>> extends GenericSolutionAttribute<S, Integer>
         implements Ranking<S> {
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADD.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADD.java
@@ -13,6 +13,7 @@ import org.uma.jmetal.util.solutionattribute.impl.DominanceRanking;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings("serial")
 public class MOEADD<S extends DoubleSolution> extends AbstractMOEAD<S> {
 
   protected Ranking<S> ranking;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/util/MOEADUtils.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/util/MOEADUtils.java
@@ -156,7 +156,9 @@ public class MOEADUtils {
           currentBest = solutionList.get(j);
         }
       }
-      resultSolutionList.add((S) currentBest.copy());
+      @SuppressWarnings("unchecked")
+      S copy = (S) currentBest.copy() ;
+      resultSolutionList.add(copy);
     }
   }
 
@@ -196,7 +198,9 @@ public class MOEADUtils {
 
       // add the selected to res and remove from candidate list
       S removedSolution = candidate.remove(index) ;
-      resultSolutionList.add((S)removedSolution.copy());
+      @SuppressWarnings("unchecked")
+      S copy = (S) removedSolution.copy() ;
+      resultSolutionList.add(copy);
     }
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/util/MOEADUtils.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/util/MOEADUtils.java
@@ -166,7 +166,7 @@ public class MOEADUtils {
           int newSolutionListSize) {
 
     Distance<S, List<S>> distance =
-            new EuclideanDistanceBetweenSolutionAndASolutionListInObjectiveSpace() ;
+            new EuclideanDistanceBetweenSolutionAndASolutionListInObjectiveSpace<>() ;
 
     int randomIndex = JMetalRandom.getInstance().nextInt(0, solutionList.size() - 1) ;
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/DNSGAII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/DNSGAII.java
@@ -18,6 +18,7 @@ import java.util.List;
  * "Cai X, Sun H, Fan Z. A diversity indicator based on reference vectors for many-objective optimization[J]. Information Sciences, 2018, 430-431:467-486.".
  * @author sunhaoran <nuaa_sunhr@yeah.net>
  */
+@SuppressWarnings("serial")
 public class DNSGAII<S extends Solution<?>> extends NSGAII<S> {
 
     private double[][] referenceVectors ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/rnsgaii/util/RNSGAIIRanking.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/rnsgaii/util/RNSGAIIRanking.java
@@ -112,15 +112,6 @@ public class RNSGAIIRanking <S extends Solution<?>> extends GenericSolutionAttri
     }
 
 
-    private void removeRank(S solution){
-        int i=0;
-        while(i< this.rankedSubpopulations.size()){
-            while(this.rankedSubpopulations.get(i).contains(solution)){
-                this.rankedSubpopulations.get(i).remove(solution);
-            }
-            i++;
-        }
-    }
     private double preference(S solution1, S solution2,List<Double> upperBounds,List<Double> lowerBounds){
         double result =0.0D;
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/rnsgaii/util/RNSGAIIRanking.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/rnsgaii/util/RNSGAIIRanking.java
@@ -10,6 +10,7 @@ import org.uma.jmetal.util.solutionattribute.impl.NumberOfViolatedConstraints;
 
 import java.util.*;
 
+@SuppressWarnings("serial")
 public class RNSGAIIRanking <S extends Solution<?>> extends GenericSolutionAttribute<S, Integer>
         implements Ranking<S> {
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSORP.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSORP.java
@@ -43,6 +43,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
+@SuppressWarnings("serial")
 public class SMPSORP
         extends AbstractParticleSwarmOptimization<DoubleSolution, List<DoubleSolution>>
         implements Measurable {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/util/EnvironmentalSelection.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/spea2/util/EnvironmentalSelection.java
@@ -18,7 +18,6 @@ import java.util.*;
 public class EnvironmentalSelection<S extends Solution<?>> implements SelectionOperator<List<S>,List<S>> {
 
   private int solutionsToSelect ;
-  private int k ;
   private StrengthRawFitness<S> strengthRawFitness ;
 
   public EnvironmentalSelection(int solutionsToSelect) {
@@ -27,7 +26,6 @@ public class EnvironmentalSelection<S extends Solution<?>> implements SelectionO
 
   public EnvironmentalSelection(int solutionsToSelect, int k) {
     this.solutionsToSelect = solutionsToSelect ;
-    this.k = k ;
     this.strengthRawFitness = new StrengthRawFitness<>(k) ;
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/util/WASFGARanking.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/wasfga/util/WASFGARanking.java
@@ -28,6 +28,7 @@ import java.util.List;
  * - If two solutions have equal overall constraint values it compares de values of the utility function.
  *
  */
+@SuppressWarnings("serial")
 public class WASFGARanking<S extends Solution<?>> extends GenericSolutionAttribute<S, Integer>
 		implements Ranking<S> {
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/NPointCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/NPointCrossover.java
@@ -12,6 +12,7 @@ import java.util.List;
 /**
  * Created by FlapKap on 23-03-2017.
  */
+@SuppressWarnings("serial")
 public class NPointCrossover<T> implements CrossoverOperator<Solution<T>> {
   private final JMetalRandom randomNumberGenerator = JMetalRandom.getInstance();
   private final double probability;

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/TwoPointCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/crossover/TwoPointCrossover.java
@@ -8,6 +8,7 @@ import java.util.List;
 /**
  * Created by FlapKap on 27-05-2017.
  */
+@SuppressWarnings("serial")
 public class TwoPointCrossover<T> implements CrossoverOperator<Solution<T>> {
   NPointCrossover<T> operator;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/RankingAndDirScoreSelection.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/RankingAndDirScoreSelection.java
@@ -19,6 +19,7 @@ import java.util.List;
  * "Cai X, Sun H, Fan Z. A diversity indicator based on reference vectors for many-objective optimization[J]. Information Sciences, 2018, 430-431:467-486."
  * @author sunhaoran <nuaa_sunhr@yeah.net>
  */
+@SuppressWarnings("serial")
 public class RankingAndDirScoreSelection<S extends Solution<?>>
         extends RankingAndCrowdingSelection<S> {
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/RankingAndPreferenceSelection.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/impl/selection/RankingAndPreferenceSelection.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@SuppressWarnings("serial")
 public class RankingAndPreferenceSelection<S extends Solution<?>>
         implements SelectionOperator<List<S>, List<S>> {
   private final int solutionsToSelect;

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/impl/DynamicDoubleProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/impl/DynamicDoubleProblem.java
@@ -42,6 +42,7 @@ import org.uma.jmetal.util.solutionattribute.impl.OverallConstraintViolation;
  *  This class does not intend to be a replacement of the existing of {@link AbstractDoubleProblem};
  *  it is merely an alternative way of defining a problem.
  */
+@SuppressWarnings("serial")
 public class DynamicDoubleProblem implements DoubleProblem {
 
   private List<Function<Double[], Double>> objectiveFunction ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/StoredSolutionsUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/StoredSolutionsUtils.java
@@ -73,6 +73,7 @@ public class StoredSolutionsUtils {
   }
 
 
+  @SuppressWarnings("serial")
   private static class DummyProblem extends AbstractDoubleProblem {
 
     public DummyProblem(int numberOfObjectives) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/StoredSolutionsUtils.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/StoredSolutionsUtils.java
@@ -47,6 +47,8 @@ public class StoredSolutionsUtils {
         return solution;
       })
       .collect(toList());
+    
+    lines.close();
 
     return solutions;
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archivewithreferencepoint/ArchiveWithReferencePoint.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archivewithreferencepoint/ArchiveWithReferencePoint.java
@@ -15,6 +15,7 @@ import java.util.List;
  *
  * @param <S>
  */
+@SuppressWarnings("serial")
 public abstract class ArchiveWithReferencePoint <S extends Solution<?>> extends AbstractBoundedArchive<S> {
   protected List<Double> referencePoint ;
   protected S referencePointSolution ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archivewithreferencepoint/ArchiveWithReferencePoint.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archivewithreferencepoint/ArchiveWithReferencePoint.java
@@ -36,7 +36,9 @@ public abstract class ArchiveWithReferencePoint <S extends Solution<?>> extends 
     boolean result ;
 
     if (referencePointSolution == null) {
-      referencePointSolution = (S) solution.copy();
+      @SuppressWarnings("unchecked")
+      S copy = (S) solution.copy();
+      referencePointSolution = copy;
       for (int i = 0; i < solution.getNumberOfObjectives(); i++) {
         referencePointSolution.setObjective(i, this.referencePoint.get(i));
       }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archivewithreferencepoint/impl/CrowdingDistanceArchiveWithReferencePoint.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archivewithreferencepoint/impl/CrowdingDistanceArchiveWithReferencePoint.java
@@ -27,6 +27,7 @@ import java.util.List;
  * Class representing a {@link ArchiveWithReferencePoint} archive using a crowding distance based density estimator
  * @author Antonio J. Nebro
  */
+@SuppressWarnings("serial")
 public class CrowdingDistanceArchiveWithReferencePoint<S extends Solution<?>> extends ArchiveWithReferencePoint<S> {
   private DensityEstimator<S> densityEstimator ;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/archivewithreferencepoint/impl/HypervolumeArchiveWithReferencePoint.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/archivewithreferencepoint/impl/HypervolumeArchiveWithReferencePoint.java
@@ -30,6 +30,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro
  */
+@SuppressWarnings("serial")
 public class HypervolumeArchiveWithReferencePoint<S extends Solution<?>> extends ArchiveWithReferencePoint<S> {
   private Hypervolume<S> hypervolume ;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/ArtificialDecisionMaker.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/ArtificialDecisionMaker.java
@@ -7,6 +7,7 @@ import org.uma.jmetal.problem.Problem;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings("serial")
 public abstract class ArtificialDecisionMaker<S, R> implements Algorithm<R> {
 
   protected InteractiveAlgorithm<S,R> algorithm;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/impl/ArtificialDecisionMakerDecisionTree.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/impl/ArtificialDecisionMakerDecisionTree.java
@@ -22,6 +22,7 @@ import java.util.*;
  * In International Conference on Parallel Problem Solving from Nature (pp. 483-492). Springer, Cham.
  * @author Cristobal Barba <cbarba@lcc.uma.es>
  */
+@SuppressWarnings("serial")
 public class ArtificialDecisionMakerDecisionTree<S extends Solution<?>> extends ArtificialDecisionMaker<S,List<S>> {
 
   protected List<Double> idealOjectiveVector = null;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/impl/ArtificiallDecisionMakerBuilder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/impl/ArtificiallDecisionMakerBuilder.java
@@ -22,7 +22,6 @@ public class ArtificiallDecisionMakerBuilder<S extends Solution<?>> implements A
   private double considerationProbability;
   private double tolerance;
   private List<Double> rankingCoeficient;
-  private int numberReferencePoints;
   private List<Double> asp;
 
   /**
@@ -32,7 +31,6 @@ public class ArtificiallDecisionMakerBuilder<S extends Solution<?>> implements A
     this.problem = problem;
     this.maxEvaluations = 25000;
     this.algorithm = algorithm;
-    this.numberReferencePoints =1;
   }
 
   public ArtificiallDecisionMakerBuilder<S> setMaxEvaluations(int maxEvaluations) {
@@ -79,7 +77,6 @@ public class ArtificiallDecisionMakerBuilder<S extends Solution<?>> implements A
   }
 
   public ArtificiallDecisionMakerBuilder<S> setNumberReferencePoints(int numberReferencePoints) {
-    this.numberReferencePoints = numberReferencePoints;
     return this;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/chartcontainer/ChartContainerWithReferencePoints.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/chartcontainer/ChartContainerWithReferencePoints.java
@@ -30,13 +30,7 @@ public class ChartContainerWithReferencePoints {
   private int delay;
   private int objective1;
   private int objective2;
-  private int variable1;
-  private int variable2;
-  private Map<String, List<Integer>> iterations;
-  private Map<String, List<Double>> indicatorValues;
   private List<String> referencePointName ;
-
-  private int updateCounter = 1 ;
 
   public ChartContainerWithReferencePoints(String name) {
     this(name, 0);
@@ -46,8 +40,6 @@ public class ChartContainerWithReferencePoints {
     this.name = name;
     this.delay = delay;
     this.charts = new LinkedHashMap<String, XYChart>();
-    this.iterations = new HashMap<String, List<Integer>>();
-    this.indicatorValues = new HashMap<String, List<Double>>();
     this.referencePointName = new ArrayList<>() ;
   }
 
@@ -174,14 +166,6 @@ public class ChartContainerWithReferencePoints {
     double[] result = new double[solutionList.size()];
     for (int i = 0; i < solutionList.size(); i++) {
       result[i] = solutionList.get(i).getObjective(objective);
-    }
-    return result;
-  }
-
-  private double[] getVariableValues(List<DoubleSolution> solutionList, int variable) {
-    double[] result = new double[solutionList.size()];
-    for (int i = 0; i < solutionList.size(); i++) {
-      result[i] = solutionList.get(i).getVariableValue(variable);
     }
     return result;
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/DirScoreComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/DirScoreComparator.java
@@ -10,6 +10,7 @@ import java.util.Comparator;
  * The comparator of DIR score used in D-NSGA-II
  * @author sunhaoran <nuaa_sunhr@yeah.net>
  */
+@SuppressWarnings("serial")
 public class DirScoreComparator<S extends Solution<?>> implements Comparator<S>, Serializable {
 
     @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/RankingAndDirScoreDistanceComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/RankingAndDirScoreDistanceComparator.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
  * @see DirScoreComparator
  * @author sunhaoran <nuaa_sunhr@yeah.net>
  */
+@SuppressWarnings("serial")
 public class RankingAndDirScoreDistanceComparator<S extends Solution<?>> implements Comparator<S>, Serializable {
     private final Comparator<S> rankingComparator = new RankingComparator<>();
     private final Comparator<S> dirScoreComparator = new DirScoreComparator<>() ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/experiment/component/ComputeQualityIndicators.java
@@ -17,7 +17,6 @@ import org.uma.jmetal.util.front.util.FrontNormalizer;
 import org.uma.jmetal.util.front.util.FrontUtils;
 import org.uma.jmetal.util.point.PointSolution;
 
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -98,35 +97,6 @@ public class ComputeQualityIndicators<S extends Solution<?>, Result extends List
       os.write("" + indicatorValue + "\n");
     } catch (IOException ex) {
       throw new JMetalException("Error writing indicator file" + ex) ;
-    }
-  }
-
-  /**
-   * Deletes a file or directory if it does exist
-   * @param file
-   */
-  private void resetFile(String file) {
-    File f = new File(file);
-    if (f.exists()) {
-      JMetalLogger.logger.info("Already existing file " + file);
-
-      if (f.isDirectory()) {
-        JMetalLogger.logger.info("Deleting directory " + file);
-        if (f.delete()) {
-          JMetalLogger.logger.info("Directory successfully deleted.");
-        } else {
-          JMetalLogger.logger.info("Error deleting directory.");
-        }
-      } else {
-        JMetalLogger.logger.info("Deleting file " + file);
-        if (f.delete()) {
-          JMetalLogger.logger.info("File successfully deleted.");
-        } else {
-          JMetalLogger.logger.info("Error deleting file.");
-        }
-      }
-    } else {
-      JMetalLogger.logger.info("File " + file + " does NOT exist.");
     }
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/KNearestNeighborhood.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/KNearestNeighborhood.java
@@ -14,6 +14,7 @@ import java.util.List;
  *
  * @param <S>
  */
+@SuppressWarnings("serial")
 public class KNearestNeighborhood<S extends Solution<?>> implements Neighborhood<S> {
   private int neighborSize;
   private Distance<S, S> distance;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/WeightVectorNeighborhood.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/neighborhood/impl/WeightVectorNeighborhood.java
@@ -14,6 +14,7 @@ import java.util.StringTokenizer;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
+@SuppressWarnings("serial")
 public class WeightVectorNeighborhood<S> implements Neighborhood<S> {
   private int numberOfWeightVectors;
   private int weightVectorSize;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/DirScore.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/DirScore.java
@@ -12,6 +12,7 @@ import java.util.List;
  * Estimate DIR scores for solutions, used in D-NSGA-II
  * @author sunhaoran <nuaa_sunhr@yeah.net>
  */
+@SuppressWarnings("serial")
 public class DirScore<S extends Solution<?>>  extends GenericSolutionAttribute<S, Double> implements DensityEstimator<S> {
 
     private double[][] referenceVectors ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/PreferenceDistance.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/PreferenceDistance.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+@SuppressWarnings("serial")
 public class PreferenceDistance<S extends Solution<?>> extends GenericSolutionAttribute<S, Double> implements DensityEstimator<S> {
     private  List<Double> interestPoint;
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/SolutionTextRepresentation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/solutionattribute/impl/SolutionTextRepresentation.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.util.solutionattribute.impl;
 
 import org.uma.jmetal.solution.Solution;
 
+@SuppressWarnings("serial")
 public class SolutionTextRepresentation extends GenericSolutionAttribute<Solution<?>,String>{
 
   private static SolutionTextRepresentation singleInstance = null;

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/NaryTournamentSelectionTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/impl/selection/NaryTournamentSelectionTest.java
@@ -12,7 +12,6 @@ import org.uma.jmetal.solution.IntegerSolution;
 import org.uma.jmetal.util.JMetalException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 

--- a/jmetal-core/src/test/java/org/uma/jmetal/qualityindicator/impl/hypervolume/PISAHypervolumeTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/qualityindicator/impl/hypervolume/PISAHypervolumeTest.java
@@ -45,6 +45,7 @@ public class PISAHypervolumeTest {
     assertEquals(0.6661, result, 0.0001) ;
   }
 
+  @SuppressWarnings("serial")
   private class MockDoubleProblem extends AbstractDoubleProblem {
 
     /** Constructor */

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/SolutionUtilsTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/SolutionUtilsTest.java
@@ -161,6 +161,7 @@ public class SolutionUtilsTest {
     assertEquals(0.5, SolutionUtils.averageDistanceToSolutionList(solution1, solutionList), EPSILON) ;
   }
 */
+  @SuppressWarnings("serial")
   private class MockedDoubleProblem extends AbstractDoubleProblem {
     public MockedDoubleProblem(int numberOfVariables) {
       setNumberOfVariables(numberOfVariables);

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/neighborhood/impl/WeightVectorNeighborhoodTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/neighborhood/impl/WeightVectorNeighborhoodTest.java
@@ -77,6 +77,7 @@ public class WeightVectorNeighborhoodTest {
 		assertSame(solutionList.get(79), neighbors.get(19)) ;
 	}
 	
+	@SuppressWarnings("serial")
 	private static class MockedDoubleProblem extends AbstractDoubleProblem {
 		public MockedDoubleProblem(int numberOfVariables, int numberOfObjectives) {
 			setNumberOfVariables(numberOfVariables);

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORPChangingTheReferencePointsAndChartsRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORPChangingTheReferencePointsAndChartsRunner.java
@@ -191,33 +191,35 @@ public class SMPSORPChangingTheReferencePointsAndChartsRunner {
 
     @Override
     public void run() {
-      Scanner scanner = new Scanner(System.in);
-
-      double v1 ;
-      double v2 ;
-
-      while (true) {
-        System.out.println("Introduce the new reference point (between commas):");
-        String s = scanner.nextLine() ;
-        Scanner sl= new Scanner(s);
-        sl.useDelimiter(",");
-
-        for (int i = 0; i < referencePoints.size(); i++) {
-          try {
-            v1 = Double.parseDouble(sl.next());
-            v2 = Double.parseDouble(sl.next());
-          } catch (Exception e) {//any problem
-            v1 = 0;
-            v2 = 0;
+      try (Scanner scanner = new Scanner(System.in)) {
+        double v1 ;
+        double v2 ;
+        
+        while (true) {
+          System.out.println("Introduce the new reference point (between commas):");
+          String s = scanner.nextLine() ;
+          
+          try (Scanner sl = new Scanner(s)) {
+            sl.useDelimiter(",");
+            
+            for (int i = 0; i < referencePoints.size(); i++) {
+              try {
+                v1 = Double.parseDouble(sl.next());
+                v2 = Double.parseDouble(sl.next());
+              } catch (Exception e) {//any problem
+                v1 = 0;
+                v2 = 0;
+              }
+              
+              referencePoints.get(i).set(0, v1);
+              referencePoints.get(i).set(1, v2);
+            }
           }
-
-          referencePoints.get(i).set(0, v1);
-          referencePoints.get(i).set(1, v2);
+          
+          chart.updateReferencePoint(referencePoints);
+          
+          algorithm.changeReferencePoints(referencePoints);
         }
-
-        chart.updateReferencePoint(referencePoints);
-
-        algorithm.changeReferencePoints(referencePoints);
       }
     }
   }

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORPChangingTheReferencePointsAndChartsRunner.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORPChangingTheReferencePointsAndChartsRunner.java
@@ -174,7 +174,6 @@ public class SMPSORPChangingTheReferencePointsAndChartsRunner {
   private static class ChangeReferencePoint implements Runnable {
     ChartContainerWithReferencePoints chart ;
     List<List<Double>> referencePoints;
-    List<ArchiveWithReferencePoint<DoubleSolution>> archivesWithReferencePoints;
     SMPSORP algorithm ;
 
     public ChangeReferencePoint(
@@ -184,7 +183,6 @@ public class SMPSORPChangingTheReferencePointsAndChartsRunner {
             ChartContainerWithReferencePoints chart)
         throws InterruptedException {
       this.referencePoints = referencePoints;
-      this.archivesWithReferencePoints = archivesWithReferencePoints;
       this.chart = chart ;
       this.algorithm = (SMPSORP) algorithm ;
     }

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1.java
@@ -191,33 +191,35 @@ public class SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1 {
 
     @Override
     public void run() {
-      Scanner scanner = new Scanner(System.in);
-
-      double v1 ;
-      double v2 ;
-
-      while (true) {
-        System.out.println("Introduce the new reference point (between commas):");
-        String s = scanner.nextLine() ;
-        Scanner sl= new Scanner(s);
-        sl.useDelimiter(",");
-
-        for (int i = 0; i < referencePoints.size(); i++) {
-          try {
-            v1 = Double.parseDouble(sl.next());
-            v2 = Double.parseDouble(sl.next());
-          } catch (Exception e) {//any problem
-            v1 = 0;
-            v2 = 0;
+      try (Scanner scanner = new Scanner(System.in)) {
+        double v1 ;
+        double v2 ;
+        
+        while (true) {
+          System.out.println("Introduce the new reference point (between commas):");
+          String s = scanner.nextLine() ;
+          
+          try (Scanner sl = new Scanner(s)) {
+            sl.useDelimiter(",");
+            
+            for (int i = 0; i < referencePoints.size(); i++) {
+              try {
+                v1 = Double.parseDouble(sl.next());
+                v2 = Double.parseDouble(sl.next());
+              } catch (Exception e) {//any problem
+                v1 = 0;
+                v2 = 0;
+              }
+              
+              referencePoints.get(i).set(0, v1);
+              referencePoints.get(i).set(1, v2);
+            }
           }
-
-          referencePoints.get(i).set(0, v1);
-          referencePoints.get(i).set(1, v2);
+          
+          chart.updateReferencePoint(referencePoints);
+          
+          algorithm.changeReferencePoints(referencePoints);
         }
-
-        chart.updateReferencePoint(referencePoints);
-
-        algorithm.changeReferencePoints(referencePoints);
       }
     }
   }

--- a/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/runner/multiobjective/SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1.java
@@ -174,7 +174,6 @@ public class SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1 {
   private static class ChangeReferencePoint implements Runnable {
     ChartContainerWithReferencePoints chart ;
     List<List<Double>> referencePoints;
-    List<ArchiveWithReferencePoint<DoubleSolution>> archivesWithReferencePoints;
     SMPSORP algorithm ;
 
     public ChangeReferencePoint(
@@ -184,7 +183,6 @@ public class SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1 {
             ChartContainerWithReferencePoints chart)
         throws InterruptedException {
       this.referencePoints = referencePoints;
-      this.archivesWithReferencePoints = archivesWithReferencePoints;
       this.chart = chart ;
       this.algorithm = (SMPSORP) algorithm ;
     }

--- a/jmetal-exec/src/main/java/org/uma/jmetal/utility/GenerateReferenceFrontFromFile.java
+++ b/jmetal-exec/src/main/java/org/uma/jmetal/utility/GenerateReferenceFrontFromFile.java
@@ -70,6 +70,9 @@ public class GenerateReferenceFrontFromFile {
       throw new JMetalException(e) ;
     }
 
-    return lines.findFirst().get().split(" ").length;
+    int numberOfObjectives = lines.findFirst().get().split(" ").length ;
+    lines.close();
+    
+    return numberOfObjectives;
   }
 }

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF01.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF01.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF01
  */
+@SuppressWarnings("serial")
 public class MaF01 extends AbstractDoubleProblem {
 
   /**

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF02.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF02.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF02, DTLZ2BZ
  */
+@SuppressWarnings("serial")
 public class MaF02 extends AbstractDoubleProblem {
 
   public static int const2;

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF03.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF03.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF03, convex DTLZ3
  */
+@SuppressWarnings("serial")
 public class MaF03 extends AbstractDoubleProblem {
 
   /**

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF04.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF04.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF04
  */
+@SuppressWarnings("serial")
 public class MaF04 extends AbstractDoubleProblem {
   public static double const4[];
 

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF05.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF05.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF05
  */
+@SuppressWarnings("serial")
 public class MaF05 extends AbstractDoubleProblem {
 
   public static double const5[];

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF06.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF06.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF06
  */
+@SuppressWarnings("serial")
 public class MaF06 extends AbstractDoubleProblem {
 
   /**

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF07.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF07.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF07
  */
+@SuppressWarnings("serial")
 public class MaF07 extends AbstractDoubleProblem {
 
   /**

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF08.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF08.java
@@ -9,6 +9,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF08
  */
+@SuppressWarnings("serial")
 public class MaF08 extends AbstractDoubleProblem {
 
   public static double const8[][];

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF09.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF09.java
@@ -10,6 +10,7 @@ import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 /**
  * Class representing problem MaF05
  */
+@SuppressWarnings("serial")
 public class MaF09 extends AbstractDoubleProblem {
 
   public static int maxinter9;

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF10.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF10.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF10
  */
+@SuppressWarnings("serial")
 public class MaF10 extends AbstractDoubleProblem {
   public static int K10;
 

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF11.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF11.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF11
  */
+@SuppressWarnings("serial")
 public class MaF11 extends AbstractDoubleProblem {
 
   public static int K11, L11;

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF12.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF12.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF12
  */
+@SuppressWarnings("serial")
 public class MaF12 extends AbstractDoubleProblem {
 
   public static int K12, L12;

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF13.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF13.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF13
  */
+@SuppressWarnings("serial")
 public class MaF13 extends AbstractDoubleProblem {
 
   /**

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF14.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF14.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF14
  */
+@SuppressWarnings("serial")
 public class MaF14 extends AbstractDoubleProblem {
   public static int nk14;
   public static int sublen14[], len14[];

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF15.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF15.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.DoubleSolution;
 /**
  * Class representing problem MaF15
  */
+@SuppressWarnings("serial")
 public class MaF15 extends AbstractDoubleProblem {
   public static int nk15;
   public static int sublen15[], len15[];


### PR DESCRIPTION
Here is another resolution of warnings. Some are trivial stuff, but others not.

For closing the resources, I used an explicit close or a try-resource pattern depending of what I judged more practical. The second solution implies a reindentation, which is why you can see big blocks of changes. If you hide whitespaces, you can see that it is just about closing the resources.

For the unchecked types, I added explicit variables to suppress warnings on them (to not suppress it on the whole method).

For unused stuff, I have **removed several variables, fields, and methods**. Some removals made public methods useless. I did not remove them to not break anything, but I added deprecated tags. Please look at these changes to see if the removal are properly motivated.

All the other commits are about trivial stuff.