### PR TITLE
Remove useless life time of random generators.

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -17,6 +17,10 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
   private List<T> variables;
   protected P problem ;
   protected Map<Object, Object> attributes ;
+  /**
+   * @deprecated Call {@link JMetalRandom#getInstance()} if you need one.
+   */
+  @Deprecated
   protected final JMetalRandom randomGenerator ;
 
   /**

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
@@ -3,6 +3,7 @@ package org.uma.jmetal.solution.impl;
 import org.uma.jmetal.problem.BinaryProblem;
 import org.uma.jmetal.solution.BinarySolution;
 import org.uma.jmetal.util.binarySet.BinarySet;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +22,7 @@ public class DefaultBinarySolution
   public DefaultBinarySolution(BinaryProblem problem) {
     super(problem) ;
 
-    initializeBinaryVariables();
+    initializeBinaryVariables(JMetalRandom.getInstance());
     initializeObjectiveValues();
   }
 
@@ -40,7 +41,7 @@ public class DefaultBinarySolution
     attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
-  private BinarySet createNewBitSet(int numberOfBits) {
+  private static BinarySet createNewBitSet(int numberOfBits, JMetalRandom randomGenerator) {
     BinarySet bitSet = new BinarySet(numberOfBits) ;
 
     for (int i = 0; i < numberOfBits; i++) {
@@ -88,9 +89,9 @@ public class DefaultBinarySolution
     return result ;
   }
   
-  private void initializeBinaryVariables() {
+  private void initializeBinaryVariables(JMetalRandom randomGenerator) {
     for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, createNewBitSet(problem.getNumberOfBits(i)));
+      setVariableValue(i, createNewBitSet(problem.getNumberOfBits(i), randomGenerator));
     }
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.DoubleBinaryProblem;
 import org.uma.jmetal.solution.DoubleBinarySolution;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.BitSet;
 import java.util.HashMap;
@@ -29,8 +30,8 @@ public class DefaultDoubleBinarySolution
 
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
 
-    initializeDoubleVariables();
-    initializeBitSet() ;
+    initializeDoubleVariables(JMetalRandom.getInstance());
+    initializeBitSet(JMetalRandom.getInstance()) ;
     initializeObjectiveValues();
   }
 
@@ -47,7 +48,7 @@ public class DefaultDoubleBinarySolution
     attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
-  private void initializeDoubleVariables() {
+  private void initializeDoubleVariables(JMetalRandom randomGenerator) {
     for (int i = 0 ; i < numberOfDoubleVariables; i++) {
       Double value = randomGenerator.nextDouble(getLowerBound(i), getUpperBound(i)) ;
       //variables.add(value) ;
@@ -55,8 +56,8 @@ public class DefaultDoubleBinarySolution
     }
   }
 
-  private void initializeBitSet() {
-    BitSet bitset = createNewBitSet(problem.getNumberOfBits()) ;
+  private void initializeBitSet(JMetalRandom randomGenerator) {
+    BitSet bitset = createNewBitSet(problem.getNumberOfBits(), randomGenerator) ;
     setVariableValue(numberOfDoubleVariables, bitset);
   }
 
@@ -101,7 +102,7 @@ public class DefaultDoubleBinarySolution
     return getVariableValue(index).toString() ;
   }
 
-  private BitSet createNewBitSet(int numberOfBits) {
+  private BitSet createNewBitSet(int numberOfBits, JMetalRandom randomGenerator) {
     BitSet bitSet = new BitSet(numberOfBits) ;
 
     for (int i = 0; i < numberOfBits; i++) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +21,7 @@ public class DefaultDoubleSolution
   public DefaultDoubleSolution(DoubleProblem problem) {
     super(problem) ;
 
-    initializeDoubleVariables();
+    initializeDoubleVariables(JMetalRandom.getInstance());
     initializeObjectiveValues();
   }
 
@@ -59,7 +60,7 @@ public class DefaultDoubleSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeDoubleVariables() {
+  private void initializeDoubleVariables(JMetalRandom randomGenerator) {
     for (int i = 0 ; i < problem.getNumberOfVariables(); i++) {
       Double value = randomGenerator.nextDouble(getLowerBound(i), getUpperBound(i)) ;
       setVariableValue(i, value) ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.IntegerDoubleProblem;
 import org.uma.jmetal.solution.IntegerDoubleSolution;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +27,7 @@ public class DefaultIntegerDoubleSolution
     numberOfIntegerVariables = problem.getNumberOfIntegerVariables() ;
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
 
-    initializeIntegerDoubleVariables() ;
+    initializeIntegerDoubleVariables(JMetalRandom.getInstance()) ;
     initializeObjectiveValues() ;
   }
 
@@ -79,7 +80,7 @@ public class DefaultIntegerDoubleSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeIntegerDoubleVariables() {
+  private void initializeIntegerDoubleVariables(JMetalRandom randomGenerator) {
     for (int i = 0 ; i < numberOfIntegerVariables; i++) {
       Integer value = randomGenerator.nextInt((Integer)getLowerBound(i), (Integer)getUpperBound(i)) ;
       setVariableValue(i, value) ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.IntegerProblem;
 import org.uma.jmetal.solution.IntegerSolution;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +21,7 @@ public class DefaultIntegerSolution
   public DefaultIntegerSolution(IntegerProblem problem) {
     super(problem) ;
 
-    initializeIntegerVariables();
+    initializeIntegerVariables(JMetalRandom.getInstance());
     initializeObjectiveValues();
   }
 
@@ -59,7 +60,7 @@ public class DefaultIntegerSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeIntegerVariables() {
+  private void initializeIntegerVariables(JMetalRandom randomGenerator) {
     for (int i = 0 ; i < problem.getNumberOfVariables(); i++) {
       Integer value = randomGenerator.nextInt(getLowerBound(i), getUpperBound(i));
       setVariableValue(i, value) ;


### PR DESCRIPTION
Randomization is only used at instantiation time, thus it does not make
sense to retain this instance during all the life time of the solution.
Not only we save significant memory space by removing a field in all
solution instances, but we also centralize the responsibilities where
relevant, which unlocks future refactoring and optimizations.

The now obsolete field is only deprecated to not break existing
implementations. It should be removed for the next non-retrocompatible
release.