### PR TITLE
Refine type parameters of a few classes, which removes certain warnings.

### DIFF
--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/fame/FAMEIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/fame/FAMEIT.java
@@ -31,12 +31,12 @@ public class FAMEIT {
     int archiveSize=100 ;
     int maxEvaluations=25000;
 
-    algorithm = new FAME(problem,
+    algorithm = new FAME<>(problem,
             populationSize,
             archiveSize,
             maxEvaluations,
             selection,
-            new SequentialSolutionListEvaluator()) ;
+            new SequentialSolutionListEvaluator<>()) ;
 
     algorithm.run();
 
@@ -62,13 +62,13 @@ public class FAMEIT {
     int maxEvaluations = 25000;
 
     algorithm =
-        new FAME(
+        new FAME<>(
             problem,
             populationSize,
             archiveSize,
             maxEvaluations,
             selection,
-            new SequentialSolutionListEvaluator());
+            new SequentialSolutionListEvaluator<>());
 
     algorithm.run();
 

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/util/preference/Preference.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/util/preference/Preference.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.auto.util.preference;
 
 import org.uma.jmetal.component.densityestimator.DensityEstimator;
 import org.uma.jmetal.component.ranking.Ranking;
+import org.uma.jmetal.solution.Solution;
 
 import java.util.List;
 
@@ -11,7 +12,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class Preference<S>  {
+public class Preference<S extends Solution<?>>  {
   private Ranking<S> ranking ;
   private DensityEstimator<S> densityEstimator ;
   private Preference<S> relatedPreference ;
@@ -48,7 +49,7 @@ public class Preference<S>  {
   }
 
   private boolean densityEstimatorsAreDifferent() {
-    return densityEstimator.getAttributeId() != relatedPreference.getDensityEstimator().getAttributeId() ;
+    return !densityEstimator.getAttributeId().equals(relatedPreference.getDensityEstimator().getAttributeId());
   }
 
   private void recomputeDensityEstimator() {
@@ -62,7 +63,7 @@ public class Preference<S>  {
   }
 
   private boolean rankingsAreDifferent() {
-    return ranking.getAttributeId() != relatedPreference.getRanking().getAttributeId() ;
+    return !ranking.getAttributeId().equals(relatedPreference.getRanking().getAttributeId());
   }
 
   public Ranking<S> getRanking() {

--- a/jmetal-core/src/main/java/org/uma/jmetal/component/densityestimator/DensityEstimator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/component/densityestimator/DensityEstimator.java
@@ -1,5 +1,6 @@
 package org.uma.jmetal.component.densityestimator;
 
+import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.solution.util.attribute.Attribute;
 
 import java.util.List;
@@ -9,9 +10,8 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface DensityEstimator<S> extends Attribute {
+public interface DensityEstimator<S extends Solution<?>> extends Attribute<S> {
   void computeDensityEstimator(List<S> solutionSet) ;
 
   List<S> sort(List<S> solutionList) ;
 }
-

--- a/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/Ranking.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/Ranking.java
@@ -1,5 +1,6 @@
 package org.uma.jmetal.component.ranking;
 
+import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.solution.util.attribute.Attribute;
 
 import java.util.List;
@@ -9,7 +10,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface Ranking<S> extends Attribute {
+public interface Ranking<S extends Solution<?>> extends Attribute<S> {
   Ranking<S> computeRanking(List<S> solutionList) ;
   List<S> getSubFront(int rank) ;
   int getNumberOfSubFronts() ;


### PR DESCRIPTION
`Ranking`, `DensityEstimator`, `Preference` receive "`extends Solution<?>`".

This removes a few type inference warnings, which were surprising at the first sight.

In `Preference` I have also fixed string comparison using `!=`, which is probably wrong.