### PR TITLE
Revert the type parameter narrowing.

### DIFF
--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/util/preference/Preference.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/util/preference/Preference.java
@@ -2,7 +2,6 @@ package org.uma.jmetal.auto.util.preference;
 
 import org.uma.jmetal.component.densityestimator.DensityEstimator;
 import org.uma.jmetal.component.ranking.Ranking;
-import org.uma.jmetal.solution.Solution;
 
 import java.util.List;
 
@@ -12,7 +11,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public class Preference<S extends Solution<?>>  {
+public class Preference<S>  {
   private Ranking<S> ranking ;
   private DensityEstimator<S> densityEstimator ;
   private Preference<S> relatedPreference ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/component/densityestimator/DensityEstimator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/component/densityestimator/DensityEstimator.java
@@ -1,6 +1,5 @@
 package org.uma.jmetal.component.densityestimator;
 
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.solution.util.attribute.Attribute;
 
 import java.util.List;
@@ -10,7 +9,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface DensityEstimator<S extends Solution<?>> extends Attribute<S> {
+public interface DensityEstimator<S> extends Attribute<S> {
   void computeDensityEstimator(List<S> solutionSet) ;
 
   List<S> sort(List<S> solutionList) ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/Ranking.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/Ranking.java
@@ -1,6 +1,5 @@
 package org.uma.jmetal.component.ranking;
 
-import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.solution.util.attribute.Attribute;
 
 import java.util.List;
@@ -10,7 +9,7 @@ import java.util.List;
  *
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
-public interface Ranking<S extends Solution<?>> extends Attribute<S> {
+public interface Ranking<S> extends Attribute<S> {
   Ranking<S> computeRanking(List<S> solutionList) ;
   List<S> getSubFront(int rank) ;
   int getNumberOfSubFronts() ;

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/util/attribute/Attribute.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/util/attribute/Attribute.java
@@ -1,10 +1,8 @@
 package org.uma.jmetal.solution.util.attribute;
 
-import org.uma.jmetal.solution.Solution;
-
 import java.util.Comparator;
 
-public interface Attribute<S extends Solution<?>> {
+public interface Attribute<S> {
   String getAttributeId() ;
   Comparator<S> getSolutionComparator() ;
 }


### PR DESCRIPTION
The concerns were raised that e.g. `Preference<S extends Solution<?>>` is too strict since we don't want to constrain the user to extend their solutions from `Solution`.

To follow that, but also to keep the type-safe path, we now drop the constraint on the `Attribute`, as this is entirely possible. Now everything typechecks again (e.g. no raw class usage in the related code), but this time it is less restrictive.