### PR TITLE
Speed-up of the MNDS

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/impl/util/MNDSBitsetManager.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/impl/util/MNDSBitsetManager.java
@@ -11,7 +11,6 @@ public class MNDSBitsetManager {
 	private final static int FIRST_WORD_RANGE = 0;
 	private final static int LAST_WORD_RANGE = 1;
 	private final static int N_BIT_ADDR = 6;
-	private final static int WORD_SIZE = 1 << N_BIT_ADDR;
 	private static final long WORD_MASK = 0xffffffffffffffffL;
 	private long[][] bitsets; //N bitsets. Each solution has a bitset
 	private int[][] bsRanges; //N ranges [first sol - last sol]. Each of each bitset of each solution
@@ -70,14 +69,18 @@ public class MNDSBitsetManager {
 		for (; fw <= lw; fw++) {
 			long word = solutionBS[fw] & incrementalBitset[fw];
 			if (word != 0) {
-				int i = Long.numberOfTrailingZeros(word);
-				int offset = fw * WORD_SIZE;
+				int offset = fw << N_BIT_ADDR;
+				int thisWordRanking = wordRanking[fw];
 				do {
-					if (ranking[offset + i] >= rank)
+					int i = Long.numberOfTrailingZeros(word);
+					if (ranking[offset + i] >= rank) {
 						rank = ranking[offset + i] + 1;
-					i++;
-					i += Long.numberOfTrailingZeros(word >> i);
-				} while (i < WORD_SIZE && rank <= wordRanking[fw]);
+						if (rank > thisWordRanking) {
+							break;
+						}
+					}
+					word &= word - 1;
+				} while (word != 0);
 				if (rank > maxRank) {
 					maxRank = rank;
 					break;
@@ -87,8 +90,9 @@ public class MNDSBitsetManager {
 		ranking[solutionId] = rank;
 		ranking0[initSolId] = rank;
 		int i = solutionId >> N_BIT_ADDR;
-		if (rank > wordRanking[i])
+		if (rank > wordRanking[i]) {
 			wordRanking[i] = rank;
+		}
 	}
 
 	public void updateIncrementalBitset(int solutionId) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/impl/util/MNDSBitsetManager.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/impl/util/MNDSBitsetManager.java
@@ -64,13 +64,14 @@ public class MNDSBitsetManager {
 			fw = incBsFstWord;
 		if (fw > lw)
 			return;
-		long word;
-		int i = 0, rank = 0, offset;
+
+		int rank = 0;
+		long[] solutionBS = bitsets[solutionId];
 		for (; fw <= lw; fw++) {
-			word = bitsets[solutionId][fw] & incrementalBitset[fw];
+			long word = solutionBS[fw] & incrementalBitset[fw];
 			if (word != 0) {
-				i = Long.numberOfTrailingZeros(word);
-				offset = fw * WORD_SIZE;
+				int i = Long.numberOfTrailingZeros(word);
+				int offset = fw * WORD_SIZE;
 				do {
 					if (ranking[offset + i] >= rank)
 						rank = ranking[offset + i] + 1;
@@ -85,7 +86,7 @@ public class MNDSBitsetManager {
 		}
 		ranking[solutionId] = rank;
 		ranking0[initSolId] = rank;
-		i = solutionId >> N_BIT_ADDR;
+		int i = solutionId >> N_BIT_ADDR;
 		if (rank > wordRanking[i])
 			wordRanking[i] = rank;
 	}

--- a/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/impl/util/MNDSBitsetManager.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/component/ranking/impl/util/MNDSBitsetManager.java
@@ -20,15 +20,6 @@ public class MNDSBitsetManager {
 	private long[] incrementalBitset;
 	private int incBsFstWord, incBsLstWord;
 
-	public void freeMem() {
-		incrementalBitset = null;
-		bitsets = null;
-		bsRanges = null;
-		wordRanking = null;
-		ranking = null;
-		ranking0 = null;
-	}
-
 	public int[] getRanking() {
 		return ranking0;
 	}
@@ -120,7 +111,7 @@ public class MNDSBitsetManager {
 			return intersection != 0;
 		}
 		//more than one word in common
-		int lw = incBsLstWord < wordIndex ? incBsLstWord : wordIndex;
+		int lw = Math.min(incBsLstWord, wordIndex);
 		bsRanges[solutionId][FIRST_WORD_RANGE] = incBsFstWord;
 		bsRanges[solutionId][LAST_WORD_RANGE] = lw;
 		bitsets[solutionId] = new long[lw + 1];

--- a/jmetal-core/src/test/java/org/uma/jmetal/component/ranking/MergeNDSEvaluation.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/component/ranking/MergeNDSEvaluation.java
@@ -1,0 +1,199 @@
+package org.uma.jmetal.component.ranking;
+
+import org.uma.jmetal.component.ranking.impl.MergeNonDominatedSortRanking;
+import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.solution.util.attribute.util.attributecomparator.AttributeComparator;
+import org.uma.jmetal.solution.util.attribute.util.attributecomparator.impl.IntegerValueAttributeComparator;
+import org.uma.jmetal.util.ConstraintHandling;
+import org.uma.jmetal.util.comparator.impl.OverallConstraintViolationComparator;
+import org.uma.jmetal.util.point.PointSolution;
+
+import ru.ifmo.nds.NonDominatedSorting;
+import ru.ifmo.nds.SetIntersectionSort;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * In this class I try to evaluate two implementations of the Merge Non-Dominated Sorting,
+ * the one by Moreno ({@link org.uma.jmetal.component.ranking.impl.MergeNonDominatedSortRanking})
+ * and the one by Buzdalov ({@link ru.ifmo.nds.SetIntersectionSort}).
+ *
+ * This shall be done using JMH, but as it is too expensive now to allocate a whole new module for it,
+ * this is done the cheap way.
+ *
+ * @author Maxim Buzdalov
+ */
+public class MergeNDSEvaluation {
+    public static void main(String[] args) {
+        int n = Integer.parseInt(args[1]);
+        int d = Integer.parseInt(args[2]);
+        int count = Integer.parseInt(args[3]);
+        List<List<PointSolution>> tests = generateRandomTests(n, d, count);
+
+        switch (args[0]) {
+            case "Moreno":
+                runRanking(tests, new MergeNonDominatedSortRanking<>());
+                break;
+            case "Buzdalov":
+                runRanking(tests, new BuzdalovSetIntersectionSortWrapper<>());
+                break;
+        }
+    }
+
+    private static List<List<PointSolution>> generateRandomTests(int n, int d, int count) {
+        List<List<PointSolution>> rv = new ArrayList<>(count);
+        Random r = new Random(n * 31 + d * 2342 + count);
+        for (int i = 0; i < count; ++i) {
+            List<PointSolution> instance = new ArrayList<>(n);
+            for (int j = 0; j < n; ++j) {
+                PointSolution s = new PointSolution(d);
+                for (int k = 0; k < d; ++k) {
+                    s.setObjective(k, r.nextDouble());
+                }
+                instance.add(s);
+            }
+            rv.add(instance);
+        }
+        return rv;
+    }
+
+    private static void runRanking(List<List<PointSolution>> solutions, Ranking<PointSolution> ranking) {
+        int nMeasurements = 0;
+        long t0 = System.nanoTime();
+        long tenSeconds = 10000000000L;
+        while (nMeasurements < 5 || System.nanoTime() - t0 < tenSeconds) {
+            long start = System.nanoTime();
+            for (List<PointSolution> instance : solutions) {
+                ranking.computeRanking(instance);
+            }
+            long time = System.nanoTime() - start;
+            ++nMeasurements;
+            System.out.println("Iteration " + nMeasurements + ": " + (time / 1e9 / solutions.size()) + " seconds per instance");
+        }
+    }
+
+    private static class BuzdalovSetIntersectionSortWrapper<S extends Solution<?>> implements Ranking<S> {
+        private String attributeId = getClass().getName() ;
+        private Comparator<S> solutionComparator ;
+
+        public BuzdalovSetIntersectionSortWrapper() {
+            this.solutionComparator =
+                    new IntegerValueAttributeComparator<>(attributeId, AttributeComparator.Ordering.ASCENDING);
+        }
+
+        // Interface support: the place to store the fronts.
+        private final List<List<S>> subFronts = new ArrayList<>();
+
+        // Constraint violation checking support.
+        private final OverallConstraintViolationComparator<S> overallConstraintViolationComparator
+                = new OverallConstraintViolationComparator<>();
+
+        // Delegation.
+        private NonDominatedSorting sortingInstance = null;
+
+        @Override
+        public Ranking<S> computeRanking(List<S> solutionList) {
+            subFronts.clear();
+            int nSolutions = solutionList.size();
+            if (nSolutions == 0) {
+                return this;
+            }
+
+            // We have at least one individual
+            S first = solutionList.get(0);
+            int nObjectives = first.getNumberOfObjectives();
+            boolean hasConstraintViolation = getConstraint(first) < 0;
+
+            // Iterate over all individuals to check if all have the same number of objectives,
+            // and to get whether we have meaningful constraints
+            for (int i = 1; i < nSolutions; ++i) {
+                S current = solutionList.get(i);
+                if (nObjectives != current.getNumberOfObjectives()) {
+                    throw new IllegalArgumentException("Solutions have different numbers of objectives");
+                }
+                hasConstraintViolation |= getConstraint(current) < 0;
+            }
+
+            if (!hasConstraintViolation) {
+                // Running directly on the input, no further work is necessary
+                runSorting(solutionList, 0, nSolutions, nObjectives, 0);
+            } else {
+                // Need to apply the constraint comparator first
+                List<S> defensiveCopy = new ArrayList<>(solutionList);
+                defensiveCopy.sort(overallConstraintViolationComparator);
+                int rankOffset = 0;
+                int lastSpanStart = 0;
+                double lastConstraint = getConstraint(defensiveCopy.get(0));
+                for (int i = 1; i < nSolutions; ++i) {
+                    double currConstraint = getConstraint(defensiveCopy.get(i));
+                    if (lastConstraint != currConstraint) {
+                        lastConstraint = currConstraint;
+                        rankOffset = 1 + runSorting(defensiveCopy, lastSpanStart, i, nObjectives, rankOffset);
+                        lastSpanStart = i;
+                    }
+                }
+                runSorting(defensiveCopy, lastSpanStart, nSolutions, nObjectives, rankOffset);
+            }
+
+            return this;
+        }
+
+        private int runSorting(List<S> solutions, int from, int until, int dimension, int rankOffset) {
+            ensureEnoughSpace(until - from, dimension);
+            double[][] points = new double[until - from][];
+            int[] ranks = new int[until - from];
+            for (int i = from; i < until; ++i) {
+                points[i - from] = solutions.get(i).getObjectives();
+            }
+            sortingInstance.sort(points, ranks, until - from);
+            int maxRank = 0;
+            for (int i = from; i < until; ++i) {
+                S current = solutions.get(i);
+                int rank = ranks[i - from] + rankOffset;
+                maxRank = Math.max(maxRank, rank);
+                current.setAttribute(attributeId, rank);
+                while (subFronts.size() <= rank) {
+                    subFronts.add(new ArrayList<>());
+                }
+                subFronts.get(rank).add(current);
+            }
+            return maxRank;
+        }
+
+        private void ensureEnoughSpace(int nPoints, int dimension) {
+            if (sortingInstance == null
+                    || sortingInstance.getMaximumPoints() < nPoints
+                    || sortingInstance.getMaximumDimension() < dimension) {
+
+                sortingInstance = SetIntersectionSort.getBitSetInstance().getInstance(nPoints, dimension);
+            }
+        }
+
+        private double getConstraint(S solution) {
+            return ConstraintHandling.overallConstraintViolationDegree(solution);
+        }
+
+        @Override
+        public List<S> getSubFront(int rank) {
+            return subFronts.get(rank);
+        }
+
+        @Override
+        public int getNumberOfSubFronts() {
+            return subFronts.size();
+        }
+
+        @Override
+        public Comparator<S> getSolutionComparator() {
+            return solutionComparator;
+        }
+
+        @Override
+        public String getAttributeId() {
+            return attributeId ;
+        }
+    }
+}


### PR DESCRIPTION
In this branch, I speed up this repository's implementation of Merge Non-Dominated Sorting by some constant factor by writing the tightest loop better.

I have also added a simple benchmarking code which compares the performance of the mentioned implementation with its [equivalent in mbuzdalov/non-dominated-sorting](https://github.com/mbuzdalov/non-dominated-sorting/blob/master/implementations/src/main/java/ru/ifmo/nds/mnds/BitSetImplementation.java). The comparison results (on a certain fixed laptop) are as follows:

|  n  |  d  |  Moreno old  |  Moreno new  |  Buzdalov  |
|-----:|-----:|----------------|---------------|---------------|
| 10000 |  5  |    0.021     |    **0.019**     |    0.023   |
| 30000 |  5  |    0.148     |    **0.131**     |    0.186   |
| 100000 |  5  |    1.46      |    **1.20**     |    2.3     |
| 10000 | 10  |    0.023     |    0.023     |    **0.016**   |
| 30000 | 10  |    0.130     |    0.130     |    **0.114**  |
| 100000 | 10  |    1.02      |    1.01      |    **0.88**    |

Here, "Moreno old" is the state in master, "Moreno new" is the state of this PR, "Buzdalov" is the `BitSetImplementation` from my repo. The fastest result in each row is bold.

We can see that "Moreno new" strictly dominates "Moreno old". The comparison with "Buzdalov" is more involved: for dimension 5, the latter is worse, while for dimension 10, the latter is better. The exact reason is not yet known to me, but, most probably, this is due to `wordRanking`: for smaller dimensions it helps, for larger ones it is a useless overhead.

P.S.1: Here, "Buzdalov" is not the same as `ExperimentalFastNonDominanceRanking`. This is me having implemented a (so far simplified) MNDS on my own using stock bitsets.