### PR TITLE
Auto-parametering & observers

### DIFF
--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaii/AutoNSGAIIConfigurator.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaii/AutoNSGAIIConfigurator.java
@@ -99,7 +99,7 @@ public class AutoNSGAIIConfigurator {
   Ranking<DoubleSolution> ranking = new DominanceRanking<>(new DominanceComparator<>());
   DensityEstimator<DoubleSolution> densityEstimator = new CrowdingDistanceDensityEstimator<>();
   MultiComparator<DoubleSolution> rankingAndCrowdingComparator =
-      new MultiComparator<>(
+      new MultiComparator<DoubleSolution>(
           Arrays.asList(ranking.getSolutionComparator(), densityEstimator.getSolutionComparator()));
 
   Replacement<DoubleSolution> replacement =

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaii/NSGAII.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaii/NSGAII.java
@@ -72,7 +72,7 @@ public class NSGAII {
     DensityEstimator<DoubleSolution> densityEstimator = new CrowdingDistanceDensityEstimator<>();
 
     MultiComparator<DoubleSolution> rankingAndCrowdingComparator =
-        new MultiComparator<>(
+        new MultiComparator<DoubleSolution>(
             Arrays.asList(
                 ranking.getSolutionComparator(), densityEstimator.getSolutionComparator()));
 

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/AlgorithmCreator.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/AlgorithmCreator.java
@@ -1,0 +1,48 @@
+package org.uma.jmetal.auto.algorithm.nsgaiib;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.uma.jmetal.operator.crossover.CrossoverOperator;
+import org.uma.jmetal.operator.mutation.MutationOperator;
+import org.uma.jmetal.operator.selection.SelectionOperator;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
+
+public interface AlgorithmCreator<T> {
+	
+	// XXX - Definition
+	
+	T create(String[] args);
+
+	// XXX - Specific algorithms
+	
+	@SuppressWarnings("unchecked")
+	public static AlgorithmCreator<NSGAII<Solution<Object>>> NSGA2 = args -> {
+		// Data
+		int populationSize = Parameter.POPULATION_SIZE.getFrom(args);
+		int offspringPopulationSize = Parameter.OFFSPRING_POPULATION_SIZE.getFrom(args);
+		int maxEvaluations = Parameter.MAX_EVALUATIONS.getFrom(args);
+		
+		/*
+		 * Operators. Since the instantiation is dynamic (done at runtime), generics
+		 * have no effect whatsoever due to type erasure, so we can do what we want.
+		 * Here we cast them to the most abstract types to enforce broad compatibility.
+		 * The generics of the returned algorithm will also be of the most abstract type
+		 * automatically.
+		 */
+		Problem<Solution<Object>> problem = (Problem<Solution<Object>>) Parameter.PROBLEM.getFrom(args);
+		SelectionOperator<List<Solution<Object>>, Solution<Object>> selectionOperator = (SelectionOperator<List<Solution<Object>>, Solution<Object>>) Parameter.SELECTION_OPERATOR.getFrom(args);
+		CrossoverOperator<Solution<Object>> crossoverOperator = (CrossoverOperator<Solution<Object>>) Parameter.CROSSOVER_OPERATOR.getFrom(args);
+		MutationOperator<Solution<Object>> mutationOperator = (MutationOperator<Solution<Object>>) Parameter.MUTATION_OPERATOR.getFrom(args);
+		SolutionListEvaluator<Solution<Object>> evaluator = (SolutionListEvaluator<Solution<Object>>) Parameter.EVALUATOR.getFrom(args);
+		Comparator<Solution<Object>> dominanceComparator = (Comparator<Solution<Object>>) Parameter.DOMINANCE_COMPARATOR.getFrom(args);
+		
+		return new NSGAII<>(
+				// Data
+				populationSize, offspringPopulationSize, maxEvaluations,
+				// Operators
+				problem, selectionOperator, crossoverOperator, mutationOperator, evaluator, dominanceComparator);
+	};
+}

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/Main.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/Main.java
@@ -1,9 +1,13 @@
 package org.uma.jmetal.auto.algorithm.nsgaiib;
 
+import static org.uma.jmetal.auto.algorithm.nsgaiib.NSGAII.Step.*;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 
+import org.uma.jmetal.auto.algorithm.nsgaiib.NSGAII.Step;
 import org.uma.jmetal.solution.Solution;
 
 public class Main {
@@ -11,6 +15,55 @@ public class Main {
 	public static void main(String[] args) {
 		System.out.println("Create algorithm");
 		NSGAII<Solution<Object>> algorithm = AlgorithmCreator.NSGA2.create(args);
+
+		System.out.println("Setup algorithm observation");
+		algorithm.registerObserver(new NSGAII.Observer<Solution<Object>>() {
+			int evaluations = 0;
+
+			@Override
+			public void updateNumberOfEvaluations(int evaluations) {
+				this.evaluations = evaluations;
+			}
+
+			int creations = 0;
+
+			@Override
+			public void createSolution(Solution<Object> solution) {
+				creations++;
+			}
+
+			List<Solution<Object>> lastPopulation = Collections.emptyList();
+			int replacements = 0;
+
+			@Override
+			public void updatePopulation(List<Solution<Object>> population) {
+				replacements += population.stream().filter(solution -> !lastPopulation.contains(solution)).count();
+				lastPopulation = population;
+			}
+
+			int iterations = 0;
+
+			@Override
+			public void updateStep(Step step) {
+				if (step == DONE) {
+					System.out.print(step + " ");
+				}
+				if (step == MATE || step == DONE) {
+					// Iteration summary
+					System.out.println("= "
+							+ creations + " creations, "       // total nb of creations
+							+ evaluations + " evaluations, "   // total nb of evaluations
+							+ replacements + " replacements"); // replacements of iteration
+					replacements = 0;                          // reset replacements
+				}
+				if (step == MATE) {
+					System.out.print(++iterations + ": ");
+				}
+				if (step != DONE) {
+					System.out.print(step + " ");
+				}
+			}
+		});
 
 		System.out.println("Run algorithm");
 		algorithm.run();

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/Main.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/Main.java
@@ -1,0 +1,29 @@
+package org.uma.jmetal.auto.algorithm.nsgaiib;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
+
+import org.uma.jmetal.solution.Solution;
+
+public class Main {
+
+	public static void main(String[] args) {
+		System.out.println("Create algorithm");
+		NSGAII<Solution<Object>> algorithm = AlgorithmCreator.NSGA2.create(args);
+
+		System.out.println("Run algorithm");
+		algorithm.run();
+
+		System.out.println("Result:");
+		algorithm.getResult().forEach(solution -> {
+			System.out.println("  Solution:");
+			System.out.println("    Variables : " + solution.getVariables());
+			System.out.println("    Objectives: " + toList(solution.getObjectives()));
+		});
+	}
+
+	private static List<Double> toList(double[] objectives) {
+		return DoubleStream.of(objectives).mapToObj(x -> x).collect(Collectors.toList());
+	}
+}

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/MissingParameterException.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/MissingParameterException.java
@@ -1,0 +1,9 @@
+package org.uma.jmetal.auto.algorithm.nsgaiib;
+
+@SuppressWarnings("serial")
+public class MissingParameterException extends RuntimeException {
+
+	public MissingParameterException(String parameterName) {
+		super("Missing parameter " + parameterName);
+	}
+}

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/NSGAII.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/NSGAII.java
@@ -1,0 +1,185 @@
+package org.uma.jmetal.auto.algorithm.nsgaiib;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.uma.jmetal.algorithm.Algorithm;
+import org.uma.jmetal.operator.crossover.CrossoverOperator;
+import org.uma.jmetal.operator.mutation.MutationOperator;
+import org.uma.jmetal.operator.selection.SelectionOperator;
+import org.uma.jmetal.operator.selection.impl.RankingAndCrowdingSelection;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.util.SolutionListUtils;
+import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
+
+/**
+ * @author Antonio J. Nebro <antonio@lcc.uma.es>
+ */
+@SuppressWarnings("serial")
+public class NSGAII<S extends Solution<?>> implements Algorithm<List<S>> {
+	// XXX - Fields
+
+	// Mutable data
+	private List<S> population;
+	private int evaluations;
+
+	// Immutable data
+	private final int populationSize;
+	private final int offspringPopulationSize;
+	private final int maxEvaluations;
+
+	/*
+	 * Immutable operators. Can be considered part of the state or not depending on
+	 * the definitions we choose.
+	 */
+	private final Problem<S> problem;
+	private final SelectionOperator<List<S>, S> selectionOperator;
+	private final CrossoverOperator<S> crossoverOperator;
+	private final MutationOperator<S> mutationOperator;
+	private final SolutionListEvaluator<S> evaluator;
+	private final Comparator<S> dominanceComparator;
+
+	/* XXX - Constructor */
+
+	public NSGAII(
+			// Data
+			int populationSize, int offspringPopulationSize, int maxEvaluations,
+			// Operators
+			Problem<S> problem, SelectionOperator<List<S>, S> selectionOperator, CrossoverOperator<S> crossoverOperator,
+			MutationOperator<S> mutationOperator, SolutionListEvaluator<S> evaluator,
+			Comparator<S> dominanceComparator) {
+		// State
+		this.problem = problem;
+		this.populationSize = populationSize;
+		this.offspringPopulationSize = offspringPopulationSize;
+		this.maxEvaluations = maxEvaluations;
+
+		// Operators
+		this.selectionOperator = selectionOperator;
+		this.crossoverOperator = crossoverOperator;
+		this.mutationOperator = mutationOperator;
+		this.evaluator = evaluator;
+		this.dominanceComparator = dominanceComparator;
+	}
+
+	/* XXX - Methods required by the Algorithm interface */
+
+	@Override
+	public String getName() {
+		return "NSGAII";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Nondominated Sorting Genetic Algorithm version II";
+	}
+
+	@Override
+	public void run() {
+		List<S> offspringPopulation;
+		List<S> matingPopulation;
+
+		population = createInitialPopulation();
+		population = evaluatePopulation(population);
+		evaluations = populationSize;
+		while (evaluations < maxEvaluations) {
+			matingPopulation = selection(population);
+			offspringPopulation = reproduction(matingPopulation);
+			offspringPopulation = evaluatePopulation(offspringPopulation);
+			population = replacement(population, offspringPopulation);
+			evaluations += offspringPopulationSize;
+		}
+	}
+
+	@Override
+	public List<S> getResult() {
+		return SolutionListUtils.getNondominatedSolutions(population);
+	}
+
+	/* XXX - Methods required by the run() method */
+
+	/**
+	 * This method implements a default scheme create the initial population of
+	 * genetic algorithm
+	 * 
+	 * @return
+	 */
+	private List<S> createInitialPopulation() {
+		List<S> population = new ArrayList<>(populationSize);
+		for (int i = 0; i < populationSize; i++) {
+			S newIndividual = problem.createSolution();
+			population.add(newIndividual);
+		}
+		return population;
+	}
+
+	private List<S> evaluatePopulation(List<S> population) {
+		return evaluator.evaluate(population, problem);
+	}
+
+	/**
+	 * This method iteratively applies a {@link SelectionOperator} to the population
+	 * to fill the mating pool population.
+	 *
+	 * @param population
+	 * @return The mating pool population
+	 */
+	private List<S> selection(List<S> population) {
+		int matingPoolSize = offspringPopulationSize * crossoverOperator.getNumberOfRequiredParents();
+		List<S> matingPopulation = new ArrayList<>(matingPoolSize);
+		for (int i = 0; i < matingPoolSize; i++) {
+			S solution = selectionOperator.execute(population);
+			matingPopulation.add(solution);
+		}
+
+		return matingPopulation;
+	}
+
+	/**
+	 * This methods iteratively applies a {@link CrossoverOperator} a
+	 * {@link MutationOperator} to the population to create the offspring
+	 * population. The population size must be divisible by the number of parents
+	 * required by the {@link CrossoverOperator}; this way, the needed parents are
+	 * taken sequentially from the population.
+	 *
+	 * The number of solutions returned by the {@link CrossoverOperator} must be
+	 * equal to the offspringPopulationSize state variable
+	 *
+	 * @param matingPool
+	 * @return The new created offspring population
+	 */
+	private List<S> reproduction(List<S> matingPool) {
+		int numberOfParents = crossoverOperator.getNumberOfRequiredParents();
+
+		List<S> offspringPopulation = new ArrayList<>(offspringPopulationSize);
+		for (int i = 0; i < matingPool.size(); i += numberOfParents) {
+			List<S> parents = new ArrayList<>(numberOfParents);
+			for (int j = 0; j < numberOfParents; j++) {
+				parents.add(population.get(i + j));
+			}
+
+			List<S> offspring = crossoverOperator.execute(parents);
+
+			for (S s : offspring) {
+				mutationOperator.execute(s);
+				offspringPopulation.add(s);
+				if (offspringPopulation.size() >= offspringPopulationSize)
+					break;
+			}
+		}
+		return offspringPopulation;
+	}
+
+	private List<S> replacement(List<S> population, List<S> offspringPopulation) {
+		List<S> jointPopulation = new ArrayList<>();
+		jointPopulation.addAll(population);
+		jointPopulation.addAll(offspringPopulation);
+
+		RankingAndCrowdingSelection<S> rankingAndCrowdingSelection;
+		rankingAndCrowdingSelection = new RankingAndCrowdingSelection<S>(populationSize, dominanceComparator);
+
+		return rankingAndCrowdingSelection.execute(jointPopulation);
+	}
+}

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/Parameter.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaiib/Parameter.java
@@ -1,0 +1,123 @@
+package org.uma.jmetal.auto.algorithm.nsgaiib;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.uma.jmetal.operator.crossover.CrossoverOperator;
+import org.uma.jmetal.operator.crossover.impl.BLXAlphaCrossover;
+import org.uma.jmetal.operator.mutation.MutationOperator;
+import org.uma.jmetal.operator.mutation.impl.PolynomialMutation;
+import org.uma.jmetal.operator.selection.SelectionOperator;
+import org.uma.jmetal.operator.selection.impl.TournamentSelection;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.problem.multiobjective.wfg.WFG6;
+import org.uma.jmetal.util.comparator.DominanceComparator;
+import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
+import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
+
+public interface Parameter<T> {
+
+	// XXX - Definition
+
+	public T getFrom(String[] args);
+
+	// XXX - Factory methods
+
+	public static Parameter<String> onString(String key) {
+		return on(key, Function.identity());
+	}
+
+	public static Parameter<Integer> onInt(String key) {
+		return on(key, Integer::parseInt);
+	}
+
+	public static Parameter<Double> onDouble(String key) {
+		return on(key, Double::parseDouble);
+	}
+
+	public static <T> Parameter<T> onMap(String key, Map<String, Supplier<T>> suppliers) {
+		return args -> suppliers.get(retrieve(args, key)).get();
+	}
+
+	public static <T> Parameter<T> on(String key, Function<String, T> parser) {
+		return args -> parser.apply(retrieve(args, key));
+	}
+
+	public static String retrieve(String[] args, String key) {
+		int index = Arrays.asList(args).indexOf(key);
+		if (index == -1 || index == args.length - 1) {
+			throw new MissingParameterException(key);
+		} else {
+			return args[index + 1];
+		}
+	}
+
+	// XXX - Specific parameters
+
+	// Simple integers
+
+	public static Parameter<Integer> POPULATION_SIZE = Parameter.onInt("--populationSize");
+
+	public static Parameter<Integer> OFFSPRING_POPULATION_SIZE = Parameter.onInt("--offspringPopulationSize");
+
+	public static Parameter<Integer> MAX_EVALUATIONS = Parameter.onInt("--maxEvaluations");
+
+	// Specific values mapped to specific strings
+
+	public static Parameter<Problem<?>> PROBLEM = Parameter.onMap("--problemName",
+			Collections.singletonMap("WFG6", () -> new WFG6())
+			// ... more problems ...
+	);
+
+	public static Parameter<SolutionListEvaluator<?>> EVALUATOR = Parameter.onMap("--evaluator",
+			Collections.singletonMap("sequential", () -> new SequentialSolutionListEvaluator<>())
+			// ... more evaluators ...
+	);
+
+	public static Parameter<Comparator<?>> DOMINANCE_COMPARATOR = Parameter.onMap("--comparator",
+			Collections.singletonMap("dominance", () -> new DominanceComparator<>())
+			// ... more comparators ...
+	);
+
+	// Fully customized parameters, building on several values
+
+	public static Parameter<SelectionOperator<?, ?>> SELECTION_OPERATOR = args -> {
+		String name = Parameter.onString("--selection").getFrom(args);
+		if (name.equals("tournament")) {
+			int size = Parameter.onInt("--selectionTournamentSize").getFrom(args);
+			return new TournamentSelection<>(size);
+		} else {
+			// ... more selectors ...
+			return null;
+		}
+	};
+
+	public static Parameter<CrossoverOperator<?>> CROSSOVER_OPERATOR = args -> {
+		String name = Parameter.onString("--crossover").getFrom(args);
+		if (name.equals("BLX_ALPHA")) {
+			double probability = Parameter.onDouble("--crossoverProbability").getFrom(args);
+			double alpha = Parameter.onDouble("--blxAlphaCrossoverAlphaValue").getFrom(args);
+			return new BLXAlphaCrossover(probability, alpha);
+		} else {
+			// ... more crossover operators ...
+			return null;
+		}
+	};
+
+	public static Parameter<MutationOperator<?>> MUTATION_OPERATOR = args -> {
+		String name = Parameter.onString("--mutation").getFrom(args);
+		if (name.equals("polynomial")) {
+			double probability = Parameter.onDouble("--mutationProbability").getFrom(args);
+			double distributionIndex = Parameter.onDouble("--mutationDistributionIndex").getFrom(args);
+			return new PolynomialMutation(probability, distributionIndex);
+		} else {
+			// ... more crossover operators ...
+			return null;
+		}
+	};
+
+}


### PR DESCRIPTION
Regarding your `auto` branch, it looks to me like you tried to do several novel things at once, and thus aggregated the struggling points. Consequently, I propose you a *short* (you know what it means, right?) tutorial. It is not aimed for merging, only for sharing good practice and feedback.

As far as I can tell, I see 3 themes in your `auto` branch:
- the algorithm template
- the auto-parametering (command line instantiation)
- the observer pattern

I will skip the algorithm template and directly build on existing ones. Indeed, you already have several of them, so you know what it is. There is only few points I consider to be problematic:
- Some templates, like `AbstractEvolutionaryAlgorithm`, are abstract classes (with abstract methods), instead of concrete classes (with operators). We already discussed this issue, so I won't cover it here. Other templates, like `NSGAII`, are proper concrete classes, so we have examples to build on.
- Operator-based templates use operators based on a single `Operator` interface, instead of using various signatures (specific ones or generic ones like `Supplier`, `Function`, `BiFunction`, etc.). You have my `AutoMOEA` as an example. This single interface is quite limiting, but we have working algorithms, so let's build on that for now.
- A better use of generics could be achieved, but this is a running issue which requires time to experiment and improve, so nothing specific to templates.

Rather than spending time on the template part, I will just reuse the NSGA2 template as we know it. I will cover here the *auto-parametering*, which allows to do runtime instantiation, and the *observer pattern*, which allows to audit the running algorithms.

It is a pull request because I provide you the code I built. For each step, you will find a commit which shows you how I do it. You won't find all the code in this description, please look at the commits for details. They have been organised for an easy reading, so you can check them separately, in the order. The very first commit is just some fixes because the `auto` branch I had at this time did not compile. So I fixed it in the first commit. All the following commits are for this tutorial.

# Create the algorithm

I go for the NSGA-2 to remain close to what you know well. Moreover, it allows me to reuse your stuff without to spend time caring about how it works. In all this stuff, I won't care about whether or not the way I use NSGA2 makes sense nor whether its results are good. I will just use it as an illustration, so we stay focused on the topic.

I reused the current implementation from jMetal. I simplified it by removing several stuff:
- I keep only 1 constructor (the most detailed one).
- I integrate all the stuff from the class it extends (`AbstractGeneticAlgorithm`, `AbstractEvolutionaryAlgorithm`), this way it is a direct implementation of `Algorithm`, so we completely decorrelate it from existing templates and make it self-contained.
- I replace `protected` stuff by `private`, this way we will have the need to expose stuff, giving us ground for the *observer pattern*.
- I remove all setters & getters (except the ones required by the interface) for the same reason.
- I removed the mating pool size, since it must be equal to the offspring population size times the number of required parents for the crossover. It allows me to remove a check method.
- I inline some small methods to remove complexity (`initProgress()`, `updateProgress()`, etc.).
- I made the fields `final` where possible to better identify mutable and immutable pieces of the state of the algorithm.
- I reorganize and comment a bit to make everything water clear.

This way, we have a complete algorithm, focused on its own matter, ready to be used. You can find it in the second commit (i.e. after the fixes).

# Auto-parametering

We have some algorithms ready for use in jMetal. The point is that they are mainly instantiated manually by creating dedicated runners. Instead, we would like a lib to run. By giving it the right parameters, it should instantiate, parameter, and run the algorithm automatically.

## Goal

Parse and apply parameters to instantiate an algorithm automatically.

## Method

### Define the parameters to expose

Parameters can be of several kinds, but they are mainly:
- contructor parameters, when they *must* be provided before to consider the instance to be ready for use
- setters, when they can be modified during the instance use

Of course, they can overlap: if a parameter is required *and* able to change over time, it should have a constructor parameter and a setter.

Our algorithm is assumed to be a "one shot" algorithm: you parameter it, you run it, and you wait for the final result. As such, there is no setters, only constructor parameters. These parameters are of 2 kinds:
- data:
	- `int populationSize`
	- `int offspringPopulationSize`
	- `int maxEvaluations`
- operators:
	- `Problem<S> problem` (used to create + evaluate solutions, so operators)
	- `SelectionOperator<List<S>, S> selectionOperator`
	- `CrossoverOperator<S> crossoverOperator`
	- `MutationOperator<S> mutationOperator`
	- `SolutionListEvaluator<S> evaluator`
	- `Comparator<S> dominanceComparator`

The *data* parameters are easy to represent: you need to know their type and value. Basic mono-valued parameters, like integers, characters, strings, enums, etc. can directly be represented through their values. Multi-valued parameters, in other words structures, would need to be represented as a map of fields & values or equivalent, possibly recursively. For the most complex cases, we may need more specific representations depending on the expressivity we target. In our case, let's make it simple and reuse some of your stuff:
- `int populationSize`
	- `--populationSize` (e.g. 20)
- `int offspringPopulationSize`
	- `--offspringPopulationSize` (e.g. 10)
- `int maxEvaluations`
	- `--maxEvaluations` (e.g. 1000)

The *operators* have no value, since they are functions. They need to be identified at least by a specific identifier. This identifier should be mapped to a method/constructor which instantiates it. Additionally, this method may require its own parameters. These parameters should be added to the representation of the *operator*. If a parameter is a piece of *data*, then it canbe directly represented. If a parameter is again an *operator*, then we go on recursively. At the end, the representation must be complete for the operator to be instantiated. In our case:
- `Problem<S> problem`
	- `--problemName` (e.g. WFG6)
- `SelectionOperator<List<S>, S> selectionOperator`
	- `--selection` (e.g. tournament)
	- `--selectionTournamentSize` (e.g. 9)
- `CrossoverOperator<S> crossoverOperator`
	- `--crossover` (e.g. BLX_ALPHA)
	- `--crossoverProbability` (e.g. 0.9983)
	- `--blxAlphaCrossoverAlphaValue` (e.g. 0.7648)
- `MutationOperator<S> mutationOperator`
	- `--mutation` (e.g. polynomial)
	- `--mutationProbability` (e.g. 0.0078)
	- `--mutationDistributionIndex` (e.g. 0.7294)
- `SolutionListEvaluator<S> evaluator`
	- `--evaluator` (e.g. sequential)
- `Comparator<S> dominanceComparator`
	- `--comparator` (e.g. dominance)

I keep it simple for the ones you don't have in your `auto` branch. We can of course add more details, but let's keep the work reduced. I also don't care about the relevance of the example values. The goal here is only to be able to instantiate and run, not to get nice results.

Now we need 2 things:
- map these parameters to the corresponding methods/constructors to instantiate them
- map the instances to the algorithm parameters

You do both in your `AutoNSGAIIConfigurator`. That is however not the way to go in general, since each parameter may be used for other algorithms. So we need first to define each parameter separately. We do that in a `Parameter` interface:
- the interface defines the signature of each parameter `T getFrom(String[] args)`, which translates the program arguments into a well instantiated parameter.
- some factory methods are provided to help create various types of parameters (`onInt()`, `onDouble()`, etc.).
- the various parameters are created as constants in this interface, making them available everywhere, similarly to an enum.

We have simple parameters, like:
```java
Parameter<Integer> POPULATION_SIZE = Parameter.onInt("--populationSize");
```
and more complex ones building on each other like:
```java
Parameter<SelectionOperator<?, ?>> SELECTION_OPERATOR = args -> {
	String name = Parameter.onString("--selection").getFrom(args);
	if (name.equals("tournament")) {
		int size = Parameter.onInt("--selectionTournamentSize").getFrom(args);
		return new TournamentSelection<>(size);
	} else {
		// ... more selectors ...
		return null;
	}
};
```

You can find the `Parameter` interface in the next commit.

### Map the parameters to the algorithm

Once the parameters are available, we can create the method that will retrieve the right parameters for our algorithm. We reuse the same convention than for parameters:
- we create an `AlgorithmCreator` interface.
- the interface defines the signature of each algorithm creator `T create(String[] args)`, which translates the program arguments into a ready to use algorithm.
- since we only have one algorithm, we make only one constant.

Here is how it looks like:
```java
AlgorithmCreator<NSGAII<Solution<Object>>> NSGA2 = args -> {
	// Data
	int populationSize = Parameter.POPULATION_SIZE.getFrom(args);
	int offspringPopulationSize = Parameter.OFFSPRING_POPULATION_SIZE.getFrom(args);
	int maxEvaluations = Parameter.MAX_EVALUATIONS.getFrom(args);
	
	/*
	 * Operators. Since the instantiation is dynamic (done at runtime), generics
	 * have no effect whatsoever due to type erasure, so we can do what we want.
	 * Here we cast them to the most abstract types to enforce broad compatibility.
	 * The generics of the returned algorithm will also be of the most abstract type
	 * automatically.
	 */
	Problem<Solution<Object>> problem = (Problem<Solution<Object>>) Parameter.PROBLEM.getFrom(args);
	SelectionOperator<List<Solution<Object>>, Solution<Object>> selectionOperator = (SelectionOperator<List<Solution<Object>>, Solution<Object>>) Parameter.SELECTION_OPERATOR.getFrom(args);
	CrossoverOperator<Solution<Object>> crossoverOperator = (CrossoverOperator<Solution<Object>>) Parameter.CROSSOVER_OPERATOR.getFrom(args);
	MutationOperator<Solution<Object>> mutationOperator = (MutationOperator<Solution<Object>>) Parameter.MUTATION_OPERATOR.getFrom(args);
	SolutionListEvaluator<Solution<Object>> evaluator = (SolutionListEvaluator<Solution<Object>>) Parameter.EVALUATOR.getFrom(args);
	Comparator<Solution<Object>> dominanceComparator = (Comparator<Solution<Object>>) Parameter.DOMINANCE_COMPARATOR.getFrom(args);
	
	return new NSGAII<>(
			// Data
			populationSize, offspringPopulationSize, maxEvaluations,
			// Operators
			problem, selectionOperator, crossoverOperator, mutationOperator, evaluator, dominanceComparator);
};
```

You can find the `AlgorithmCreator` interface in the next commit.

### Combine and run

All which remains is to:
1. receive our parameters through the `main(String[] args)` method,
2. instantiate the NSGA2 algorithm with our algorithm creator constant,
3. run the algorithm instance,
4. display its result.

We do that in the `Main` class:
```java
public static void main(String[] args) {
	System.out.println("Create algorithm");
	NSGAII<Solution<Object>> algorithm = AlgorithmCreator.NSGA2.create(args);
	
	System.out.println("Run algorithm");
	algorithm.run();
	
	System.out.println("Result:");
	algorithm.getResult().forEach(solution -> {
		System.out.println("  Solution:");
		System.out.println("    Variables : " + solution.getVariables());
		System.out.println("    Objectives: " + toList(solution.getObjectives()));
	});
}

```

Of course, here we only have 1 algorithm, so it is hard coded. As soon as we add a new one, we need to add a new argument to select it. It may look like that:
```java
public static void main(String[] args) {
	Map<String, Supplier<AlgorithmCreator<?>>> creators = new HashMap<>();
	creators.put("nsga2", () -> AlgorithmCreator.NSGA2);
	/* ... more algorithms ... */
	Parameter<AlgorithmCreator<?>> creator = Parameter.onMap("--algorithm", creators);
	
	System.out.println("Create algorithm");
	@SuppressWarnings("unchecked")
	Algorithm<List<Solution<Object>>> algorithm = (Algorithm<List<Solution<Object>>>) creator.getFrom(args).create(args);
	
	System.out.println("Run algorithm");
	algorithm.run();
	
	System.out.println("Result:");
	algorithm.getResult().forEach(solution -> {
		System.out.println("  Solution:");
		System.out.println("    Variables : " + solution.getVariables());
		System.out.println("    Objectives: " + toList(solution.getObjectives()));
	});
}
```

You can find the `Main` class with the `main(...)` method in the next commit.

## Result

We now have an application which can take various arguments and run the implemented algorithm. If I run it with this set of parameters:
```bash
--populationSize 5
--offspringPopulationSize 2
--maxEvaluations 1000000
--problemName WFG6
--selection tournament
--selectionTournamentSize 9
--crossover BLX_ALPHA
--crossoverProbability 0.9983
--blxAlphaCrossoverAlphaValue 0.7648
--mutation polynomial
--mutationProbability 0.0078
--mutationDistributionIndex 0.7294
--evaluator sequential
--comparator dominance
```

I obtain on my computer a result which looks like this:
```bash
Create algorithm
Run algorithm
Result:
  Solution:
    Variables : [0.0, 4.0, 1.1612110482825384, 1.548254417655579, 6.405640417290847, 2.3224167131098468]
    Objectives: [2.1788344383239746, 0.17883439362049103]
  Solution:
    Variables : [0.0, 0.0, 1.1612110482825384, 1.548254417655579, 6.405640383689146, 2.3224167131098468]
    Objectives: [0.17883439362049103, 4.178834438323975]
  Solution:
    Variables : [0.0, 4.0, 1.1612110482825384, 1.548254417655579, 6.405640384599616, 2.3224167131098468]
    Objectives: [2.1788344383239746, 0.17883439362049103]
  Solution:
    Variables : [0.0, 0.0, 1.1612110482825384, 1.548254417655579, 6.405640431393031, 2.3224167131098468]
    Objectives: [0.17883439362049103, 4.178834438323975]
  Solution:
    Variables : [0.0, 1.94270899661359, 1.1612110482825384, 1.548254417655579, 6.405640407117802, 2.3224167131098468]
    Objectives: [1.560875654220581, 3.0701746940612793]
```

You can play with the *values* of the parameters, but I only implemented those parameters. Feel free to add others if you want.

We can of course extend it with more advanced features, better controls, and so on. I focused here on the basics, without using any external lib nor doing exhaustive checks. I did not care about the meaning of the parameters nor the analysis of this result. I only used it to illustrate how to do auto-parametering in Java with minimal -but right- code. I did not test it thoroughly, so there might have some bugs, but the main stuff is covered.

As a side note, I am basically doing the same thing in my micro-service branch, where I translate JSON descriptions into propre instances.

## Discussion of the `auto` branch

### Picocli library

You use the Picocli library, especially its `CommandLine` class and its `Option` annotation. I didn't know about this library, but it seems to have some nice feature for dealing with command lines. I especially notice:
- the generation of the help message (parameters, descriptions, syntax, etc.)
- multiple values
- arity constraints
- password input

There is other features that seem nice at first, but are actually rather limited. Auto-completion for instance requires you to provide the list of completion candidates. Required fields only manage boolean values, so you have to manage inter-parameter dependencies (a main concern here) by yourself or design a parameter language to have a single parameter per Java instance.

Other features seem useful, but they actually enforce more work than you actually need. Especially the conversion, which you don't use but is a key purpose for us. In the way I presented above, all you need is a simple generic interface + one instance per parameter. Each instance can be created through a lambda and stored directly as a constant of the interface. So in one file, you have everything you need, with concise parameters ready for use, highly similar to an enum. However, `@Option(converter = ...)` requires a class, which means that you need to extract almost each of these lambdas into its own, dedicated class. I say "Almost" because only the most basic ones (typically integers) don't need anything. Since all your operators are complex parameters, you need several of these classes. The code inside is the same as the corresponding lambda, but it adds a lot of boilerplate code due to class multiplication. It is not a bad thing in itself, since it is functionally equivalent, but it is more verbose. Before lambdas were available, you would have needed anonymous classes, so you would have more or less the same thing than dedicated classes. But with the shortness of lambdas, it becomes arguable. And since annotation parameters cannot take custom instances (it is a Java limitation), it is not going to improve soon. Moreover, I did not find anything which helps composing: you often need several parameters to build a single operator, but here each parameter is processed separately. In other word, it appears that it does not help much actually in converting parameters into fully fledged Java objects.

Finally, other features seem useless to me. The default value is a `String` and must pass through the conversion, while you can directly provide the already converted value to the fields directly, as you already do.

In short, this lib seems a nice addition to generate the help message. However, it does not provide much support for instantiation.

### Align our method to reuse Picocli

Picocli does not integrate well with the method I presented above. Indeed, this lib has 1 field per parameter, while I have 1 constant per Java object (some built from several parameters at once). In other words, this lib works at the command line level, while I work at the Java level, so you still need something to link the two. This is what makes your configurator so heavy: since you use this lib, you must add all the command parameters + methods to link them to Java instances. We can investigate several ways to better integrate them, but I will focus here on the one I find the most appealing.

The probem of mapping each command line parameter to the Java instances is not an issue from the lib. It is a problem from the fact that we represent only simple values with each parameter. Indeed, each parameter is provided separately despite having dependencies, which means that:
- you need extra care to provide the right set of parameters
- you need to add plenty of controls in the `Parameter` code to help the user with explicit error messages
- if you need similar parameters for several objects, you must nevertheless create separate parameters

The last point is the most annoying. Although it remains manageable when dealing with a single algorithm, it is really hard to deal with a lot of similar stuff this way. For instance, and I think you noticed it already, making an experiment with several algorithms or problems is quite a challenge. Indeed, the same parameter key will be needed for several cases, but with different values. However, unless you create a different parameter for each, you cannot do it.

The reason is simple: you have inter-dependent parameter, so you should not treat them as separate ones. The correct design is to bring all the dependent parameters together into a single one. In other words, to ensure that each Java object is completely described with at most 1 parameter. It imposes to create a description language for each complex parameter, and among the most used is JSON. You could create a parameter for each object, and even the complex ones would have a single JSON description.

We could also create an overall, single JSON description which gives all the required information, instead of splitting it in several parameters. This is the way I go in the micro-service branch. However, splitting allows to map directly with the Picocli lib.

Whether or not we adapt the method, the principle remains the same. The code of the parameters may change because we change the representation, but the recipe is the same. I won't dig dipper on JSON here and let that for other discussions.

# Observer Pattern

So far, we could run an algorithm in command line and display its result. The final result is nice, but we would like more info about the run itself. In particular, the algorithm run for a while, silently, and then display the final results only. We may be interested about the progress of the algorithm and other stuff.

## Goal

Access the internal state of the algorithm.

## Method

### Identify the data to expose

Looking for something to expose, first we have to look at was is available in our implementation of NSGA2. We can find:
- mutable data:
	- `List<S> population`
	- `int evaluations`
- immutable data:
	- `int populationSize`
	- `int offspringPopulationSize`
	- `int maxEvaluations`
- immutable operators:
	- `Problem<S> problem`
	- `SelectionOperator<List<S>, S> selectionOperator`
	- `CrossoverOperator<S> crossoverOperator`
	- `MutationOperator<S> mutationOperator`
	- `SolutionListEvaluator<S> evaluator`
	- `Comparator<S> dominanceComparator`

Immutable elements may be exposed, but since they directly relate to the parameters we provide, we already know them. As such, they have no value in being exposed. If some immutables are only known internally, they may have some interest. Howver, since they are not mutable, adding getters would be enough. We obtain them once and that's all. In general, exposure makes sense for the mutable elements. Since they evolve in the lifetime of the instance, they may provide useful information to understand how the instance behaves.

In our case, the mutable state contains only 2 elements:
- `List<S> population`
- `int evaluations`

However, it is not the only information of interest in the algorithm. Some people may be interested in the generated solutions, which are not systematically found in the population. They may also be interested in the current step of the algorithm to evaluate the time spent in each of them. We could expose many things, but let's go with these 4 pieces of data:
- the population
- the number of evaluations
- the generated solutions
- the steps of the algorithm

No commit for this one, since it is only an analysis.

### Expose the data: the observer pattern

Let's first clarify something: a design pattern is not a concept to be implemented by itself. It is not a _design_, its is a design _pattern_: it should be applied to a design when it is relevant to the designed concept. For example, the singleton pattern is not implemented through a `Singleton` class or interface. We make a specific concept, say a `Car`, a singleton by applying on it a singleton design pattern. In other words, the `Car` class has a private constructor and a static `getInstance()` method.

Similarly, the [observer pattern](https://en.wikipedia.org/wiki/Observer_pattern) is a set of rules to be applied on a class of relevance. In our case, we want to observe our NSGA2 implementation, so we need to make it observable. We do so by creating an observer for NSGA2:
```java
interface Observer<S extends Solution<?>> {
	default void updatePopulation(List<S> population) {}
	default void updateNumberOfEvaluations(int evaluations) {}
	default void createSolution(S solution) {}
	default void updateStep(Step step) {}
}
```

This is not a generic observer, but an NSGA2-specific observer. It provides methods relevant to observe NSGA2 algorithms. We call it `Observer` because we define it inside `NSGA2`. If we define it outside, `NSGA2Observer` would be more correct.

Since an observer instance may need only some of these methods, we provide them empty default implementations. If one doesn't have default implementations (Java 7 and earlier), using a class with empty methods would work as well. Instead of a single observer with all the methods, we could also make an observer for each piece of data. We come back later on that design.

To manage these observers, the algorithm needs to know about them. To do so, the user should register its observer, and unregister it to stop being notified:
```java
private final Collection<Observer<S>> observers = new LinkedList<>();

public void registerObserver(Observer<S> observer) {
	observers.add(observer);
}

public void unregisterObserver(Observer<S> observer) {
	observers.remove(observer);
}
```

The registered observers can then be notified by the algorithm when relevant. In our case, we have a notification method for each observable piece of data. For example, we can notify a specific change of step:
```java
void notifyStep(Step step) {
	observers.forEach(observer -> observer.updateStep(step));
}
```

The `run()` method is then decorated with these notification calls. For example, here are the notifications added for the step update:
```java
            List<S> offspringPopulation;
            List<S> matingPopulation;
            
/*--->*/    notifyStep(INIT);
            population = createInitialPopulation();
            population = evaluatePopulation(population);
            evaluations = populationSize;
            while (evaluations < maxEvaluations) {
/*--->*/    	notifyStep(SELECT);
            	matingPopulation = selection(population);
/*--->*/    	notifyStep(MATE);
            	offspringPopulation = reproduction(matingPopulation);
/*--->*/    	notifyStep(EVALUATE);
            	offspringPopulation = evaluatePopulation(offspringPopulation);
/*--->*/    	notifyStep(REPLACE);
            	population = replacement(population, offspringPopulation);
            	evaluations += offspringPopulationSize;
            }
/*--->*/    notifyStep(DONE);
```

Other notifications are added to update the population and the number of evaluations. Solution generations are also notified in loops over the first population and the offsprings.

A different design could be to use an observer per piece of data:
```java
interface PopulationObserver<S extends Solution<?>> {
	void updatePopulation(List<S> population)
}
interface EvaluationsObserver {
	void updateNumberOfEvaluations(int evaluations)
}
interface SolutionObserver<S extends Solution<?>> {
	void createSolution(S solution)
}
interface StepObserver {
	void updateStep(Step step)
}
```

We would have the same notification methods, but we would need a list of observers + un/register methods for each of them. Such a design would be relevant if the methods are prone to be called by different observers. You may also be tempted to give them common method names like `update(...)`, but it further limits the ability to implement them in a single instance.

The current design save more code and memory space, but all observers are called everytime. It makes more sense in jMetal since it is an experimental framework: we do not expect much observers beside the framework itself, and it is prone to get everything for traceability.

I compare that with your own design later. Let's see first what we can do with that.

You can find the changes provided to the `NSGAII` class in the next commit.

### Exploit the data

Now that we have access to internal data, let's exploit it in the `main(String[] args)` method. Before to run the algorithm, we register a new observer which exploit each piece of data.

First, we count the total number of evaluations:
```java
int evaluations = 0;

@Override
public void updateNumberOfEvaluations(int evaluations) {
	this.evaluations = evaluations;
}
```

We also count the total number of solutions generated:
```java
int creations = 0;

@Override
public void createSolution(Solution<Object> solution) {
	creations++;
}
```

By receiving the population each time it is updated, we can count the number of replacements:
```java
List<Solution<Object>> lastPopulation = Collections.emptyList();
int replacements = 0;

@Override
public void updatePopulation(List<Solution<Object>> population) {
	replacements += population.stream().filter(solution -> !lastPopulation.contains(solution)).count();
	lastPopulation = population;
}
```

Finally, the steps indicate us when the iteration starts and stop, which allows us to display a summary after each iteration.
I don't explain the depth of the code here, just notice that one condition displays the various data, while the others are only here to complete the display:
```java
int iterations = 0;

@Override
public void updateStep(Step step) {
	if (step == DONE) {
		System.out.print(step + " ");
	}
	if (step == MATE || step == DONE) {
		// Iteration summary
		System.out.println("= "
		        + creations + " creations, "       // total nb of creations
		        + evaluations + " evaluations, "   // total nb of evaluations
		        + replacements + " replacements"); // replacements of iteration
		replacements = 0;                          // reset replacements
	}
	if (step == MATE) {
		System.out.print(++iterations + ": ");
	}
	if (step != DONE) {
		System.out.print(step + " ");
	}
}
```

If the observer tends to have heavy computation, delegating to another thread may be interesting. Here we don't do it because it is rather light and it is easier to remain in sync with each iteration.

With the current design (single observer with all methods), we create one instance with everything inside. With one observer per piece of data, we could use lambdas, but we would need to manage the variables outside, which comes with `final` constraints. Once again, the design choice is a matter of compromise: single observers ease interactions between methods, while split observers favor short lambdas.

You can find the changes provided to the `Main` class in the next commit.

## Result

Now we can run again our application with the same parameters as before to obtain a richer display:
```bash
Create algorithm
Setup algorithm observation
Run algorithm
INIT SELECT = 5 creations, 5 evaluations, 5 replacements
1: MATE EVALUATE REPLACE SELECT = 8 creations, 7 evaluations, 2 replacements
2: MATE EVALUATE REPLACE SELECT = 11 creations, 9 evaluations, 2 replacements
3: MATE EVALUATE REPLACE SELECT = 14 creations, 11 evaluations, 1 replacements
4: MATE EVALUATE REPLACE SELECT = 17 creations, 13 evaluations, 2 replacements
5: MATE EVALUATE REPLACE SELECT = 20 creations, 15 evaluations, 3 replacements
# ... many lines ...
499994: MATE EVALUATE REPLACE SELECT = 1499987 creations, 999993 evaluations, 1 replacements
499995: MATE EVALUATE REPLACE SELECT = 1499990 creations, 999995 evaluations, 2 replacements
499996: MATE EVALUATE REPLACE SELECT = 1499993 creations, 999997 evaluations, 1 replacements
499997: MATE EVALUATE REPLACE SELECT = 1499996 creations, 999999 evaluations, 0 replacements
499998: MATE EVALUATE REPLACE DONE = 1499999 creations, 1000001 evaluations, 2 replacements
Result:
  Solution:
    Variables : [0.0, 4.0, 0.8069594482550969, 1.0759600609861983, 7.5022699438285345, 9.002750517429805]
    Objectives: [2.2462985515594482, 0.24629855155944824]
  Solution:
    Variables : [0.0, 0.0, 0.8069594482550919, 1.0759600609573217, 7.502269819018154, 9.00275051742981]
    Objectives: [0.24629855155944824, 4.246298789978027]
  Solution:
    Variables : [0.0, 4.0, 0.8069594482551, 1.0759600610008566, 7.502269865916643, 9.002750517429806]
    Objectives: [2.2462985515594482, 0.24629855155944824]
  Solution:
    Variables : [0.0, 0.0, 0.8069594482550922, 1.0759600609735287, 7.502269849555169, 9.002750517429805]
    Objectives: [0.24629855155944824, 4.246298789978027]
  Solution:
    Variables : [0.0, 3.0271335301850084, 0.8069594482550942, 1.0759600609482822, 7.502269848575982, 9.002750517429808]
    Objectives: [2.1021077632904053, 1.7375696897506714]
```

Among other things, we can observe:
- the addition of a bunch of lines representing each iteration
- the growing number of total creations (+3/iteration)
- the growing number of total evaluations (+2/iteration)
- the fluctuating number of replacements per iteration (0~3)
- almost 500'000 iterations to reach the max evaluations (termination condition)

Of course, we can exploit this data in many other ways:
- compute more data
- update a graphical interface
- generate graphs over the number of iterations
- send data over the network for remote processing
- save data for later processing
- etc.

## Discussion of the `auto` branch

### Comparison with the method

Let's start with your `Observer` interface:
```java
public interface Observer<D> extends DescribedEntity {
	void update(Observable<D> observable, D data) ;
}
```

First, you took the habit to add `DescribedEntity` to all your interfaces. That is not the way to go: you should keep your interfaces focused. on the practical side, be aware that it makes us unable to use lambdas because we always have 2 more methods to implement. Moreover, if a method requires an object to implement several interfaces, it can request it by itself through generics. For instance, with my own `Observer` interface:
```java
public <T extends Observer<S> & DescribedEntity> void consume(T observer) {
	observer.updateNumberOfEvaluations(30);
	System.out.println("Updated evaluations of " + observer.getName());
}
```
You don't need to add this constraint systematically, only where it is actually required.

Another difference is that you make a generic observer interface. As we said earlier, it is not fundamentally limiting, but it imposes a specific way to deal with it. In particular, forget about composing observers into a single instance.

The main difference is that you also provide the observable item. That is normally not necessary, since the observer should be registered to the observable, so the observable should be known.

Now let's speak about the `Observable`:
```java
public interface Observable<D> extends DescribedEntity {
	void register(Observer<D> observer) ;
	void unregister(Observer<D> observer) ;

	void notifyObservers(D data);
	int numberOfRegisteredObservers() ;
	void setChanged() ;
	boolean hasChanged() ;
	void clearChanged() ;

	Collection<Observer<D>> getObservers() ;
}
```

We retrieve what we used before:
- un/register methods which take the observer
- a notification method to send the piece of data
- a collection of observers.

However, once again it is a generic interface, so you cannot implement it twice. If you want an algorithm to provide several pieces of data, you need either:
- to implement this interface and provide all of them through this single interface, which means that `D` is a container for all your pieces of data. This is wrong because different pieces of data usually come with different events (i.e. at different times), so you often have to send partial containers, potentially with additional information to know which event you are facing. This is rather cumbersome to use.
- to store a map of observables, each dealing with its own piece of data. The keys in the map identify the piece of data.
- to have a getter for each type of observable. Highly similar to the previous one.

In your implementation, you have chosen the first solution, enforced by your `ObservableEntity` interface which only provides a `getObservable()` method, thus notifying a map of attributes instead of a single piece of data. I assume you didn't find the constraint to send all at once really flexible. Surely enough, dealing with maps and casting in `EvaluationObserver`,  `RunTimeChartObserver`, and the others doesn't seem really attractive either. If you had preferred the second solution, you could have more specialized observers, although you would still have casting issues with the map storing the observables. Only the last one allows to completely get rid of casting issues, and thus is the best of the three.

Although the last one seems to be the easiest to use, at the expense of some additional code, it is still not perfect. Indeed, your interface exposes the observers through a `Collection`, so one can interact with them through `getObservers()`. In other words, once you have `getObservers()`, you don't need un/register methods at all since you can use `getObservers().add(observer)` and `getObservers().remove(observer)`. However, you also give the possibility to mess it up by exposing more, like clearing the collection, getting any registered observer to do something else with it, etc. It may seem like more flexibility is added, but if you really need that you can just do it through another mean. Rather, by allowing that here you impose all implementations to pay more attention on how they implement the observer collection and what they do with it. Un/register methods only expose the minimal stuff, free to the implementations to store and manage it the way they want, not even through a `Collection` if they need something else.

Similarly, you expose the notification method, which means that someone else can get the observable and generate illegitimate notifications. Since it does not take an observable, it means the observable received by `update(...)` has no idea of who generated the event: was it the algorithm or some external user?

More generally, `Observable` covers several responsibilities:
- what should be exposed to the user (un/register)
- what should be used inside the algorithm (notification, observer collection) and thus private

In short, all these generic solutions have additional issues. Indeed, interfaces cannot tell what should be done in private, and that is fine because it allows you to do it the way you want. But that means the `Observable` interface would only come with un/registering methods, which does not tell you much about what to do with that. The point is that most of the behaviour of an observable occurs inside it (store observers, call them at the right time, etc.). So it makes no sense to define some generic way to do it, since it will depends on the specific needs of the class it is applied to. This is why observers and observables are not generic concepts to reuse (i.e. a library to import) but a design pattern to apply to your own concepts.

### Additional stuff

Your `Observable` contains more than what we saw, so let's continue with the additional stuff.

We can mention that `numberOfRegisteredObservers()` is not needed since you can call `getObservers().size()`. But that is mere redundancy to be removed. I can also highlight that it exposes a code smell: you need to know the size to know whether a specific observer has already been registererd. This is a quick and dirty shortcut that you should not need because you can have the required knowledge another way. Again, the point is not to change a generic interface because you have a specific need in a specific context.

We quickly mentionned it, but `Observable` depends on `Observer`, which is part of the pattern, but your `Observer` also depends on `Observable`, thus a circular dependency. Circular dependencies are problematic when found in concrete implementations, while they are not in interfaces. However, they are still a code smell, since they identify useless dependencies or actually show that your methods are too tightly coupled to separate them, so they should be merged into a single interface. In our case, the dependency is useless, which you may have already figured since you never use the observable received through `update(...)`. However, this is not useless because *you* don't use it, but because it is *fundamentally* never needed, similarly to `numberOfRegisteredObservers()`. In the cases where it makes sense to have it, all you need to do is to provide it to the observer by another mean (constructor parameters, setter, as you want). Only in the rare case of having an observer registered to several observables (for the very same piece of data) the question may be relevant. But in this case, you can easily decorate the data with its source to receive a source+data piece instead of the data alone (done when you register the observer, which is when you know the source). In other words, you never need it in the definition, only to adapt the specific observer implementations that need it.

You also have an additional set of methods:
- `void setChanged()` to tell that the data has changed, called before calling the observers if the data has changed
- `void clearChanged()` to reset the previous one, called after calling the observers
- `boolean hasChanged()` to tell whether the first one have been called, I assume it should be used in the observer

Once again, we can say several things here. First, `hasChanged()` is never used, which completely annihilates the purpose of the three methods and thus adds useless complexity and computation. Second, whether or not the data changed can be done through mere comparison with the last received data, so the observer can do it on its own *if necessary*, without having this *systematic* extra burden on the algorithm. Third, these methods must be called at specific times around the call of `notifyObservers(...)`, which is not guaranteed here since they are defined separately. Such cases are generally dealt with [template methods](https://en.wikipedia.org/wiki/Template_method_pattern), like your algorithm templates. Fourth, it is not thread safe: heavy computation are usually delegated to other threads, so `clearChanged()` may have been already called when the observer look at `hasChanged()`. Fifth, two of them are again exposed although they should only be used internally. Finally, if you need this information, you can just add it to the piece of data directly (e.g. as additional attribute), which means none of these methods is required at all.

# Conclusion

This tutorial has provided three chapters:
- create an algorithm, short because I reused existing stuff
- expose its parameters for auto-parametering
- expose its internal data for richer results

I tried to focus on the minimal code required to illustrate them and provide running code for you to test it. I also compared it to what you already did in your `auto` branch for further insight, especially for motivating my own designs. There is potential improvements, like the use of JSON for complex parameters, which would ease the integration of Picocli.

Although it is a pull request, it is not aimed for merging, only for illustration. Feel free to do what you want with it though.

If you have any question or remark related to what is presented and discussed here, feel free to comment.