### PR TITLE
Factor index bounding methods.

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
@@ -1,5 +1,7 @@
 package org.uma.jmetal.problem;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * A {@link BoundedProblem} is a {@link Problem} for which solution boundaries
  * exist. Boundaries restrict each variable to be within an interval. This
@@ -12,12 +14,13 @@ package org.uma.jmetal.problem;
  * @param <S>
  *          Type of {@link Problem} solutions
  */
-public interface BoundedProblem<T extends Number, S> extends Problem<S> {
+public interface BoundedProblem<T extends Number, S> extends Problem<S>, IndexBounder<T> {
   /**
    * @param index
    *          index of the variable
    * @return lower bound of the variable
    */
+  @Override
   public T getLowerBound(int index);
 
   /**
@@ -25,5 +28,6 @@ public interface BoundedProblem<T extends Number, S> extends Problem<S> {
    *          index of the variable
    * @return upper bound of the variable
    */
+  @Override
   public T getUpperBound(int index);
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/DoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/DoubleBinarySolution.java
@@ -1,13 +1,13 @@
 package org.uma.jmetal.solution;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * Interface representing a solution having an array of real values and a bitset
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface DoubleBinarySolution extends Solution<Object>{
+public interface DoubleBinarySolution extends Solution<Object>, IndexBounder<Double>{
   public int getNumberOfDoubleVariables() ;
-  public Double getLowerBound(int index) ;
-  public Double getUpperBound(int index) ;
   public int getNumberOfBits() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/DoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/DoubleSolution.java
@@ -1,11 +1,11 @@
 package org.uma.jmetal.solution;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * Interface representing a double solutions
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface DoubleSolution extends Solution<Double> {
-  public Double getLowerBound(int index) ;
-  public Double getUpperBound(int index) ;
+public interface DoubleSolution extends Solution<Double>, IndexBounder<Double> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/IntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/IntegerDoubleSolution.java
@@ -1,13 +1,13 @@
 package org.uma.jmetal.solution;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * Interface representing a solution composed of integers and real values
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface IntegerDoubleSolution extends Solution<Number> {
-  public Number getLowerBound(int index) ;
-  public Number getUpperBound(int index) ;
+public interface IntegerDoubleSolution extends Solution<Number>, IndexBounder<Number> {
   public int getNumberOfIntegerVariables() ;
   public int getNumberOfDoubleVariables() ;
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/IntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/IntegerSolution.java
@@ -1,11 +1,11 @@
 package org.uma.jmetal.solution;
 
+import org.uma.jmetal.util.IndexBounder;
+
 /**
  * Interface representing a integer solutions
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface IntegerSolution extends Solution<Integer> {
-  public Integer getLowerBound(int index) ;
-  public Integer getUpperBound(int index) ;
+public interface IntegerSolution extends Solution<Integer>, IndexBounder<Integer> {
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -39,7 +39,6 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
   public AbstractGenericSolution(P problem, Function<Integer, T> variableProvider, Function<Integer, Double> objectiveProvider, Map<Object, Object> attributes
       ) {
     this.problem = problem ;
-    attributes = new HashMap<>() ;
     randomGenerator = JMetalRandom.getInstance() ;
 
     objectives = new double[problem.getNumberOfObjectives()] ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -63,7 +63,7 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
    *          variable values
    */
   public AbstractGenericSolution(P problem, Function<Integer, T> variableProvider) {
-    this(problem, variableProvider, i -> 0.0, Collections.emptyMap());
+    this(problem, variableProvider, i -> 0.0, new HashMap<>());
   }
 
   /**

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/AbstractGenericSolution.java
@@ -140,7 +140,7 @@ public abstract class AbstractGenericSolution<T, P extends Problem<?>> implement
    *             {@link #AbstractGenericSolution(Problem, Function)}. If you don't
    *             need it, it means you aim for non-zero objectives, in which case
    *             you should rely on
-   *             {@link #AbstractGenericSolution(Problem, Function, Function)} or
+   *             {@link #AbstractGenericSolution(Problem, Function, Function, Map)} or
    *             {@link #AbstractGenericSolution(Problem, Solution)} instead.
    */
   @Deprecated

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultBinarySolution.java
@@ -23,22 +23,12 @@ public class DefaultBinarySolution
     super(problem) ;
 
     initializeBinaryVariables(JMetalRandom.getInstance());
-    initializeObjectiveValues();
   }
 
   /** Copy constructor */
   public DefaultBinarySolution(DefaultBinarySolution solution) {
-    super(solution.problem);
-
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, (BinarySet) solution.getVariableValue(i).clone());
-    }
-
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, i -> (BinarySet) solution.getVariableValue(i).clone(), solution::getObjective,
+        new HashMap<>(solution.getAttributes()));
   }
 
   private static BinarySet createNewBitSet(int numberOfBits, JMetalRandom randomGenerator) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -5,8 +5,8 @@ import org.uma.jmetal.solution.DoubleBinarySolution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.BitSet;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Description:
@@ -26,50 +26,27 @@ public class DefaultDoubleBinarySolution
 
   /** Constructor */
   public DefaultDoubleBinarySolution(DoubleBinaryProblem<?> problem) {
-    super(problem) ;
+    super(problem, variableInitializer(problem, JMetalRandom.getInstance())) ;
 
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
-
-    initializeDoubleVariables(JMetalRandom.getInstance());
-    initializeBitSet(JMetalRandom.getInstance()) ;
-    initializeObjectiveValues();
   }
 
   /** Copy constructor */
   public DefaultDoubleBinarySolution(DefaultDoubleBinarySolution solution) {
-    super(solution.problem) ;
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    copyDoubleVariables(solution);
-    copyBitSet(solution);
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
-
-  private void initializeDoubleVariables(JMetalRandom randomGenerator) {
-    for (int i = 0 ; i < numberOfDoubleVariables; i++) {
-      Double value = randomGenerator.nextDouble(getLowerBound(i), getUpperBound(i)) ;
-      //variables.add(value) ;
-      setVariableValue(i, value);
-    }
-  }
-
-  private void initializeBitSet(JMetalRandom randomGenerator) {
-    BitSet bitset = createNewBitSet(problem.getNumberOfBits(), randomGenerator) ;
-    setVariableValue(numberOfDoubleVariables, bitset);
-  }
-
-  private void copyDoubleVariables(DefaultDoubleBinarySolution solution) {
-    for (int i = 0 ; i < numberOfDoubleVariables; i++) {
-      setVariableValue(i, solution.getVariableValue(i));
-    }
-  }
-
-  private void copyBitSet(DefaultDoubleBinarySolution solution) {
-    BitSet bitset = (BitSet)solution.getVariableValue(solution.getNumberOfVariables()-1) ;
-    setVariableValue(numberOfDoubleVariables, bitset);
+  
+  private static Function<Integer, Object> variableInitializer(DoubleBinaryProblem<?> problem,
+      JMetalRandom randomGenerator) {
+    return i -> {
+      if (i < problem.getNumberOfDoubleVariables()) {
+        Double lowerBound = (Double) problem.getLowerBound(i);
+        Double upperBound = (Double) problem.getUpperBound(i);
+        return randomGenerator.nextDouble(lowerBound, upperBound);
+      } else {
+        return createNewBitSet(problem.getNumberOfBits(), randomGenerator);
+      }
+    };
   }
 
   @Override
@@ -102,7 +79,7 @@ public class DefaultDoubleBinarySolution
     return getVariableValue(index).toString() ;
   }
 
-  private BitSet createNewBitSet(int numberOfBits, JMetalRandom randomGenerator) {
+  private static BitSet createNewBitSet(int numberOfBits, JMetalRandom randomGenerator) {
     BitSet bitSet = new BitSet(numberOfBits) ;
 
     for (int i = 0; i < numberOfBits; i++) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleBinarySolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.DoubleBinaryProblem;
 import org.uma.jmetal.solution.DoubleBinarySolution;
+import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.BitSet;
@@ -23,17 +24,20 @@ public class DefaultDoubleBinarySolution
     extends AbstractGenericSolution<Object, DoubleBinaryProblem<?>>
     implements DoubleBinarySolution {
   private int numberOfDoubleVariables ;
+  private final IndexBounder<Number> bounder;
 
   /** Constructor */
   public DefaultDoubleBinarySolution(DoubleBinaryProblem<?> problem) {
     super(problem, variableInitializer(problem, JMetalRandom.getInstance())) ;
 
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
+    this.bounder = problem;
   }
 
   /** Copy constructor */
   public DefaultDoubleBinarySolution(DefaultDoubleBinarySolution solution) {
     super(solution.problem, solution) ;
+    this.bounder = solution.bounder;
   }
   
   private static Function<Integer, Object> variableInitializer(DoubleBinaryProblem<?> problem,
@@ -56,7 +60,7 @@ public class DefaultDoubleBinarySolution
 
   @Override
   public Double getUpperBound(int index) {
-    return (Double)problem.getUpperBound(index);
+    return (Double)bounder.getUpperBound(index);
   }
 
   @Override
@@ -66,7 +70,7 @@ public class DefaultDoubleBinarySolution
 
   @Override
   public Double getLowerBound(int index) {
-    return (Double)problem.getLowerBound(index) ;
+    return (Double)bounder.getLowerBound(index) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -22,22 +22,11 @@ public class DefaultDoubleSolution
     super(problem) ;
 
     initializeDoubleVariables(JMetalRandom.getInstance());
-    initializeObjectiveValues();
   }
 
   /** Copy constructor */
   public DefaultDoubleSolution(DefaultDoubleSolution solution) {
-    super(solution.problem) ;
-
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, solution.getVariableValue(i));
-    }
-
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultDoubleSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.DoubleProblem;
 import org.uma.jmetal.solution.DoubleSolution;
+import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
@@ -17,9 +18,12 @@ public class DefaultDoubleSolution
     extends AbstractGenericSolution<Double, DoubleProblem>
     implements DoubleSolution {
 
+  private final IndexBounder<Double> bounder;
+
   /** Constructor */
   public DefaultDoubleSolution(DoubleProblem problem) {
     super(problem) ;
+    this.bounder = problem;
 
     initializeDoubleVariables(JMetalRandom.getInstance());
   }
@@ -27,16 +31,17 @@ public class DefaultDoubleSolution
   /** Copy constructor */
   public DefaultDoubleSolution(DefaultDoubleSolution solution) {
     super(solution.problem, solution) ;
+    this.bounder = solution.bounder;
   }
 
   @Override
   public Double getUpperBound(int index) {
-    return problem.getUpperBound(index);
+    return bounder.getUpperBound(index);
   }
 
   @Override
   public Double getLowerBound(int index) {
-    return problem.getLowerBound(index) ;
+    return bounder.getLowerBound(index) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -6,6 +6,7 @@ import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Defines an implementation of a class for solutions having integers and doubles
@@ -22,32 +23,15 @@ public class DefaultIntegerDoubleSolution
 
   /** Constructor */
   public DefaultIntegerDoubleSolution(IntegerDoubleProblem<?> problem) {
-    super(problem) ;
+    super(problem, variableInitializer(problem)) ;
 
     numberOfIntegerVariables = problem.getNumberOfIntegerVariables() ;
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
-
-    initializeIntegerDoubleVariables(JMetalRandom.getInstance()) ;
-    initializeObjectiveValues() ;
   }
 
   /** Copy constructor */
   public DefaultIntegerDoubleSolution(DefaultIntegerDoubleSolution solution) {
-    super(solution.problem) ;
-
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    for (int i = 0 ; i < numberOfIntegerVariables; i++) {
-      setVariableValue(i, solution.getVariableValue(i)) ;
-    }
-
-    for (int i = numberOfIntegerVariables ; i < (numberOfIntegerVariables+numberOfDoubleVariables); i++) {
-      setVariableValue(i, solution.getVariableValue(i)) ;
-    }
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
 
   @Override
@@ -80,16 +64,17 @@ public class DefaultIntegerDoubleSolution
     return getVariableValue(index).toString() ;
   }
   
-  private void initializeIntegerDoubleVariables(JMetalRandom randomGenerator) {
-    for (int i = 0 ; i < numberOfIntegerVariables; i++) {
-      Integer value = randomGenerator.nextInt((Integer)getLowerBound(i), (Integer)getUpperBound(i)) ;
-      setVariableValue(i, value) ;
-    }
-
-    for (int i = numberOfIntegerVariables ; i < getNumberOfVariables(); i++) {
-      Double value = randomGenerator.nextDouble((Double)getLowerBound(i), (Double)getUpperBound(i)) ;
-      setVariableValue(i, value) ;
-    }
+  private static Function<Integer, Number> variableInitializer(IntegerDoubleProblem<?> problem) {
+    return i -> {
+      Number lowerBound = problem.getLowerBound(i);
+      Number upperBound = problem.getUpperBound(i);
+      JMetalRandom randomGenerator = JMetalRandom.getInstance();
+      if (i < problem.getNumberOfIntegerVariables()) {
+        return randomGenerator.nextInt((Integer) lowerBound, (Integer) upperBound);
+      } else {
+        return randomGenerator.nextDouble((Double) lowerBound, (Double) upperBound);
+      }
+    };
   }
   
 	@Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerDoubleSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.IntegerDoubleProblem;
 import org.uma.jmetal.solution.IntegerDoubleSolution;
+import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
@@ -20,6 +21,7 @@ public class DefaultIntegerDoubleSolution
 
   private int numberOfIntegerVariables ;
   private int numberOfDoubleVariables ;
+  private final IndexBounder<Number> bounder;
 
   /** Constructor */
   public DefaultIntegerDoubleSolution(IntegerDoubleProblem<?> problem) {
@@ -27,16 +29,18 @@ public class DefaultIntegerDoubleSolution
 
     numberOfIntegerVariables = problem.getNumberOfIntegerVariables() ;
     numberOfDoubleVariables = problem.getNumberOfDoubleVariables() ;
+    this.bounder = problem;
   }
 
   /** Copy constructor */
   public DefaultIntegerDoubleSolution(DefaultIntegerDoubleSolution solution) {
     super(solution.problem, solution) ;
+    this.bounder = solution.bounder;
   }
 
   @Override
   public Number getUpperBound(int index) {
-    return problem.getUpperBound(index);
+    return bounder.getUpperBound(index);
   }
 
   @Override
@@ -51,7 +55,7 @@ public class DefaultIntegerDoubleSolution
 
   @Override
   public Number getLowerBound(int index) {
-    return problem.getLowerBound(index) ;
+    return bounder.getLowerBound(index) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerPermutationSolution.java
@@ -4,9 +4,9 @@ import org.uma.jmetal.problem.PermutationProblem;
 import org.uma.jmetal.solution.PermutationSolution;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Defines an implementation of solution composed of a permuation of integers
@@ -20,8 +20,10 @@ public class DefaultIntegerPermutationSolution
 
   /** Constructor */
   public DefaultIntegerPermutationSolution(PermutationProblem<?> problem) {
-    super(problem) ;
+    super(problem, variableInitializer(problem)) ;
+  }
 
+  private static Function<Integer, Integer> variableInitializer(PermutationProblem<?> problem) {
     List<Integer> randomSequence = new ArrayList<>(problem.getPermutationLength());
 
     for (int j = 0; j < problem.getPermutationLength(); j++) {
@@ -30,23 +32,12 @@ public class DefaultIntegerPermutationSolution
 
     java.util.Collections.shuffle(randomSequence);
 
-    for (int i = 0; i < getNumberOfVariables(); i++) {
-      setVariableValue(i, randomSequence.get(i)) ;
-    }
+    return randomSequence::get ;
   }
 
   /** Copy Constructor */
   public DefaultIntegerPermutationSolution(DefaultIntegerPermutationSolution solution) {
-    super(solution.problem) ;
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, solution.getVariableValue(i));
-    }
-    
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
 
   @Override public String getVariableValueString(int index) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -4,7 +4,6 @@ import org.uma.jmetal.problem.IntegerProblem;
 import org.uma.jmetal.solution.IntegerSolution;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -22,22 +21,11 @@ public class DefaultIntegerSolution
     super(problem) ;
 
     initializeIntegerVariables(JMetalRandom.getInstance());
-    initializeObjectiveValues();
   }
 
   /** Copy constructor */
   public DefaultIntegerSolution(DefaultIntegerSolution solution) {
-    super(solution.problem) ;
-
-    for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      setVariableValue(i, solution.getVariableValue(i));
-    }
-
-    for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-      setObjective(i, solution.getObjective(i)) ;
-    }
-
-    attributes = new HashMap<Object, Object>(solution.attributes) ;
+    super(solution.problem, solution) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/impl/DefaultIntegerSolution.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.solution.impl;
 
 import org.uma.jmetal.problem.IntegerProblem;
 import org.uma.jmetal.solution.IntegerSolution;
+import org.uma.jmetal.util.IndexBounder;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.Map;
@@ -16,9 +17,12 @@ public class DefaultIntegerSolution
     extends AbstractGenericSolution<Integer, IntegerProblem>
     implements IntegerSolution {
 
+  private final IndexBounder<Integer> bounder;
+
   /** Constructor */
   public DefaultIntegerSolution(IntegerProblem problem) {
     super(problem) ;
+    this.bounder = problem;
 
     initializeIntegerVariables(JMetalRandom.getInstance());
   }
@@ -26,16 +30,17 @@ public class DefaultIntegerSolution
   /** Copy constructor */
   public DefaultIntegerSolution(DefaultIntegerSolution solution) {
     super(solution.problem, solution) ;
+    this.bounder = solution.bounder;
   }
 
   @Override
   public Integer getUpperBound(int index) {
-    return problem.getUpperBound(index);
+    return bounder.getUpperBound(index);
   }
 
   @Override
   public Integer getLowerBound(int index) {
-    return problem.getLowerBound(index) ;
+    return bounder.getLowerBound(index) ;
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/IndexBounder.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/IndexBounder.java
@@ -1,0 +1,33 @@
+package org.uma.jmetal.util;
+
+import java.util.List;
+
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
+
+/**
+ * An {@link IndexBounder} provide up & down boundaries for a given type of
+ * {@link Number} at a given index. It is mainly used for associating a
+ * {@link List} or array of numerical values with a custom set of boundaries for
+ * each value. The main use is for bounded {@link Problem}s and
+ * {@link Solution}s.
+ * 
+ * @author Matthieu Vergne <matthieu.vergne@gmail.com>
+ *
+ * @param <T>
+ */
+public interface IndexBounder<T extends Number> {
+  /**
+   * @param index
+   *          index of the {@link Number}
+   * @return lower bound of the {@link Number}
+   */
+  public T getLowerBound(int index);
+
+  /**
+   * @param index
+   *          index of the {@link Number}
+   * @return upper bound of the {@link Number}
+   */
+  public T getUpperBound(int index);
+}


### PR DESCRIPTION
Build on #344, which should be merged first.

It unlocks further decomposition of classes providing boundaries. This is
a step towards problem-independence of the AbstractGenericSolution, which
does not use it and thus should not store it.