### PR TITLE
fix for wrong initialization of progress variables in multiple algorithms

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/paes/PAES.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/paes/PAES.java
@@ -62,7 +62,7 @@ public class PAES<S extends Solution<?>> extends AbstractEvolutionStrategy<S, Li
   }
 
   @Override protected void initProgress() {
-    evaluations = 0;
+    evaluations = 1;
   }
 
   @Override protected void updateProgress() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/coralreefsoptimization/CoralReefsOptimization.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/coralreefsoptimization/CoralReefsOptimization.java
@@ -21,22 +21,22 @@ public class CoralReefsOptimization<S>
 		extends AbstractCoralReefsOptimization<S, List<S>> {
 
 	private Problem<S> problem;
-	private int maxEvaluations;
-	private int evaluations;
+	private int maxIterations;
+	private int iterations;
 	private MersenneTwisterGenerator random;
 
 	public CoralReefsOptimization(Problem<S> problem,
-																int maxEvaluations, Comparator<S> comparator,
-																SelectionOperator<List<S>, S> selectionOperator,
-																CrossoverOperator<S> crossoverOperator,
-																MutationOperator<S> mutationOperator, int n, int m, double rho,
-																double fbs, double fa, double pd, int attemptsToSettle) {
+                                  int maxIterations, Comparator<S> comparator,
+                                  SelectionOperator<List<S>, S> selectionOperator,
+                                  CrossoverOperator<S> crossoverOperator,
+                                  MutationOperator<S> mutationOperator, int n, int m, double rho,
+                                  double fbs, double fa, double pd, int attemptsToSettle) {
 
 		super(comparator, selectionOperator, crossoverOperator,
 				mutationOperator, n, m, rho, fbs, fa, pd, attemptsToSettle);
 
 		this.problem = problem;
-		this.maxEvaluations = maxEvaluations;
+		this.maxIterations = maxIterations;
 		this.random = new MersenneTwisterGenerator();
 
 	}
@@ -45,17 +45,17 @@ public class CoralReefsOptimization<S>
 
 	@Override
 	protected void initProgress() {
-		evaluations = 0;
+		iterations = 0;
 	}
 
 	@Override
 	protected void updateProgress() {
-		evaluations++;
+		iterations++;
 	}
 
 	@Override
 	protected boolean isStoppingConditionReached() {
-		return evaluations == maxEvaluations;
+		return iterations == maxIterations;
 	}
 
 	@Override

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
@@ -162,7 +162,7 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
   }
 
   @Override protected void initProgress() {
-    evaluations = 0;
+    evaluations = lambda;
   }
 
   @Override protected void updateProgress() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/NonElitistEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/NonElitistEvolutionStrategy.java
@@ -41,7 +41,7 @@ public class NonElitistEvolutionStrategy<S extends Solution<?>> extends Abstract
   }
 
   @Override protected void initProgress() {
-    evaluations = 1;
+    evaluations = mu;
   }
 
   @Override protected void updateProgress() {

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/SteadyStateGeneticAlgorithm.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/geneticalgorithm/SteadyStateGeneticAlgorithm.java
@@ -92,7 +92,7 @@ public class SteadyStateGeneticAlgorithm<S extends Solution<?>> extends Abstract
   }
 
   @Override public void initProgress() {
-    evaluations = 1;
+    evaluations = getMaxPopulationSize();
   }
 
   @Override public void updateProgress() {


### PR DESCRIPTION
For multiple algorithms the initilization of the evaluations variable is slightly wrong.

In detail:
CMAES: evaluations value initialized with 0, not the population size (lambda)
NonElitistES: evaluations value initialized with 0, not the population size (mu)
ssGA: evaluations value initialized with 1, not the population size
PAES: evaluations value initialized with 0, not the population size

CRO: progress variable named evaluations, but counting iterations