### PR TITLE
Fix for PSO algorithms not updating their leading particle with a copy of the solution

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2007.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2007.java
@@ -221,13 +221,13 @@ public class StandardPSO2007 extends AbstractParticleSwarmOptimization<DoubleSol
     DoubleSolution bestSolution = findBestSolution.execute(swarm);
 
     if (bestFoundParticle == null) {
-      bestFoundParticle = bestSolution;
+      bestFoundParticle = (DoubleSolution) bestSolution.copy();
     } else {
       if (bestSolution.getObjective(objectiveId) == bestFoundParticle.getObjective(0)) {
         neighborhood.recompute();
       }
       if (bestSolution.getObjective(objectiveId) < bestFoundParticle.getObjective(0)) {
-        bestFoundParticle = bestSolution;
+        bestFoundParticle = (DoubleSolution) bestSolution.copy();
       }
     }
   }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2011.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2011.java
@@ -267,13 +267,13 @@ public class StandardPSO2011 extends AbstractParticleSwarmOptimization<DoubleSol
     DoubleSolution bestSolution = findBestSolution.execute(swarm);
 
     if (bestFoundParticle == null) {
-      bestFoundParticle = bestSolution;
+      bestFoundParticle = (DoubleSolution) bestSolution.copy();
     } else {
       if (bestSolution.getObjective(objectiveId) == bestFoundParticle.getObjective(0)) {
         neighborhood.recompute();
       }
       if (bestSolution.getObjective(objectiveId) < bestFoundParticle.getObjective(0)) {
-        bestFoundParticle = bestSolution;
+        bestFoundParticle = (DoubleSolution) bestSolution.copy();
       }
     }
   }


### PR DESCRIPTION
Both StandardPSO algorithms do not use the copy function when updating their best found particle, leading to wrong results as the base particle will change in further iterations.