### PR TITLE
Fix JDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <doclint>none</doclint>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
         <junit.version>4.13</junit.version>
     </properties>
 
@@ -92,7 +90,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <release>10</release>  <!--or <release>10</release>-->
+                    <release>11</release>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
- The release is on an unstable version (10) while the source and target are on a LTS version (11), so we align them.
- The source and target are already covered by the release element ([source](https://www.baeldung.com/maven-java-version)), which makes them useless so we remove them.



It also helps to fix the issues observed in #395.