### PR TITLE
Fix for wrong initialization of weights in CMAES

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
@@ -240,7 +240,7 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
     weights = new double[mu];
     double sum = 0;
     for (int i = 0; i < mu; i++) {
-      weights[i] = (Math.log(mu + 1 / 2) - Math.log(i + 1));
+      weights[i] = (Math.log(mu + 0.5) - Math.log(i + 1));
       sum += weights[i];
     }
     // normalize recombination weights array


### PR DESCRIPTION
In the initialization of the weights an integer division is used which results in an addition of 0 and not 1/2.