### PR TITLE
delete static modifier in MaF datasets that will cause error in paral…

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIII.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIII.java
@@ -28,7 +28,7 @@ public class NSGAIII<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, 
 
   protected SolutionListEvaluator<S> evaluator ;
 
-  protected Vector<Integer> numberOfDivisions  ;
+  protected int numberOfDivisions  ;
   protected List<ReferencePoint<S>> referencePoints = new Vector<>() ;
 
   /** Constructor */
@@ -43,8 +43,7 @@ public class NSGAIII<S extends Solution<?>> extends AbstractGeneticAlgorithm<S, 
     evaluator = builder.getEvaluator() ;
 
     /// NSGAIII
-    numberOfDivisions = new Vector<>(1) ;
-    numberOfDivisions.add(12) ; // Default value for 3D problems
+    numberOfDivisions = builder.getNumberOfDivisions() ;
 
     (new ReferencePoint<S>()).generateReferencePoints(referencePoints,getProblem().getNumberOfObjectives() , numberOfDivisions);
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIIIBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/NSGAIIIBuilder.java
@@ -18,6 +18,7 @@ public class NSGAIIIBuilder<S extends Solution<?>> implements AlgorithmBuilder<N
   private Problem<S> problem ;
   private int maxIterations ;
   private int populationSize ;
+  private int numberOfDivisions;
   private CrossoverOperator<S> crossoverOperator ;
   private MutationOperator<S> mutationOperator ;
   private SelectionOperator<List<S>, S> selectionOperator ;
@@ -29,6 +30,7 @@ public class NSGAIIIBuilder<S extends Solution<?>> implements AlgorithmBuilder<N
     this.problem = problem ;
     maxIterations = 250 ;
     populationSize = 100 ;
+    numberOfDivisions = 4;
     evaluator = new SequentialSolutionListEvaluator<S>() ;
   }
 
@@ -40,6 +42,12 @@ public class NSGAIIIBuilder<S extends Solution<?>> implements AlgorithmBuilder<N
 
   public NSGAIIIBuilder<S> setPopulationSize(int populationSize) {
     this.populationSize = populationSize ;
+
+    return this ;
+  }
+
+  public NSGAIIIBuilder<S> setNumberOfDivisions(int numberOfDivisions){
+    this.numberOfDivisions = numberOfDivisions ;
 
     return this ;
   }
@@ -83,6 +91,8 @@ public class NSGAIIIBuilder<S extends Solution<?>> implements AlgorithmBuilder<N
   public int getPopulationSize() {
     return populationSize;
   }
+
+  public int getNumberOfDivisions() { return numberOfDivisions; }
 
   public CrossoverOperator<S> getCrossoverOperator() {
     return crossoverOperator;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/util/ReferencePoint.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/nsgaiii/util/ReferencePoint.java
@@ -44,10 +44,10 @@ public class ReferencePoint<S extends Solution<?>> {
   public void generateReferencePoints(
           List<ReferencePoint<S>> referencePoints,
           int numberOfObjectives,
-          List<Integer> numberOfDivisions) {
+          int numberOfDivisions) {
 
     ReferencePoint<S> refPoint = new ReferencePoint<>(numberOfObjectives) ;
-    generateRecursive(referencePoints, refPoint, numberOfObjectives, numberOfDivisions.get(0), numberOfDivisions.get(0), 0);
+    generateRecursive(referencePoints, refPoint, numberOfObjectives, numberOfDivisions, numberOfDivisions, 0);
   }
 
   private void generateRecursive(

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF02.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF02.java
@@ -12,7 +12,7 @@ import java.util.List;
 @SuppressWarnings("serial")
 public class MaF02 extends AbstractDoubleProblem {
 
-  public static int const2;
+  public int const2;
 
   /**
    * Default constructor

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF04.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF04.java
@@ -11,7 +11,7 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public class MaF04 extends AbstractDoubleProblem {
-  public static double const4[];
+  public double const4[];
 
   /**
    * Default constructor

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF05.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF05.java
@@ -12,7 +12,7 @@ import java.util.List;
 @SuppressWarnings("serial")
 public class MaF05 extends AbstractDoubleProblem {
 
-  public static double const5[];
+  public double const5[];
 
   /**
    * Default constructor

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF08.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF08.java
@@ -13,7 +13,7 @@ import java.util.List;
 @SuppressWarnings("serial")
 public class MaF08 extends AbstractDoubleProblem {
 
-  public static double const8[][];
+  public double const8[][];
 
   /**
    * Default constructor

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF09.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF09.java
@@ -14,10 +14,10 @@ import java.util.List;
 @SuppressWarnings("serial")
 public class MaF09 extends AbstractDoubleProblem {
 
-  public static int maxinter9;
-  public static int pindex9[];
-  public static int M9;
-  public static double points9[][], rangex9[][], rangey9[][], r_polyline9[][], oth_poly_points9[][];
+  public int maxinter9;
+  public int pindex9[];
+  public int M9;
+  public double points9[][], rangex9[][], rangey9[][], r_polyline9[][], oth_poly_points9[][];
 
   /**
    * Default constructor
@@ -248,7 +248,7 @@ public class MaF09 extends AbstractDoubleProblem {
   }
   //check if a point is inside any generated polygons(not including the boundary)(only for MaF9)
 
-  public static boolean if_infeasible(double[] x) {
+  public boolean if_infeasible(double[] x) {
     boolean infeasible = false;
     for (int i = 0; i < pindex9.length - 1; i++) {
       double[][] p = new double[pindex9[i + 1] - pindex9[i]][2];

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF10.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF10.java
@@ -11,7 +11,7 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public class MaF10 extends AbstractDoubleProblem {
-  public static int K10;
+  public int K10;
 
   /**
    * Default constructor

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF11.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF11.java
@@ -12,7 +12,7 @@ import java.util.List;
 @SuppressWarnings("serial")
 public class MaF11 extends AbstractDoubleProblem {
 
-  public static int K11, L11;
+  public int K11, L11;
 
   /**
    * Default constructor

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF12.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF12.java
@@ -12,7 +12,7 @@ import java.util.List;
 @SuppressWarnings("serial")
 public class MaF12 extends AbstractDoubleProblem {
 
-  public static int K12, L12;
+  public int K12, L12;
 
   /**
    * Default constructor

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF14.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF14.java
@@ -11,8 +11,8 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public class MaF14 extends AbstractDoubleProblem {
-  public static int nk14;
-  public static int sublen14[], len14[];
+  public int nk14;
+  public int sublen14[], len14[];
 
   /**
    * Default constructor

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF15.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF15.java
@@ -11,8 +11,8 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public class MaF15 extends AbstractDoubleProblem {
-  public static int nk15;
-  public static int sublen15[], len15[];
+  public int nk15;
+  public int sublen15[], len15[];
 
   /**
    * Default constructor


### PR DESCRIPTION
delete static modifier in MaF datasets that will cause error in parallel execute.
change numberOfDivisions field in NSGAIII and ReferencePoint, add corresponding field in NSGAIIIBuilder, to correct the fixed value in previous code that will cause OutOfMemoryError and a very long execute time