### PR TITLE
Stop dominance check when confirmed.

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/DominanceComparator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/comparator/DominanceComparator.java
@@ -68,7 +68,7 @@ public class DominanceComparator<S extends Solution<?>> implements Comparator<S>
     int bestIsOne = 0 ;
     int bestIsTwo = 0 ;
     int result ;
-    for (int i = 0; i < solution1.getNumberOfObjectives(); i++) {
+    for (int i = 0; i < solution1.getNumberOfObjectives() && bestIsOne * bestIsTwo == 0; i++) {
       double value1 = solution1.getObjective(i);
       double value2 = solution2.getObjective(i);
       if (value1 != value2) {


### PR DESCRIPTION
I did not create any benchmark to measure the improvement, though. If it is often the case that both dominances are confirmed way before the last objective, then this optimization makes sense.