### PR TITLE
Refactor/AGS problem field

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
@@ -1,5 +1,7 @@
 package org.uma.jmetal.problem;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * A {@link BoundedProblem} is a {@link Problem} for which solution boundaries
  * exist. Boundaries restrict each variable to be within an interval. This
@@ -12,12 +14,13 @@ package org.uma.jmetal.problem;
  * @param <S>
  *          Type of {@link Problem} solutions
  */
-public interface BoundedProblem<T extends Number, S> extends Problem<S> {
+public interface BoundedProblem<T extends Number, S> extends Problem<S>, IndexBounder<T> {
   /**
    * @param index
    *          index of the variable
    * @return lower bound of the variable
    */
+  @Override
   public T getLowerBound(int index);
 
   /**
@@ -25,5 +28,6 @@ public interface BoundedProblem<T extends Number, S> extends Problem<S> {
    *          index of the variable
    * @return upper bound of the variable
    */
+  @Override
   public T getUpperBound(int index);
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/DoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/DoubleBinarySolution.java
@@ -1,13 +1,13 @@
 package org.uma.jmetal.solution;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * Interface representing a solution having an array of real values and a bitset
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface DoubleBinarySolution extends Solution<Object>{
+public interface DoubleBinarySolution extends Solution<Object>, IndexBounder<Double>{
   public int getNumberOfDoubleVariables() ;
-  public Double getLowerBound(int index) ;
-  public Double getUpperBound(int index) ;
   public int getNumberOfBits() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/DoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/DoubleSolution.java
@@ -1,11 +1,11 @@
 package org.uma.jmetal.solution;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * Interface representing a double solutions
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface DoubleSolution extends Solution<Double> {
-  public Double getLowerBound(int index) ;
-  public Double getUpperBound(int index) ;
+public interface DoubleSolution extends Solution<Double>, IndexBounder<Double> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/IntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/IntegerDoubleSolution.java
@@ -1,13 +1,13 @@
 package org.uma.jmetal.solution;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * Interface representing a solution composed of integers and real values
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface IntegerDoubleSolution extends Solution<Number> {
-  public Number getLowerBound(int index) ;
-  public Number getUpperBound(int index) ;
+public interface IntegerDoubleSolution extends Solution<Number>, IndexBounder<Number> {
   public int getNumberOfIntegerVariables() ;
   public int getNumberOfDoubleVariables() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/IntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/IntegerSolution.java
@@ -1,11 +1,11 @@
 package org.uma.jmetal.solution;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * Interface representing a integer solutions
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface IntegerSolution extends Solution<Integer> {
-  public Integer getLowerBound(int index) ;
-  public Integer getUpperBound(int index) ;
+public interface IntegerSolution extends Solution<Integer>, IndexBounder<Integer> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -17,6 +17,11 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
   private double[] objectives;
   private List<T> variables;
   protected P problem ;
+  /**
+   * @deprecated Call {@link #getAttributes()} instead.
+   */
+  @Deprecated
+  // Deprecation should lead to make this field private.
   protected Map<Object, Object> attributes ;
   /**
    * @deprecated Call {@link JMetalRandom#getInstance()} if you need one.

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -6,6 +6,8 @@ import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Abstract class representing a generic solution
@@ -16,6 +18,10 @@ import java.util.function.Function;
 public abstract class AbstractGenericSolution<T, P extends Problem<?>> implements Solution<T> {
   private double[] objectives;
   private List<T> variables;
+  /**
+   * @deprecated Store your own if you need one.
+   */
+  @Deprecated
   protected P problem ;
   /**
    * @deprecated Call {@link #getAttributes()} instead.
@@ -32,6 +38,52 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
   /**
    * Create a new {@link AbstractGenericSolution} with the given data.
    * 
+   * @param variables variables of the new {@link Solution}
+   * @param objectives objectives of the new {@link Solution}
+   * @param attributes attributes of the new {@link Solution}
+   */
+  public AbstractGenericSolution(List<T> variables, double[] objectives, Map<Object, Object> attributes
+      ) {
+    this.randomGenerator = JMetalRandom.getInstance() ;
+    this.objectives = objectives ;
+    this.variables = variables ;
+    this.attributes = attributes;
+  }
+
+  /**
+   * Create a new {@link AbstractGenericSolution} with zeros objectives and no
+   * attribute.
+   * 
+   * @param variables variables of the new {@link Solution}
+   * @param numberOfObjectives number of objectives of the new {@link Solution}
+   */
+  public AbstractGenericSolution(List<T> variables, int numberOfObjectives) {
+    this(variables, new double[numberOfObjectives], new HashMap<>());
+  }
+
+  /**
+   * Create a new {@link AbstractGenericSolution} with <code>null</code>
+   * variables, zeros objectives and no attribute.
+   * 
+   * @param numberOfVariables number of variables of the new {@link Solution}
+   * @param numberOfObjectives number of objectives of the new {@link Solution}
+   */
+  public AbstractGenericSolution(int numberOfVariables, int numberOfObjectives) {
+    this(new Vector<T>() {{setSize(numberOfVariables);}}, numberOfObjectives) ;
+  }
+
+  /**
+   * Copy constructor
+   */
+  public AbstractGenericSolution(Solution<T> solution) {
+    this(new ArrayList<>(solution.getVariables()),
+        Arrays.copyOf(solution.getObjectives(), solution.getObjectives().length),
+        new HashMap<>(solution.getAttributes()));
+  }
+  
+  /**
+   * Create a new {@link AbstractGenericSolution} with the given data.
+   * 
    * @param problem
    *          {@link Problem} to rely on
    * @param variableProvider
@@ -40,21 +92,17 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
    *          objective values
    * @param attributes
    *          attributes
+   * @deprecated Call {@link #AbstractGenericSolution(List, double[], Map)}
+   *             instead
    */
+  @Deprecated
   public AbstractGenericSolution(P problem, Function<Integer, T> variableProvider, Function<Integer, Double> objectiveProvider, Map<Object, Object> attributes
       ) {
+    this(
+        IntStream.range(0, problem.getNumberOfVariables()).mapToObj(variableProvider::apply).collect(Collectors.toList()),
+        IntStream.range(0, problem.getNumberOfObjectives()).mapToDouble(objectiveProvider::apply).toArray(),
+        attributes);
     this.problem = problem ;
-    randomGenerator = JMetalRandom.getInstance() ;
-
-    objectives = new double[problem.getNumberOfObjectives()] ;
-    variables = new ArrayList<>(problem.getNumberOfVariables()) ;
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      variables.add(i, variableProvider.apply(i)) ;
-    }
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      objectives[i] = objectiveProvider.apply(i) ;
-    }
-    this.attributes = attributes;
   }
 
   /**
@@ -65,7 +113,9 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
    *          {@link Problem} to rely on
    * @param variableProvider
    *          variable values
+   * @deprecated Call {@link #AbstractGenericSolution(List, int)} instead
    */
+  @Deprecated
   public AbstractGenericSolution(P problem, Function<Integer, T> variableProvider) {
     this(problem, variableProvider, i -> 0.0, new HashMap<>());
   }
@@ -76,14 +126,19 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
    * 
    * @param problem
    *          {@link Problem} to rely on
+   * @deprecated Call {@link #AbstractGenericSolution(int, int)} instead
    */
+  @Deprecated
   public AbstractGenericSolution(P problem) {
     this(problem, i -> null) ;
   }
 
   /**
    * Copy constructor
+   * 
+   * @deprecated Call {@link #AbstractGenericSolution(Solution)} instead
    */
+  @Deprecated
   public AbstractGenericSolution(P problem, Solution<T> solution) {
     this(problem, solution::getVariableValue, solution::getObjective, new HashMap<>(solution.getAttributes()));
   }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -39,7 +39,6 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
   public AbstractGenericSolution(P problem, Function<Integer, T> variableProvider, Function<Integer, Double> objectiveProvider, Map<Object, Object> attributes
       ) {
     this.problem = problem ;
-    attributes = new HashMap<>() ;
     randomGenerator = JMetalRandom.getInstance() ;
 
     objectives = new double[problem.getNumberOfObjectives()] ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -63,7 +63,7 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
    *          variable values
    */
   public AbstractGenericSolution(P problem, Function<Integer, T> variableProvider) {
-    this(problem, variableProvider, i -> 0.0, Collections.emptyMap());
+    this(problem, variableProvider, i -> 0.0, new HashMap<>());
   }
 
   /**

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -140,7 +140,7 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
    *             {@link #AbstractGenericSolution(Problem, Function)}. If you don't
    *             need it, it means you aim for non-zero objectives, in which case
    *             you should rely on
-   *             {@link #AbstractGenericSolution(Problem, Function, Function)} or
+   *             {@link #AbstractGenericSolution(Problem, Function, Function, Map)} or
    *             {@link #AbstractGenericSolution(Problem, Solution)} instead.
    */
   @Deprecated

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -102,6 +102,11 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
   public Object getAttribute(Object id) {
     return attributes.get(id) ;
   }
+  
+  @Override
+  public Map<Object, Object> getAttributes() {
+    return attributes;
+  }
 
   @Override
   public void setObjective(int index, double value) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
@@ -5,7 +5,11 @@ import org.uma.jmetal.solution.BinarySolution;
 import org.uma.jmetal.util.binarySet.BinarySet;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Defines an implementation of a binary solution
@@ -19,14 +23,13 @@ public class DefaultBinarySolution
 
   /** Constructor */
   public DefaultBinarySolution(BinaryProblem problem) {
-    super(problem) ;
-
-    initializeBinaryVariables(JMetalRandom.getInstance());
+    super(variablesInitializer(problem, JMetalRandom.getInstance()), problem.getNumberOfObjectives()) ;
   }
 
   /** Copy constructor */
   public DefaultBinarySolution(DefaultBinarySolution solution) {
-    super(solution.problem, i -> (BinarySet) solution.getVariableValue(i).clone(), solution::getObjective,
+    super(solution.getVariables().stream().map(s -> (BinarySet) s.clone()).collect(Collectors.toList()),
+        Arrays.copyOf(solution.getObjectives(), solution.getObjectives().length),
         new HashMap<>(solution.getAttributes()));
   }
 
@@ -78,9 +81,12 @@ public class DefaultBinarySolution
     return result ;
   }
   
-  private void initializeBinaryVariables(JMetalRandom randomGenerator) {
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, createNewBitSet(problem.getNumberOfBits(i), randomGenerator));
+  private static List<BinarySet> variablesInitializer(BinaryProblem problem, JMetalRandom randomGenerator) {
+    int numberOfVariables = problem.getNumberOfVariables();
+    List<BinarySet> variables = new ArrayList<>(numberOfVariables);
+    for (int i = 0; i < numberOfVariables; i++) {
+      variables.add(createNewBitSet(problem.getNumberOfBits(i), randomGenerator));
     }
+    return variables;
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
@@ -6,7 +6,6 @@ import org.uma.jmetal.util.binarySet.BinarySet;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Defines an implementation of a binary solution
@@ -84,9 +83,4 @@ public class DefaultBinarySolution
       setVariableValue(i, createNewBitSet(problem.getNumberOfBits(i), randomGenerator));
     }
   }
-
-	@Override
-	public Map<Object, Object> getAttributes() {
-		return attributes;
-	}
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
@@ -23,22 +23,12 @@ public class DefaultBinarySolution
     super(problem) ;
 
     initializeBinaryVariables(JMetalRandom.getInstance());
-    initializeObjectiveValues();
   }
 
   /** Copy constructor */
   public DefaultBinarySolution(DefaultBinarySolution solution) {
-    super(solution.problem);
-
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, (BinarySet) solution.getVariableValue(i).clone());
-    }
-
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, i -> (BinarySet) solution.getVariableValue(i).clone(), solution::getObjective,
+        new HashMap<>(solution.getAttributes()));
   }
 
   private static BinarySet createNewBitSet(int numberOfBits, JMetalRandom randomGenerator) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -5,7 +5,6 @@ import org.uma.jmetal.solution.DoubleBinarySolution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.BitSet;
-import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -91,9 +90,4 @@ public class DefaultDoubleBinarySolution
     }
     return bitSet ;
   }
-  
-  	@Override
-	public Map<Object, Object> getAttributes() {
-		return attributes;
-	}
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -5,8 +5,9 @@ import org.uma.jmetal.solution.DoubleBinarySolution;
 import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
+import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.function.Function;
+import java.util.List;
 
 /**
  * Description:
@@ -28,7 +29,7 @@ public class DefaultDoubleBinarySolution
 
   /** Constructor */
   public DefaultDoubleBinarySolution(DoubleBinaryProblem<?> problem) {
-    super(problem, variableInitializer(problem, JMetalRandom.getInstance())) ;
+    super(variablesInitializer(problem, JMetalRandom.getInstance()), problem.getNumberOfObjectives()) ;
 
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
     this.numberOfBits = problem.getNumberOfBits();
@@ -37,22 +38,21 @@ public class DefaultDoubleBinarySolution
 
   /** Copy constructor */
   public DefaultDoubleBinarySolution(DefaultDoubleBinarySolution solution) {
-    super(solution.problem, solution) ;
+    super(solution) ;
     this.numberOfBits = solution.numberOfBits;
     this.bounder = solution.bounder;
   }
   
-  private static Function<Integer, Object> variableInitializer(DoubleBinaryProblem<?> problem,
+  private static List<Object> variablesInitializer(DoubleBinaryProblem<?> problem,
       JMetalRandom randomGenerator) {
-    return i -> {
-      if (i < problem.getNumberOfDoubleVariables()) {
-        Double lowerBound = (Double) problem.getLowerBound(i);
-        Double upperBound = (Double) problem.getUpperBound(i);
-        return randomGenerator.nextDouble(lowerBound, upperBound);
-      } else {
-        return createNewBitSet(problem.getNumberOfBits(), randomGenerator);
-      }
-    };
+    List<Object> variables = new ArrayList<>(problem.getNumberOfVariables());
+    for (int i = 0; i < problem.getNumberOfDoubleVariables(); i++) {
+      Double lowerBound = (Double) problem.getLowerBound(i);
+      Double upperBound = (Double) problem.getUpperBound(i);
+      variables.add(randomGenerator.nextDouble(lowerBound, upperBound));
+    }
+    variables.add(createNewBitSet(problem.getNumberOfBits(), randomGenerator));
+    return variables;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.DoubleBinaryProblem;
 import org.uma.jmetal.solution.DoubleBinarySolution;
+import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.BitSet;
@@ -22,17 +23,20 @@ public class DefaultDoubleBinarySolution
     extends AbstractGenericSolution<Object, DoubleBinaryProblem<?>>
     implements DoubleBinarySolution {
   private int numberOfDoubleVariables ;
+  private final IndexBounder<Number> bounder;
 
   /** Constructor */
   public DefaultDoubleBinarySolution(DoubleBinaryProblem<?> problem) {
     super(problem, variableInitializer(problem, JMetalRandom.getInstance())) ;
 
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
+    this.bounder = problem;
   }
 
   /** Copy constructor */
   public DefaultDoubleBinarySolution(DefaultDoubleBinarySolution solution) {
     super(solution.problem, solution) ;
+    this.bounder = solution.bounder;
   }
   
   private static Function<Integer, Object> variableInitializer(DoubleBinaryProblem<?> problem,
@@ -55,7 +59,7 @@ public class DefaultDoubleBinarySolution
 
   @Override
   public Double getUpperBound(int index) {
-    return (Double)problem.getUpperBound(index);
+    return (Double)bounder.getUpperBound(index);
   }
 
   @Override
@@ -65,7 +69,7 @@ public class DefaultDoubleBinarySolution
 
   @Override
   public Double getLowerBound(int index) {
-    return (Double)problem.getLowerBound(index) ;
+    return (Double)bounder.getLowerBound(index) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -5,8 +5,8 @@ import org.uma.jmetal.solution.DoubleBinarySolution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.BitSet;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Description:
@@ -26,50 +26,27 @@ public class DefaultDoubleBinarySolution
 
   /** Constructor */
   public DefaultDoubleBinarySolution(DoubleBinaryProblem<?> problem) {
-    super(problem) ;
+    super(problem, variableInitializer(problem, JMetalRandom.getInstance())) ;
 
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
-
-    initializeDoubleVariables(JMetalRandom.getInstance());
-    initializeBitSet(JMetalRandom.getInstance()) ;
-    initializeObjectiveValues();
   }
 
   /** Copy constructor */
   public DefaultDoubleBinarySolution(DefaultDoubleBinarySolution solution) {
-    super(solution.problem) ;
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    copyDoubleVariables(solution);
-    copyBitSet(solution);
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
-
-  private void initializeDoubleVariables(JMetalRandom randomGenerator) {
-    for (int i = 0 ; i < numberOfDoubleVariables; i++) {
-      Double value = randomGenerator.nextDouble(getLowerBound(i), getUpperBound(i)) ;
-      //variables.add(value) ;
-      setVariableValue(i, value);
-    }
-  }
-
-  private void initializeBitSet(JMetalRandom randomGenerator) {
-    BitSet bitset = createNewBitSet(problem.getNumberOfBits(), randomGenerator) ;
-    setVariableValue(numberOfDoubleVariables, bitset);
-  }
-
-  private void copyDoubleVariables(DefaultDoubleBinarySolution solution) {
-    for (int i = 0 ; i < numberOfDoubleVariables; i++) {
-      setVariableValue(i, solution.getVariableValue(i));
-    }
-  }
-
-  private void copyBitSet(DefaultDoubleBinarySolution solution) {
-    BitSet bitset = (BitSet)solution.getVariableValue(solution.getNumberOfVariables()-1) ;
-    setVariableValue(numberOfDoubleVariables, bitset);
+  
+  private static Function<Integer, Object> variableInitializer(DoubleBinaryProblem<?> problem,
+      JMetalRandom randomGenerator) {
+    return i -> {
+      if (i < problem.getNumberOfDoubleVariables()) {
+        Double lowerBound = (Double) problem.getLowerBound(i);
+        Double upperBound = (Double) problem.getUpperBound(i);
+        return randomGenerator.nextDouble(lowerBound, upperBound);
+      } else {
+        return createNewBitSet(problem.getNumberOfBits(), randomGenerator);
+      }
+    };
   }
 
   @Override
@@ -102,7 +79,7 @@ public class DefaultDoubleBinarySolution
     return getVariableValue(index).toString() ;
   }
 
-  private BitSet createNewBitSet(int numberOfBits, JMetalRandom randomGenerator) {
+  private static BitSet createNewBitSet(int numberOfBits, JMetalRandom randomGenerator) {
     BitSet bitSet = new BitSet(numberOfBits) ;
 
     for (int i = 0; i < numberOfBits; i++) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -23,6 +23,7 @@ public class DefaultDoubleBinarySolution
     extends AbstractGenericSolution<Object, DoubleBinaryProblem<?>>
     implements DoubleBinarySolution {
   private int numberOfDoubleVariables ;
+  private final int numberOfBits;
   private final IndexBounder<Number> bounder;
 
   /** Constructor */
@@ -30,12 +31,14 @@ public class DefaultDoubleBinarySolution
     super(problem, variableInitializer(problem, JMetalRandom.getInstance())) ;
 
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
+    this.numberOfBits = problem.getNumberOfBits();
     this.bounder = problem;
   }
 
   /** Copy constructor */
   public DefaultDoubleBinarySolution(DefaultDoubleBinarySolution solution) {
     super(solution.problem, solution) ;
+    this.numberOfBits = solution.numberOfBits;
     this.bounder = solution.bounder;
   }
   
@@ -64,7 +67,7 @@ public class DefaultDoubleBinarySolution
 
   @Override
   public int getNumberOfBits() {
-    return problem.getNumberOfBits();
+    return numberOfBits;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -1,5 +1,8 @@
 package org.uma.jmetal.solution.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.IndexBounder;
@@ -19,15 +22,13 @@ public class DefaultDoubleSolution
 
   /** Constructor */
   public DefaultDoubleSolution(DoubleProblem problem) {
-    super(problem) ;
+    super(variablesInitializer(problem, JMetalRandom.getInstance()), problem.getNumberOfObjectives()) ;
     this.bounder = problem;
-
-    initializeDoubleVariables(problem.getNumberOfVariables(), JMetalRandom.getInstance());
   }
 
   /** Copy constructor */
   public DefaultDoubleSolution(DefaultDoubleSolution solution) {
-    super(solution.problem, solution) ;
+    super(solution) ;
     this.bounder = solution.bounder;
   }
 
@@ -51,10 +52,12 @@ public class DefaultDoubleSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeDoubleVariables(int numberOfVariables, JMetalRandom randomGenerator) {
-    for (int i = 0 ; i < numberOfVariables; i++) {
-      Double value = randomGenerator.nextDouble(getLowerBound(i), getUpperBound(i)) ;
-      setVariableValue(i, value) ;
+  private static List<Double> variablesInitializer(DoubleProblem problem, JMetalRandom randomGenerator) {
+    int numberOfVariables = problem.getNumberOfVariables();
+    List<Double> variables = new ArrayList<>(numberOfVariables);
+    for (int i = 0; i < numberOfVariables; i++) {
+      variables.add(randomGenerator.nextDouble(problem.getLowerBound(i), problem.getUpperBound(i)));
     }
+    return variables;
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -22,22 +22,11 @@ public class DefaultDoubleSolution
     super(problem) ;
 
     initializeDoubleVariables(JMetalRandom.getInstance());
-    initializeObjectiveValues();
   }
 
   /** Copy constructor */
   public DefaultDoubleSolution(DefaultDoubleSolution solution) {
-    super(solution.problem) ;
-
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, solution.getVariableValue(i));
-    }
-
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -4,9 +4,6 @@ import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Defines an implementation of a double solution
  *
@@ -55,9 +52,4 @@ public class DefaultDoubleSolution
       setVariableValue(i, value) ;
     }
   }
-  
-	@Override
-	public Map<Object, Object> getAttributes() {
-		return attributes;
-	}
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -22,7 +22,7 @@ public class DefaultDoubleSolution
     super(problem) ;
     this.bounder = problem;
 
-    initializeDoubleVariables(JMetalRandom.getInstance());
+    initializeDoubleVariables(problem.getNumberOfVariables(), JMetalRandom.getInstance());
   }
 
   /** Copy constructor */
@@ -51,8 +51,8 @@ public class DefaultDoubleSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeDoubleVariables(JMetalRandom randomGenerator) {
-    for (int i = 0 ; i < problem.getNumberOfVariables(); i++) {
+  private void initializeDoubleVariables(int numberOfVariables, JMetalRandom randomGenerator) {
+    for (int i = 0 ; i < numberOfVariables; i++) {
       Double value = randomGenerator.nextDouble(getLowerBound(i), getUpperBound(i)) ;
       setVariableValue(i, value) ;
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
+import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 /**
@@ -14,9 +15,12 @@ public class DefaultDoubleSolution
     extends AbstractGenericSolution<Double, DoubleProblem>
     implements DoubleSolution {
 
+  private final IndexBounder<Double> bounder;
+
   /** Constructor */
   public DefaultDoubleSolution(DoubleProblem problem) {
     super(problem) ;
+    this.bounder = problem;
 
     initializeDoubleVariables(JMetalRandom.getInstance());
   }
@@ -24,16 +28,17 @@ public class DefaultDoubleSolution
   /** Copy constructor */
   public DefaultDoubleSolution(DefaultDoubleSolution solution) {
     super(solution.problem, solution) ;
+    this.bounder = solution.bounder;
   }
 
   @Override
   public Double getUpperBound(int index) {
-    return problem.getUpperBound(index);
+    return bounder.getUpperBound(index);
   }
 
   @Override
   public Double getLowerBound(int index) {
-    return problem.getLowerBound(index) ;
+    return bounder.getLowerBound(index) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -5,7 +5,8 @@ import org.uma.jmetal.solution.IntegerDoubleSolution;
 import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
-import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Defines an implementation of a class for solutions having integers and doubles
@@ -23,7 +24,7 @@ public class DefaultIntegerDoubleSolution
 
   /** Constructor */
   public DefaultIntegerDoubleSolution(IntegerDoubleProblem<?> problem) {
-    super(problem, variableInitializer(problem)) ;
+    super(variablesInitializer(problem, JMetalRandom.getInstance()), problem.getNumberOfObjectives()) ;
 
     numberOfIntegerVariables = problem.getNumberOfIntegerVariables() ;
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
@@ -32,7 +33,7 @@ public class DefaultIntegerDoubleSolution
 
   /** Copy constructor */
   public DefaultIntegerDoubleSolution(DefaultIntegerDoubleSolution solution) {
-    super(solution.problem, solution) ;
+    super(solution) ;
     this.bounder = solution.bounder;
   }
 
@@ -66,16 +67,16 @@ public class DefaultIntegerDoubleSolution
     return getVariableValue(index).toString() ;
   }
   
-  private static Function<Integer, Number> variableInitializer(IntegerDoubleProblem<?> problem) {
-    return i -> {
-      Number lowerBound = problem.getLowerBound(i);
-      Number upperBound = problem.getUpperBound(i);
-      JMetalRandom randomGenerator = JMetalRandom.getInstance();
-      if (i < problem.getNumberOfIntegerVariables()) {
-        return randomGenerator.nextInt((Integer) lowerBound, (Integer) upperBound);
-      } else {
-        return randomGenerator.nextDouble((Double) lowerBound, (Double) upperBound);
-      }
-    };
+  private static List<Number> variablesInitializer(IntegerDoubleProblem<?> problem, JMetalRandom randomGenerator) {
+    int numberOfIntegerVariables = problem.getNumberOfIntegerVariables();
+    int numberOfDoubleVariables = problem.getNumberOfDoubleVariables();
+    List<Number> variables = new ArrayList<>(numberOfIntegerVariables+numberOfDoubleVariables);
+    for (int i = 0; i < numberOfIntegerVariables; i++) {
+      variables.add(randomGenerator.nextInt((Integer) problem.getLowerBound(i), (Integer) problem.getUpperBound(i)));
+    }
+    for (int i = 0; i < numberOfDoubleVariables; i++) {
+      variables.add(randomGenerator.nextDouble((Double) problem.getLowerBound(i), (Double) problem.getUpperBound(i)));
+    }
+    return variables;
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.IntegerDoubleProblem;
 import org.uma.jmetal.solution.IntegerDoubleSolution;
+import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.function.Function;
@@ -18,6 +19,7 @@ public class DefaultIntegerDoubleSolution
 
   private int numberOfIntegerVariables ;
   private int numberOfDoubleVariables ;
+  private final IndexBounder<Number> bounder;
 
   /** Constructor */
   public DefaultIntegerDoubleSolution(IntegerDoubleProblem<?> problem) {
@@ -25,16 +27,18 @@ public class DefaultIntegerDoubleSolution
 
     numberOfIntegerVariables = problem.getNumberOfIntegerVariables() ;
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
+    this.bounder = problem;
   }
 
   /** Copy constructor */
   public DefaultIntegerDoubleSolution(DefaultIntegerDoubleSolution solution) {
     super(solution.problem, solution) ;
+    this.bounder = solution.bounder;
   }
 
   @Override
   public Number getUpperBound(int index) {
-    return problem.getUpperBound(index);
+    return bounder.getUpperBound(index);
   }
 
   @Override
@@ -49,7 +53,7 @@ public class DefaultIntegerDoubleSolution
 
   @Override
   public Number getLowerBound(int index) {
-    return problem.getLowerBound(index) ;
+    return bounder.getLowerBound(index) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -4,8 +4,6 @@ import org.uma.jmetal.problem.IntegerDoubleProblem;
 import org.uma.jmetal.solution.IntegerDoubleSolution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -76,9 +74,4 @@ public class DefaultIntegerDoubleSolution
       }
     };
   }
-  
-	@Override
-	public Map<Object, Object> getAttributes() {
-		return attributes;
-	}
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -6,6 +6,7 @@ import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Defines an implementation of a class for solutions having integers and doubles
@@ -22,32 +23,15 @@ public class DefaultIntegerDoubleSolution
 
   /** Constructor */
   public DefaultIntegerDoubleSolution(IntegerDoubleProblem<?> problem) {
-    super(problem) ;
+    super(problem, variableInitializer(problem)) ;
 
     numberOfIntegerVariables = problem.getNumberOfIntegerVariables() ;
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
-
-    initializeIntegerDoubleVariables(JMetalRandom.getInstance()) ;
-    initializeObjectiveValues() ;
   }
 
   /** Copy constructor */
   public DefaultIntegerDoubleSolution(DefaultIntegerDoubleSolution solution) {
-    super(solution.problem) ;
-
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    for (int i = 0 ; i < numberOfIntegerVariables; i++) {
-      setVariableValue(i, solution.getVariableValue(i)) ;
-    }
-
-    for (int i = numberOfIntegerVariables ; i < (numberOfIntegerVariables+numberOfDoubleVariables); i++) {
-      setVariableValue(i, solution.getVariableValue(i)) ;
-    }
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
 
   @Override
@@ -80,16 +64,17 @@ public class DefaultIntegerDoubleSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeIntegerDoubleVariables(JMetalRandom randomGenerator) {
-    for (int i = 0 ; i < numberOfIntegerVariables; i++) {
-      Integer value = randomGenerator.nextInt((Integer)getLowerBound(i), (Integer)getUpperBound(i)) ;
-      setVariableValue(i, value) ;
-    }
-
-    for (int i = numberOfIntegerVariables ; i < getNumberOfVariables(); i++) {
-      Double value = randomGenerator.nextDouble((Double)getLowerBound(i), (Double)getUpperBound(i)) ;
-      setVariableValue(i, value) ;
-    }
+  private static Function<Integer, Number> variableInitializer(IntegerDoubleProblem<?> problem) {
+    return i -> {
+      Number lowerBound = problem.getLowerBound(i);
+      Number upperBound = problem.getUpperBound(i);
+      JMetalRandom randomGenerator = JMetalRandom.getInstance();
+      if (i < problem.getNumberOfIntegerVariables()) {
+        return randomGenerator.nextInt((Integer) lowerBound, (Integer) upperBound);
+      } else {
+        return randomGenerator.nextDouble((Double) lowerBound, (Double) upperBound);
+      }
+    };
   }
   
 	@Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
@@ -5,7 +5,6 @@ import org.uma.jmetal.solution.PermutationSolution;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -48,9 +47,4 @@ public class DefaultIntegerPermutationSolution
   public DefaultIntegerPermutationSolution copy() {
     return new DefaultIntegerPermutationSolution(this);
   }
-  
-	@Override
-	public Map<Object, Object> getAttributes() {
-		return attributes;
-	}
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
@@ -5,7 +5,6 @@ import org.uma.jmetal.solution.PermutationSolution;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * Defines an implementation of solution composed of a permuation of integers
@@ -19,10 +18,10 @@ public class DefaultIntegerPermutationSolution
 
   /** Constructor */
   public DefaultIntegerPermutationSolution(PermutationProblem<?> problem) {
-    super(problem, variableInitializer(problem)) ;
+    super(variablesInitializer(problem), problem.getNumberOfObjectives()) ;
   }
 
-  private static Function<Integer, Integer> variableInitializer(PermutationProblem<?> problem) {
+  private static List<Integer> variablesInitializer(PermutationProblem<?> problem) {
     List<Integer> randomSequence = new ArrayList<>(problem.getPermutationLength());
 
     for (int j = 0; j < problem.getPermutationLength(); j++) {
@@ -31,12 +30,12 @@ public class DefaultIntegerPermutationSolution
 
     java.util.Collections.shuffle(randomSequence);
 
-    return randomSequence::get ;
+    return randomSequence ;
   }
 
   /** Copy Constructor */
   public DefaultIntegerPermutationSolution(DefaultIntegerPermutationSolution solution) {
-    super(solution.problem, solution) ;
+    super(solution) ;
   }
 
   @Override public String getVariableValueString(int index) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
@@ -4,9 +4,9 @@ import org.uma.jmetal.problem.PermutationProblem;
 import org.uma.jmetal.solution.PermutationSolution;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Defines an implementation of solution composed of a permuation of integers
@@ -20,8 +20,10 @@ public class DefaultIntegerPermutationSolution
 
   /** Constructor */
   public DefaultIntegerPermutationSolution(PermutationProblem<?> problem) {
-    super(problem) ;
+    super(problem, variableInitializer(problem)) ;
+  }
 
+  private static Function<Integer, Integer> variableInitializer(PermutationProblem<?> problem) {
     List<Integer> randomSequence = new ArrayList<>(problem.getPermutationLength());
 
     for (int j = 0; j < problem.getPermutationLength(); j++) {
@@ -30,23 +32,12 @@ public class DefaultIntegerPermutationSolution
 
     java.util.Collections.shuffle(randomSequence);
 
-    for (int i = 0; i < getNumberOfVariables(); i++) {
-      setVariableValue(i, randomSequence.get(i)) ;
-    }
+    return randomSequence::get ;
   }
 
   /** Copy Constructor */
   public DefaultIntegerPermutationSolution(DefaultIntegerPermutationSolution solution) {
-    super(solution.problem) ;
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, solution.getVariableValue(i));
-    }
-    
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
 
   @Override public String getVariableValueString(int index) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.IntegerProblem;
 import org.uma.jmetal.solution.IntegerSolution;
+import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 /**
@@ -14,9 +15,12 @@ public class DefaultIntegerSolution
     extends AbstractGenericSolution<Integer, IntegerProblem>
     implements IntegerSolution {
 
+  private final IndexBounder<Integer> bounder;
+
   /** Constructor */
   public DefaultIntegerSolution(IntegerProblem problem) {
     super(problem) ;
+    this.bounder = problem;
 
     initializeIntegerVariables(JMetalRandom.getInstance());
   }
@@ -24,16 +28,17 @@ public class DefaultIntegerSolution
   /** Copy constructor */
   public DefaultIntegerSolution(DefaultIntegerSolution solution) {
     super(solution.problem, solution) ;
+    this.bounder = solution.bounder;
   }
 
   @Override
   public Integer getUpperBound(int index) {
-    return problem.getUpperBound(index);
+    return bounder.getUpperBound(index);
   }
 
   @Override
   public Integer getLowerBound(int index) {
-    return problem.getLowerBound(index) ;
+    return bounder.getLowerBound(index) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -1,5 +1,8 @@
 package org.uma.jmetal.solution.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.uma.jmetal.problem.IntegerProblem;
 import org.uma.jmetal.solution.IntegerSolution;
 import org.uma.jmetal.util.IndexBounder;
@@ -19,15 +22,13 @@ public class DefaultIntegerSolution
 
   /** Constructor */
   public DefaultIntegerSolution(IntegerProblem problem) {
-    super(problem) ;
+    super(variablesInitializer(problem, JMetalRandom.getInstance()), problem.getNumberOfObjectives()) ;
     this.bounder = problem;
-
-    initializeIntegerVariables(problem.getNumberOfVariables(), JMetalRandom.getInstance());
   }
 
   /** Copy constructor */
   public DefaultIntegerSolution(DefaultIntegerSolution solution) {
-    super(solution.problem, solution) ;
+    super(solution) ;
     this.bounder = solution.bounder;
   }
 
@@ -51,10 +52,12 @@ public class DefaultIntegerSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeIntegerVariables(int numberOfVariables, JMetalRandom randomGenerator) {
+  private static List<Integer> variablesInitializer(IntegerProblem problem, JMetalRandom randomGenerator) {
+    int numberOfVariables = problem.getNumberOfVariables();
+    List<Integer> variables = new ArrayList<>(numberOfVariables);
     for (int i = 0 ; i < numberOfVariables; i++) {
-      Integer value = randomGenerator.nextInt(getLowerBound(i), getUpperBound(i));
-      setVariableValue(i, value) ;
+      variables.add(randomGenerator.nextInt(problem.getLowerBound(i), problem.getUpperBound(i))) ;
     }
+    return variables;
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -22,7 +22,7 @@ public class DefaultIntegerSolution
     super(problem) ;
     this.bounder = problem;
 
-    initializeIntegerVariables(JMetalRandom.getInstance());
+    initializeIntegerVariables(problem.getNumberOfVariables(), JMetalRandom.getInstance());
   }
 
   /** Copy constructor */
@@ -51,8 +51,8 @@ public class DefaultIntegerSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeIntegerVariables(JMetalRandom randomGenerator) {
-    for (int i = 0 ; i < problem.getNumberOfVariables(); i++) {
+  private void initializeIntegerVariables(int numberOfVariables, JMetalRandom randomGenerator) {
+    for (int i = 0 ; i < numberOfVariables; i++) {
       Integer value = randomGenerator.nextInt(getLowerBound(i), getUpperBound(i));
       setVariableValue(i, value) ;
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -4,7 +4,6 @@ import org.uma.jmetal.problem.IntegerProblem;
 import org.uma.jmetal.solution.IntegerSolution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -22,22 +21,11 @@ public class DefaultIntegerSolution
     super(problem) ;
 
     initializeIntegerVariables(JMetalRandom.getInstance());
-    initializeObjectiveValues();
   }
 
   /** Copy constructor */
   public DefaultIntegerSolution(DefaultIntegerSolution solution) {
-    super(solution.problem) ;
-
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, solution.getVariableValue(i));
-    }
-
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -4,8 +4,6 @@ import org.uma.jmetal.problem.IntegerProblem;
 import org.uma.jmetal.solution.IntegerSolution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
-import java.util.Map;
-
 /**
  * Defines an implementation of an integer solution
  *
@@ -54,10 +52,4 @@ public class DefaultIntegerSolution
       setVariableValue(i, value) ;
     }
   }
-  
-  
-	@Override
-	public Map<Object, Object> getAttributes() {
-		return attributes;
-	}
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/IndexBounder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/IndexBounder.java
@@ -1,0 +1,33 @@
+package org.uma.jmetal.util;
+
+import java.util.List;
+
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
+
+/**
+ * An {@link IndexBounder} provide up & down boundaries for a given type of
+ * {@link Number} at a given index. It is mainly used for associating a
+ * {@link List} or array of numerical values with a custom set of boundaries for
+ * each value. The main use is for bounded {@link Problem}s and
+ * {@link Solution}s.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ *
+ * @param <T>
+ */
+public interface IndexBounder<T extends Number> {
+  /**
+   * @param index
+   *          index of the {@link Number}
+   * @return lower bound of the {@link Number}
+   */
+  public T getLowerBound(int index);
+
+  /**
+   * @param index
+   *          index of the {@link Number}
+   * @return upper bound of the {@link Number}
+   */
+  public T getUpperBound(int index);
+}


### PR DESCRIPTION
Build on #345 and #350, which should be merged first.

`AbstractGenericSolution` contains a `problem` field that it is never needed. We remove this dependency to let the child classes choose whether or not it make sense to store it (or some of its data). Several implementations only need it at instantiation time, so it takes extra space for no reason in these implementations, which is significant given the number of solutions we deal with.

The field is deprecated instead of removed to remain retrocompatible. It should be removed with other deprecated stuff at the next compatibility-breaking release.