### PR TITLE
Set JDK to openjdk8 in Travis, as oracle no longer works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 install: mvn compile
 jdk:
-  - oraclejdk8
+  - openjdk8
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
As long as I know, Oracle JDK 8 is no longer available at Travis, so continuous integration basically does not work.

One can change the JDK to OpenJDK 8 in order to fix that. This is what this PR is about. 