### PR TITLE
[Refactor] Replace constructors by factories

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSBuilder.java
@@ -45,7 +45,7 @@ public class ABYSSBuilder implements AlgorithmBuilder<ABYSS> {
     double distributionIndex = 20.0;
     this.crossoverOperator = new SBXCrossover(crossoverProbability, distributionIndex);
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
-    this.mutationOperator = new PolynomialMutation(mutationProbability, distributionIndex);
+    this.mutationOperator = PolynomialMutation.createWithDoubleDefaults(mutationProbability, distributionIndex);
     int improvementRounds = 1;
     this.archive = (CrowdingDistanceArchive<DoubleSolution>) archive;
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/cdg/CDGBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/cdg/CDGBuilder.java
@@ -61,7 +61,7 @@ public class CDGBuilder implements AlgorithmBuilder<AbstractCDG<DoubleSolution>>
     populationSize = 300;
     resultPopulationSize = 300;
     maxEvaluations = 300000;
-    crossover = new DifferentialEvolutionCrossover();
+    crossover = DifferentialEvolutionCrossover.createDefault();
     neighborhoodSelectionProbability = 0.9;
     numberOfThreads = 1;
     sigma_ = 10e-6;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/fame/FAME.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/fame/FAME.java
@@ -185,7 +185,7 @@ public class FAME<S extends DoubleSolution> extends SteadyStateNSGAII<S> {
     double probabilityPolynomial, DristributionIndex;
     probabilityPolynomial = 0.30;
     DristributionIndex = 20;
-    PolynomialMutation mutationPolynomial = new PolynomialMutation(probabilityPolynomial, DristributionIndex);
+    PolynomialMutation mutationPolynomial = PolynomialMutation.createWithDoubleDefaults(probabilityPolynomial, DristributionIndex);
 
     double probabilityUniform, perturbation;
     probabilityUniform = 0.30;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/fame/FAME.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/fame/FAME.java
@@ -196,7 +196,7 @@ public class FAME<S extends DoubleSolution> extends SteadyStateNSGAII<S> {
     CR = 1.0;
     F = 0.5;
     DifferentialEvolutionCrossover crossoverOperator_DE =
-        new DifferentialEvolutionCrossover(CR, F, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
+        DifferentialEvolutionCrossover.createFromVariant(CR, F, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double crossoverProbability, crossoverDistributionIndex;
     crossoverProbability = 1.0;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3Builder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/gde3/GDE3Builder.java
@@ -31,7 +31,7 @@ public class GDE3Builder implements AlgorithmBuilder<GDE3> {
     maxEvaluations = 25000 ;
     populationSize = 100 ;
     selectionOperator = new DifferentialEvolutionSelection();
-    crossoverOperator = new DifferentialEvolutionCrossover() ;
+    crossoverOperator = DifferentialEvolutionCrossover.createDefault() ;
     evaluator = new SequentialSolutionListEvaluator<DoubleSolution>() ;
   }
 

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/ibea/IBEABuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/ibea/IBEABuilder.java
@@ -41,7 +41,7 @@ public class IBEABuilder implements AlgorithmBuilder<IBEA<DoubleSolution>> {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection = new BinaryTournamentSelection<DoubleSolution>();
   }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDE.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDE.java
@@ -158,7 +158,7 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
 
     int offspringPopulationSize = 1;
     this.variation =
-        new DifferentialCrossoverVariation(
+        DifferentialCrossoverVariation.createWithDefaultMatingPoolSize(
             offspringPopulationSize, crossover, mutation, subProblemIdGenerator);
 
     WeightVectorNeighborhood<DoubleSolution> neighborhood = null ;
@@ -245,7 +245,7 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
 
     int offspringPopulationSize = 1;
     Variation<DoubleSolution> variation =
-        new DifferentialCrossoverVariation(
+        DifferentialCrossoverVariation.createWithDefaultMatingPoolSize(
             offspringPopulationSize, crossover, mutation, subProblemIdGenerator);
 
     WeightVectorNeighborhood<DoubleSolution> neighborhood = null ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDE.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDE.java
@@ -154,7 +154,7 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
     PolynomialMutation mutation =
-        new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+        PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int offspringPopulationSize = 1;
     this.variation =
@@ -241,7 +241,7 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
     PolynomialMutation mutation =
-        new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+        PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int offspringPopulationSize = 1;
     Variation<DoubleSolution> variation =

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDE.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDE.java
@@ -5,22 +5,28 @@ import org.uma.jmetal.component.evaluation.Evaluation;
 import org.uma.jmetal.component.evaluation.impl.SequentialEvaluation;
 import org.uma.jmetal.component.initialsolutioncreation.InitialSolutionsCreation;
 import org.uma.jmetal.component.initialsolutioncreation.impl.RandomSolutionsCreation;
+import org.uma.jmetal.component.replacement.Replacement ;
 import org.uma.jmetal.component.replacement.impl.MOEADReplacement;
+import org.uma.jmetal.component.selection.MatingPoolSelection ;
 import org.uma.jmetal.component.selection.impl.PopulationAndNeighborhoodMatingPoolSelection;
 import org.uma.jmetal.component.termination.Termination;
+import org.uma.jmetal.component.variation.Variation ;
 import org.uma.jmetal.component.variation.impl.DifferentialCrossoverVariation;
 import org.uma.jmetal.operator.crossover.impl.DifferentialEvolutionCrossover;
 import org.uma.jmetal.operator.mutation.impl.PolynomialMutation;
 import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.aggregativefunction.AggregativeFunction;
+import org.uma.jmetal.util.archive.Archive ;
 import org.uma.jmetal.util.neighborhood.impl.WeightVectorNeighborhood;
+import org.uma.jmetal.util.observable.Observable ;
 import org.uma.jmetal.util.observable.impl.DefaultObservable;
 import org.uma.jmetal.util.sequencegenerator.SequenceGenerator;
 import org.uma.jmetal.util.sequencegenerator.impl.IntegerPermutationGenerator;
 
 import java.io.FileNotFoundException;
 import java.util.HashMap;
+import java.util.Map ;
 
 /**
  * This class is intended to provide an implementation of the MOEA/D-DE algorithm.
@@ -31,6 +37,39 @@ import java.util.HashMap;
 public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution> {
 
   /** Constructor */
+  public MOEADDE(
+      String name,
+      Problem<DoubleSolution> problem,
+      Observable<Map<String, Object>> observable,
+      Map<String, Object> attributes,
+      InitialSolutionsCreation<DoubleSolution> createInitialPopulation,
+      Variation<DoubleSolution> variation,
+      MatingPoolSelection<DoubleSolution> selection,
+      Replacement<DoubleSolution> replacement,
+      Termination termination,
+      Evaluation<DoubleSolution> evaluation,
+      Archive<DoubleSolution> archive) {
+    
+    this.name = name;
+    this.problem = problem;
+    this.observable = observable;
+    this.attributes = attributes;
+    this.createInitialPopulation = createInitialPopulation;
+    this.variation = variation;
+    this.selection = selection;
+    this.replacement = replacement;
+    this.termination = termination;
+    this.evaluation = evaluation;
+    this.archive = archive;
+  }
+  
+  /**
+   * Constructor
+   * 
+   * @deprecated Use instead
+   *             {@link #create(Evaluation, InitialSolutionsCreation, Termination, PopulationAndNeighborhoodMatingPoolSelection, DifferentialCrossoverVariation, MOEADReplacement)}
+   */
+  @Deprecated
   public MOEADDE(
         Evaluation<DoubleSolution> evaluation,
         InitialSolutionsCreation<DoubleSolution> initialPopulationCreation,
@@ -49,6 +88,30 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
         }
 
 
+  /** Creates a {@link MOEADDE}. */
+  public static MOEADDE create(
+      Evaluation<DoubleSolution> evaluation,
+      InitialSolutionsCreation<DoubleSolution> initialPopulationCreation,
+      Termination termination,
+      PopulationAndNeighborhoodMatingPoolSelection<DoubleSolution> selection,
+      DifferentialCrossoverVariation variation,
+      MOEADReplacement<DoubleSolution> replacement) {
+    
+    String name = "MOEAD-DE" ;
+    return new MOEADDE(
+        name,
+        null,
+        new DefaultObservable<>(name),
+        new HashMap<>(),
+        initialPopulationCreation,
+        variation,
+        selection,
+        replacement,
+        termination,
+        evaluation,
+        null);
+    }
+  
   /**
    * Constructor with the parameters used in the paper describing MOEA/D-DE.
    *
@@ -60,6 +123,8 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
    * @param maximumNumberOfReplacedSolutions
    * @param neighborhoodSize
    * @param termination
+   * @deprecated Use instead
+   *             {@link #create(Problem, int, double, double, AggregativeFunction, double, int, int, String, Termination)}.
    */
   public MOEADDE(
       Problem<DoubleSolution> problem,
@@ -135,5 +200,104 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
     this.evaluation = new SequentialEvaluation<>(problem) ;
 
     this.archive = null ;
+  }
+  
+  /**
+   * Creates a {@link MOEADDE}.
+   *
+   * @param problem
+   * @param populationSize
+   * @param f
+   * @param cr
+   * @param neighborhoodSelectionProbability
+   * @param maximumNumberOfReplacedSolutions
+   * @param neighborhoodSize
+   * @param termination
+   */
+  public static MOEADDE create(
+      Problem<DoubleSolution> problem,
+      int populationSize,
+      double cr,
+      double f,
+      AggregativeFunction aggregativeFunction,
+      double neighborhoodSelectionProbability,
+      int maximumNumberOfReplacedSolutions,
+      int neighborhoodSize,
+      String weightVectorDirectory,
+      Termination termination) {
+    String name = "MOEAD-DE" ;
+    Observable<Map<String, Object>> observable = new DefaultObservable<>(name);
+    Map<String, Object> attributes = new HashMap<>();
+
+    SequenceGenerator<Integer> subProblemIdGenerator =
+        new IntegerPermutationGenerator(populationSize);
+
+    InitialSolutionsCreation<DoubleSolution> createInitialPopulation = new RandomSolutionsCreation<>(problem, populationSize);
+
+    DifferentialEvolutionCrossover crossover =
+        new DifferentialEvolutionCrossover(
+            cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
+
+    double mutationProbability = 1.0 / problem.getNumberOfVariables();
+    double mutationDistributionIndex = 20.0;
+    PolynomialMutation mutation =
+        new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+
+    int offspringPopulationSize = 1;
+    Variation<DoubleSolution> variation =
+        new DifferentialCrossoverVariation(
+            offspringPopulationSize, crossover, mutation, subProblemIdGenerator);
+
+    WeightVectorNeighborhood<DoubleSolution> neighborhood = null ;
+    if (problem.getNumberOfObjectives() == 2) {
+      neighborhood = new WeightVectorNeighborhood<>(populationSize, neighborhoodSize);
+    } else {
+      try {
+        neighborhood =
+            new WeightVectorNeighborhood<>(
+                populationSize,
+                problem.getNumberOfObjectives(),
+                neighborhoodSize,
+                 weightVectorDirectory);
+      } catch (FileNotFoundException exception) {
+        exception.printStackTrace();
+      }
+    }
+
+    MatingPoolSelection<DoubleSolution> selection =
+        new PopulationAndNeighborhoodMatingPoolSelection<>(
+            ((DifferentialCrossoverVariation) variation)
+                .getCrossover()
+                .getNumberOfRequiredParents(),
+            subProblemIdGenerator,
+            neighborhood,
+            neighborhoodSelectionProbability,
+            true);
+
+    Replacement<DoubleSolution> replacement =
+        new MOEADReplacement<DoubleSolution>(
+            (PopulationAndNeighborhoodMatingPoolSelection<DoubleSolution>) selection,
+            neighborhood,
+            aggregativeFunction,
+            subProblemIdGenerator,
+            maximumNumberOfReplacedSolutions);
+
+    Evaluation<DoubleSolution> evaluation = new SequentialEvaluation<>(problem) ;
+
+    Archive<DoubleSolution> archive = null ;
+    
+    return new MOEADDE(
+        name,
+        problem,
+        observable,
+        attributes,
+        createInitialPopulation,
+        variation,
+        selection,
+        replacement,
+        termination,
+        evaluation,
+        archive
+        );
   }
 }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDE.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDE.java
@@ -148,7 +148,7 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
     this.createInitialPopulation = new RandomSolutionsCreation<>(problem, populationSize);
 
     DifferentialEvolutionCrossover crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
@@ -235,7 +235,7 @@ public class MOEADDE extends ComponentBasedEvolutionaryAlgorithm<DoubleSolution>
     InitialSolutionsCreation<DoubleSolution> createInitialPopulation = new RandomSolutionsCreation<>(problem, populationSize);
 
     DifferentialEvolutionCrossover crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADBuilder.java
@@ -47,7 +47,7 @@ public class MOEADBuilder implements AlgorithmBuilder<AbstractMOEAD<DoubleSoluti
     populationSize = 300 ;
     resultPopulationSize = 300 ;
     maxEvaluations = 150000 ;
-    crossover = new DifferentialEvolutionCrossover() ;
+    crossover = DifferentialEvolutionCrossover.createDefault() ;
     mutation = new PolynomialMutation(1.0/problem.getNumberOfVariables(), 20.0);
     functionType = MOEAD.FunctionType.TCHE ;
     neighborhoodSelectionProbability = 0.1 ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADBuilder.java
@@ -48,7 +48,7 @@ public class MOEADBuilder implements AlgorithmBuilder<AbstractMOEAD<DoubleSoluti
     resultPopulationSize = 300 ;
     maxEvaluations = 150000 ;
     crossover = DifferentialEvolutionCrossover.createDefault() ;
-    mutation = new PolynomialMutation(1.0/problem.getNumberOfVariables(), 20.0);
+    mutation = PolynomialMutation.createWithDoubleDefaults(1.0/problem.getNumberOfVariables(), 20.0);
     functionType = MOEAD.FunctionType.TCHE ;
     neighborhoodSelectionProbability = 0.1 ;
     maximumNumberOfReplacedSolutions = 2 ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/jmetal5version/SMPSOBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/jmetal5version/SMPSOBuilder.java
@@ -65,7 +65,7 @@ public class SMPSOBuilder implements AlgorithmBuilder<SMPSO> {
     changeVelocity1 = -1;
     changeVelocity2 = -1;
 
-    mutationOperator = new PolynomialMutation(1.0/problem.getNumberOfVariables(), 20.0) ;
+    mutationOperator = PolynomialMutation.createWithDoubleDefaults(1.0/problem.getNumberOfVariables(), 20.0) ;
     evaluator = new SequentialSolutionListEvaluator<DoubleSolution>() ;
 
     this.variant = SMPSOVariant.SMPSO ;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionBuilder.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionBuilder.java
@@ -24,7 +24,7 @@ public class DifferentialEvolutionBuilder {
     this.problem = problem;
     this.populationSize = 100;
     this.maxEvaluations = 25000;
-    this.crossoverOperator = new DifferentialEvolutionCrossover(0.5, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
+    this.crossoverOperator = DifferentialEvolutionCrossover.createFromVariant(0.5, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
     this.selectionOperator = new DifferentialEvolutionSelection();
     this.evaluator = new SequentialSolutionListEvaluator<DoubleSolution>();
   }

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSConstrainedProblemIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSConstrainedProblemIT.java
@@ -45,7 +45,7 @@ public class ABYSSConstrainedProblemIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     archive = new CrowdingDistanceArchive<>(100);
 

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSIT.java
@@ -41,7 +41,7 @@ public class ABYSSIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     archive = new CrowdingDistanceArchive<>(100);
 

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSTest.java
@@ -34,7 +34,7 @@ public class ABYSSTest {
   public void setup() {
     problem = new MockProblem();
     archive = new CrowdingDistanceArchive<>(10);
-    mutation = new PolynomialMutation(1.0, 20.0);
+    mutation = PolynomialMutation.createWithDoubleDefaults(1.0, 20.0);
     localSearch = new BasicLocalSearch<>(2, mutation, new DominanceComparator<>(), problem);
   }
 

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/artificialdecisionmaker/ArtificiallDecisionMakerIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/artificialdecisionmaker/ArtificiallDecisionMakerIT.java
@@ -51,7 +51,7 @@ public class ArtificiallDecisionMakerIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
         new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/ensemble/AlgorithmEnsembleIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/ensemble/AlgorithmEnsembleIT.java
@@ -67,7 +67,7 @@ public class AlgorithmEnsembleIT {
             populationSize,
             offspringPopulationSize,
             new SBXCrossover(crossoverProbability, crossoverDistributionIndex),
-            new PolynomialMutation(mutationProbability, mutationDistributionIndex),
+            PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex),
             termination);
 
     List<Algorithm<List<DoubleSolution>>> algorithmList = new ArrayList<>();
@@ -99,7 +99,7 @@ public class AlgorithmEnsembleIT {
             populationSize,
             offspringPopulationSize,
             new SBXCrossover(crossoverProbability, crossoverDistributionIndex),
-            new PolynomialMutation(mutationProbability, mutationDistributionIndex),
+            PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex),
             termination);
 
     List<Algorithm<List<DoubleSolution>>> algorithmList = new ArrayList<>();
@@ -136,7 +136,7 @@ public class AlgorithmEnsembleIT {
             populationSize,
             offspringPopulationSize,
             new SBXCrossover(crossoverProbability, crossoverDistributionIndex),
-            new PolynomialMutation(mutationProbability, mutationDistributionIndex),
+            PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex),
             termination);
 
     int swarmSize = 100;
@@ -150,7 +150,7 @@ public class AlgorithmEnsembleIT {
             (DoubleProblem) problem,
             swarmSize,
             leadersArchive,
-            new PolynomialMutation(mutationProbability, mutationDistributionIndex),
+            PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex),
             evaluation,
             termination);
 

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCellIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/mocell/MOCellIT.java
@@ -34,7 +34,7 @@ public class MOCellIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
   }
 
   @Test

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDEIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/MOEADDEIT.java
@@ -38,7 +38,7 @@ public class MOEADDEIT {
     AggregativeFunction aggregativeFunction = new Tschebyscheff();
 
     algorithm =
-        new MOEADDE(
+        MOEADDE.create(
             problem,
             populationSize,
             cr,
@@ -75,7 +75,7 @@ public class MOEADDEIT {
     AggregativeFunction aggregativeFunction = new Tschebyscheff();
 
     algorithm =
-        new MOEADDE(
+        MOEADDE.create(
             problem,
             populationSize,
             cr,
@@ -118,7 +118,7 @@ public class MOEADDEIT {
     AggregativeFunction aggregativeFunction = new Tschebyscheff();
 
     algorithm =
-        new MOEADDE(
+        MOEADDE.create(
             problem,
             populationSize,
             cr,

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/ConstraintMOEADIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/ConstraintMOEADIT.java
@@ -32,7 +32,7 @@ public class ConstraintMOEADIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(mutationProbability,
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability,
         mutationDistributionIndex);
 
     algorithm = new MOEADBuilder(problem, Variant.ConstraintMOEAD)
@@ -66,7 +66,7 @@ public class ConstraintMOEADIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(mutationProbability,
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability,
         mutationDistributionIndex);
 
     algorithm = new MOEADBuilder(problem, Variant.ConstraintMOEAD)

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/ConstraintMOEADIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/ConstraintMOEADIT.java
@@ -27,7 +27,7 @@ public class ConstraintMOEADIT {
 
     double cr = 1.0;
     double f = 0.5;
-    CrossoverOperator<DoubleSolution> crossover = new DifferentialEvolutionCrossover(cr, f,
+    CrossoverOperator<DoubleSolution> crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f,
             DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
@@ -61,7 +61,7 @@ public class ConstraintMOEADIT {
 
     double cr = 1.0;
     double f = 0.5;
-    CrossoverOperator<DoubleSolution> crossover = new DifferentialEvolutionCrossover(cr, f,
+    CrossoverOperator<DoubleSolution> crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f,
             DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADDRAIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADDRAIT.java
@@ -31,7 +31,7 @@ public class MOEADDRAIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(mutationProbability,
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability,
         mutationDistributionIndex);
 
     algorithm = new MOEADBuilder(problem, MOEADBuilder.Variant.MOEADDRA)
@@ -65,7 +65,7 @@ public class MOEADDRAIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(mutationProbability,
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability,
         mutationDistributionIndex);
 
     algorithm = new MOEADBuilder(problem, MOEADBuilder.Variant.MOEADDRA)

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADDRAIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADDRAIT.java
@@ -26,7 +26,7 @@ public class MOEADDRAIT {
 
     double cr = 1.0;
     double f = 0.5;
-    CrossoverOperator<DoubleSolution> crossover = new DifferentialEvolutionCrossover(cr, f,
+    CrossoverOperator<DoubleSolution> crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f,
             DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
@@ -60,7 +60,7 @@ public class MOEADDRAIT {
 
     double cr = 1.0;
     double f = 0.5;
-    CrossoverOperator<DoubleSolution> crossover = new DifferentialEvolutionCrossover(cr, f,
+    CrossoverOperator<DoubleSolution> crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f,
             DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADIT.java
@@ -28,7 +28,7 @@ public class MOEADIT {
 
     double cr = 1.0;
     double f = 0.5;
-    CrossoverOperator<DoubleSolution> crossover = new DifferentialEvolutionCrossover(cr, f,
+    CrossoverOperator<DoubleSolution> crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f,
             DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
@@ -62,7 +62,7 @@ public class MOEADIT {
 
     double cr = 1.0;
     double f = 0.5;
-    CrossoverOperator<DoubleSolution> crossover = new DifferentialEvolutionCrossover(cr, f,
+    CrossoverOperator<DoubleSolution> crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f,
             DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
@@ -104,7 +104,7 @@ public class MOEADIT {
 
     double cr = 1.0;
     double f = 0.5;
-    CrossoverOperator<DoubleSolution> crossover = new DifferentialEvolutionCrossover(cr, f,
+    CrossoverOperator<DoubleSolution> crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f,
             DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/moead/jmetal5version/MOEADIT.java
@@ -33,7 +33,7 @@ public class MOEADIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(mutationProbability,
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability,
         mutationDistributionIndex);
 
     algorithm = new MOEADBuilder(problem, MOEADBuilder.Variant.MOEAD)
@@ -67,7 +67,7 @@ public class MOEADIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(mutationProbability,
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability,
         mutationDistributionIndex);
 
     algorithm = new MOEADBuilder(problem, MOEADBuilder.Variant.MOEAD)
@@ -109,7 +109,7 @@ public class MOEADIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(mutationProbability,
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability,
             mutationDistributionIndex);
 
     algorithm = new MOEADBuilder(problem, MOEADBuilder.Variant.MOEAD)

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/mombi2/MOMBI2IT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/mombi2/MOMBI2IT.java
@@ -40,7 +40,7 @@ public class MOMBI2IT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 
@@ -75,7 +75,7 @@ public class MOMBI2IT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/NSGAIIIT.java
@@ -38,7 +38,7 @@ public class NSGAIIIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;
@@ -77,7 +77,7 @@ public class NSGAIIIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/jmetal5version/NSGAIIBuilderTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/jmetal5version/NSGAIIBuilderTest.java
@@ -43,7 +43,7 @@ public class NSGAIIBuilderTest {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     int populationSize  = 100 ;
     builder = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation, populationSize);

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/jmetal5version/NSGAIIIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/nsgaii/jmetal5version/NSGAIIIT.java
@@ -36,7 +36,7 @@ public class NSGAIIIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     int populationSize = 100 ;
     algorithm = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation, populationSize).build() ;
@@ -64,7 +64,7 @@ public class NSGAIIIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     int populationSize  = 100 ;
     algorithm = new NSGAIIBuilder<DoubleSolution>(problem, crossover, mutation, populationSize).build() ;

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2BuilderTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2BuilderTest.java
@@ -40,7 +40,7 @@ public class PESA2BuilderTest {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     builder = new PESA2Builder<DoubleSolution>(problem, crossover, mutation);
   }

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2IT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/pesa2/PESA2IT.java
@@ -36,7 +36,7 @@ public class PESA2IT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm = new PESA2Builder<DoubleSolution>(problem, crossover, mutation).build();
 
@@ -64,7 +64,7 @@ public class PESA2IT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm = new PESA2Builder<DoubleSolution>(problem, crossover, mutation).build();
 

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOAIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/smsemoa/SMSEMOAIT.java
@@ -36,7 +36,7 @@ public class SMSEMOAIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     Hypervolume<DoubleSolution> hypervolumeImplementation;
     hypervolumeImplementation = new PISAHypervolume<>();
@@ -74,7 +74,7 @@ public class SMSEMOAIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     Hypervolume<DoubleSolution> hypervolumeImplementation;
     hypervolumeImplementation = new PISAHypervolume<>();

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/wasfga/WASFGAIT.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/wasfga/WASFGAIT.java
@@ -44,7 +44,7 @@ public class WASFGAIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection =
         new BinaryTournamentSelection<DoubleSolution>(
@@ -85,7 +85,7 @@ public class WASFGAIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection =
         new BinaryTournamentSelection<DoubleSolution>(
@@ -135,7 +135,7 @@ public class WASFGAIT {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection =
         new BinaryTournamentSelection<DoubleSolution>(

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionBuilderTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/singleobjective/differentialevolution/DifferentialEvolutionBuilderTest.java
@@ -70,7 +70,7 @@ public class DifferentialEvolutionBuilderTest {
   }
 
   @Test public void setNewCrossoverOperator() {
-    DifferentialEvolutionCrossover crossover = new DifferentialEvolutionCrossover();
+    DifferentialEvolutionCrossover crossover = DifferentialEvolutionCrossover.createDefault();
     assertNotEquals(crossover, builder.getCrossoverOperator());
     builder.setCrossover(crossover);
     assertEquals(crossover, builder.getCrossoverOperator());

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaii/NSGAII.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaii/NSGAII.java
@@ -52,7 +52,7 @@ public class NSGAII {
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
     MutationOperator<DoubleSolution> mutation =
-        new PolynomialMutation(
+        PolynomialMutation.createWithDoubleDefaults(
             mutationProbability, mutationDistributionIndex, mutationSolutionRepair);
 
     CrossoverAndMutationVariation<DoubleSolution> variation =

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaii/NSGAIIv2.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/nsgaii/NSGAIIv2.java
@@ -57,7 +57,7 @@ public class NSGAIIv2 {
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
     MutationOperator<DoubleSolution> mutation =
-        new PolynomialMutation(
+        PolynomialMutation.createWithDoubleDefaults(
             mutationProbability, mutationDistributionIndex, mutationSolutionRepair);
 
     Variation<DoubleSolution> variation =

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/spea2/SPEA2.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/algorithm/spea2/SPEA2.java
@@ -53,7 +53,7 @@ public class SPEA2 {
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
     MutationOperator<DoubleSolution> mutation =
-        new PolynomialMutation(
+        PolynomialMutation.createWithDoubleDefaults(
             mutationProbability, mutationDistributionIndex, mutationSolutionRepair);
 
     Variation<DoubleSolution> variation =

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/parameter/catalogue/DifferentialEvolutionCrossoverParameter.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/parameter/catalogue/DifferentialEvolutionCrossoverParameter.java
@@ -31,7 +31,7 @@ public class DifferentialEvolutionCrossoverParameter extends CategoricalParamete
     Double cr = (Double) findSpecificParameter("cr").getValue();
     Double f  = (Double) findSpecificParameter("f").getValue() ;
 
-    result = new DifferentialEvolutionCrossover(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN) ;
+    result = DifferentialEvolutionCrossover.createFromVariant(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN) ;
 
     return result;
   }

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/parameter/catalogue/MutationParameter.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/parameter/catalogue/MutationParameter.java
@@ -44,7 +44,7 @@ public class MutationParameter extends CategoricalParameter<String> {
         Double distributionIndex =
                 (Double) findSpecificParameter("polynomialMutationDistributionIndex").getValue();
         result =
-                new PolynomialMutation(
+                PolynomialMutation.createWithDoubleDefaults(
                         mutationProbability, distributionIndex, repairDoubleSolution.getParameter());
         break;
       case "uniform":

--- a/jmetal-core/src/main/java/org/uma/jmetal/component/variation/impl/DifferentialCrossoverVariation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/component/variation/impl/DifferentialCrossoverVariation.java
@@ -24,6 +24,21 @@ public class DifferentialCrossoverVariation implements Variation<DoubleSolution>
   public DifferentialCrossoverVariation(
       int offspringPopulationSize,
       DifferentialEvolutionCrossover crossover,
+      MutationOperator<DoubleSolution> mutation,
+      SequenceGenerator<Integer> solutionIndexGenerator,
+      int matingPoolSize) {
+    this.offspringPopulationSize = offspringPopulationSize;
+    this.crossover = crossover;
+    this.mutation = mutation;
+    this.solutionIndexGenerator = solutionIndexGenerator ;
+    this.matingPoolSize = matingPoolSize;
+  }
+
+  /** @deprecated Use instead {@link #createWithDefaultMatingPoolSize(int, DifferentialEvolutionCrossover, MutationOperator, SequenceGenerator)}. */
+  @Deprecated
+  public DifferentialCrossoverVariation(
+      int offspringPopulationSize,
+      DifferentialEvolutionCrossover crossover,
       MutationOperator<DoubleSolution> mutation, SequenceGenerator<Integer> solutionIndexGenerator) {
     this.offspringPopulationSize = offspringPopulationSize;
     this.crossover = crossover;
@@ -33,9 +48,28 @@ public class DifferentialCrossoverVariation implements Variation<DoubleSolution>
     this.matingPoolSize = offspringPopulationSize * crossover.getNumberOfRequiredParents();
   }
 
+  public static DifferentialCrossoverVariation createWithDefaultMatingPoolSize(
+      int offspringPopulationSize,
+      DifferentialEvolutionCrossover crossover,
+      MutationOperator<DoubleSolution> mutation, SequenceGenerator<Integer> solutionIndexGenerator) {
+    return new DifferentialCrossoverVariation(
+        offspringPopulationSize,
+        crossover,
+        mutation,
+        solutionIndexGenerator,
+        offspringPopulationSize * crossover.getNumberOfRequiredParents());
+  }
+  
+  /** @deprecated Use instead {@link #createWithDefaultMatingPoolSizeAndNullMutation(int, DifferentialEvolutionCrossover, SequenceGenerator)}. */
+  @Deprecated
   public DifferentialCrossoverVariation(
       int offspringPopulationSize, DifferentialEvolutionCrossover crossover, SequenceGenerator<Integer> solutionIndexGenerator) {
     this(offspringPopulationSize, crossover, new NullMutation<>(), solutionIndexGenerator);
+  }
+
+  public static DifferentialCrossoverVariation createWithDefaultMatingPoolSizeAndNullMutation(
+      int offspringPopulationSize, DifferentialEvolutionCrossover crossover, SequenceGenerator<Integer> solutionIndexGenerator) {
+    return createWithDefaultMatingPoolSize(offspringPopulationSize, crossover, new NullMutation<>(), solutionIndexGenerator);
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
@@ -112,7 +112,7 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
 
   /** Creates a {@link DifferentialEvolutionCrossover} with default values */
   public static DifferentialEvolutionCrossover createDefault() {
-    return DifferentialEvolutionCrossover.createWithFewParameters(DEFAULT_CR, DEFAULT_F, DEFAULT_DE_VARIANT);
+    return DifferentialEvolutionCrossover.createFromVariant(DEFAULT_CR, DEFAULT_F, DEFAULT_DE_VARIANT);
   }
 
   /**
@@ -121,7 +121,7 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param cr
    * @param f
    * @param variant
-   * @deprecated Use instead {@link #createWithFewParameters(double, double, DE_VARIANT)}
+   * @deprecated Use instead {@link #createFromVariant(double, double, DE_VARIANT)}
    */
   @Deprecated
   public DifferentialEvolutionCrossover(double cr, double f, DE_VARIANT variant) {
@@ -140,8 +140,8 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param f
    * @param variant
    */
-  public static DifferentialEvolutionCrossover createWithFewParameters(double cr, double f, DE_VARIANT variant) {
-    return DifferentialEvolutionCrossover.createWithDetailedParameters(
+  public static DifferentialEvolutionCrossover createFromVariant(double cr, double f, DE_VARIANT variant) {
+    return DifferentialEvolutionCrossover.createFromVariant(
         cr,
         f,
         variant,
@@ -156,7 +156,7 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param f
    * @param variant
    * @param randomGenerator
-   * @deprecated Use instead {@link #createWithSomeParameters(double, double, DE_VARIANT, RandomGenerator)}.
+   * @deprecated Use instead {@link #createFromVariant(double, double, DE_VARIANT, RandomGenerator)}.
    */
   @Deprecated
   public DifferentialEvolutionCrossover(
@@ -177,9 +177,9 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param variant
    * @param randomGenerator
    */
-  public static DifferentialEvolutionCrossover createWithSomeParameters(
+  public static DifferentialEvolutionCrossover createFromVariant(
       double cr, double f, DE_VARIANT variant, RandomGenerator<Double> randomGenerator) {
-    return DifferentialEvolutionCrossover.createWithDetailedParameters(
+    return DifferentialEvolutionCrossover.createFromVariant(
         cr,
         f,
         variant,
@@ -195,7 +195,7 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param variant
    * @param jRandomGenerator
    * @param crRandomGenerator
-   * @deprecated Use instead {@link #createWithDetailedParameters(double, double, DE_VARIANT, BoundedRandomGenerator, BoundedRandomGenerator)}.
+   * @deprecated Use instead {@link #createFromVariant(double, double, DE_VARIANT, BoundedRandomGenerator, BoundedRandomGenerator)}.
    */
   @Deprecated
   public DifferentialEvolutionCrossover(
@@ -227,7 +227,7 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param jRandomGenerator
    * @param crRandomGenerator
    */
-  public static DifferentialEvolutionCrossover createWithDetailedParameters(
+  public static DifferentialEvolutionCrossover createFromVariant(
       double cr,
       double f,
       DE_VARIANT variant,

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
@@ -135,7 +135,9 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
     this.f = f;
     this.variant = variant;
 
-    analyzeVariant(variant);
+    this.numberOfDifferenceVectors = analyzeNumberOfDifferenceVectors(variant);
+    this.crossoverType = analyzeCrossoverType(variant);
+    this.mutationType = analyzeMutationType(variant);
 
     this.jRandomGenerator = jRandomGenerator;
     this.crRandomGenerator = crRandomGenerator;
@@ -143,28 +145,30 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
     solutionRepair = new RepairDoubleSolutionWithBoundValue();
   }
 
-  private void analyzeVariant(DE_VARIANT variant) {
+  private static DE_MUTATION_TYPE analyzeMutationType(DE_VARIANT variant) {
     switch (variant) {
       case RAND_1_BIN:
       case RAND_1_EXP:
-      case BEST_1_BIN:
-      case BEST_1_EXP:
-      case RAND_TO_BEST_1_BIN:
-      case RAND_TO_BEST_1_EXP:
-      case CURRENT_TO_RAND_1_BIN:
-      case CURRENT_TO_RAND_1_EXP:
-        numberOfDifferenceVectors = 1;
-        break;
       case RAND_2_BIN:
       case RAND_2_EXP:
+        return DE_MUTATION_TYPE.RAND;
+      case BEST_1_BIN:
+      case BEST_1_EXP:
       case BEST_2_BIN:
       case BEST_2_EXP:
-        numberOfDifferenceVectors = 2;
-        break;
+        return DE_MUTATION_TYPE.BEST;
+      case CURRENT_TO_RAND_1_BIN:
+      case CURRENT_TO_RAND_1_EXP:
+        return DE_MUTATION_TYPE.CURRENT_TO_RAND;
+      case RAND_TO_BEST_1_BIN:
+      case RAND_TO_BEST_1_EXP:
+        return DE_MUTATION_TYPE.RAND_TO_BEST;
       default:
-        throw new JMetalException("DE variant type invalid: " + variant);
+        throw new JMetalException("DE mutation type invalid: " + variant);
     }
+  }
 
+  private static DE_CROSSOVER_TYPE analyzeCrossoverType(DE_VARIANT variant) {
     switch (variant) {
       case RAND_1_BIN:
       case BEST_1_BIN:
@@ -172,43 +176,37 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
       case CURRENT_TO_RAND_1_BIN:
       case RAND_2_BIN:
       case BEST_2_BIN:
-        crossoverType = DE_CROSSOVER_TYPE.BIN;
-        break;
+        return DE_CROSSOVER_TYPE.BIN;
       case RAND_1_EXP:
       case BEST_1_EXP:
       case RAND_TO_BEST_1_EXP:
       case CURRENT_TO_RAND_1_EXP:
       case RAND_2_EXP:
       case BEST_2_EXP:
-        crossoverType = DE_CROSSOVER_TYPE.EXP;
-        break;
+        return DE_CROSSOVER_TYPE.EXP;
       default:
         throw new JMetalException("DE crossover type invalid: " + variant);
     }
+  }
 
+  private static int analyzeNumberOfDifferenceVectors(DE_VARIANT variant) {
     switch (variant) {
       case RAND_1_BIN:
       case RAND_1_EXP:
-      case RAND_2_BIN:
-      case RAND_2_EXP:
-        mutationType = DE_MUTATION_TYPE.RAND;
-        break;
       case BEST_1_BIN:
       case BEST_1_EXP:
-      case BEST_2_BIN:
-      case BEST_2_EXP:
-        mutationType = DE_MUTATION_TYPE.BEST;
-        break;
-      case CURRENT_TO_RAND_1_BIN:
-      case CURRENT_TO_RAND_1_EXP:
-        mutationType = DE_MUTATION_TYPE.CURRENT_TO_RAND;
-        break;
       case RAND_TO_BEST_1_BIN:
       case RAND_TO_BEST_1_EXP:
-        mutationType = DE_MUTATION_TYPE.RAND_TO_BEST;
-        break;
+      case CURRENT_TO_RAND_1_BIN:
+      case CURRENT_TO_RAND_1_EXP:
+        return 1;
+      case RAND_2_BIN:
+      case RAND_2_EXP:
+      case BEST_2_BIN:
+      case BEST_2_EXP:
+        return 2;
       default:
-        throw new JMetalException("DE mutation type invalid: " + variant);
+        throw new JMetalException("DE variant type invalid: " + variant);
     }
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
@@ -78,8 +78,41 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
   private RepairDoubleSolution solutionRepair;
 
   /** Constructor */
+  public DifferentialEvolutionCrossover(
+      double cr,
+      double f,
+      DE_VARIANT variant,
+      int numberOfDifferenceVectors,
+      DE_CROSSOVER_TYPE crossoverType,
+      DE_MUTATION_TYPE mutationType,
+      BoundedRandomGenerator<Integer> jRandomGenerator,
+      BoundedRandomGenerator<Double> crRandomGenerator,
+      RepairDoubleSolution solutionRepair) {
+
+    this.cr = cr;
+    this.f = f;
+    this.variant = variant;
+    this.numberOfDifferenceVectors = numberOfDifferenceVectors;
+    this.crossoverType = crossoverType;
+    this.mutationType = mutationType;
+    this.jRandomGenerator = jRandomGenerator;
+    this.crRandomGenerator = crRandomGenerator;
+    this.solutionRepair = solutionRepair;
+  }
+
+  /**
+   * Constructor
+   * 
+   * @deprecated Use instead {@link #createDefault()}
+   */
+  @Deprecated
   public DifferentialEvolutionCrossover() {
     this(DEFAULT_CR, DEFAULT_F, DEFAULT_DE_VARIANT);
+  }
+
+  /** Creates a {@link DifferentialEvolutionCrossover} with default values */
+  public static DifferentialEvolutionCrossover createDefault() {
+    return DifferentialEvolutionCrossover.createWithFewParameters(DEFAULT_CR, DEFAULT_F, DEFAULT_DE_VARIANT);
   }
 
   /**
@@ -88,9 +121,27 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param cr
    * @param f
    * @param variant
+   * @deprecated Use instead {@link #createWithFewParameters(double, double, DE_VARIANT)}
    */
+  @Deprecated
   public DifferentialEvolutionCrossover(double cr, double f, DE_VARIANT variant) {
     this(
+        cr,
+        f,
+        variant,
+        (a, b) -> JMetalRandom.getInstance().nextInt(a, b),
+        (a, b) -> JMetalRandom.getInstance().nextDouble(a, b));
+  }
+
+  /**
+   * Creates a {@link DifferentialEvolutionCrossover} from {@link DE_VARIANT} and other parameters.
+   *
+   * @param cr
+   * @param f
+   * @param variant
+   */
+  public static DifferentialEvolutionCrossover createWithFewParameters(double cr, double f, DE_VARIANT variant) {
+    return DifferentialEvolutionCrossover.createWithDetailedParameters(
         cr,
         f,
         variant,
@@ -105,10 +156,30 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param f
    * @param variant
    * @param randomGenerator
+   * @deprecated Use instead {@link #createWithSomeParameters(double, double, DE_VARIANT, RandomGenerator)}.
    */
+  @Deprecated
   public DifferentialEvolutionCrossover(
       double cr, double f, DE_VARIANT variant, RandomGenerator<Double> randomGenerator) {
     this(
+        cr,
+        f,
+        variant,
+        BoundedRandomGenerator.fromDoubleToInteger(randomGenerator),
+        BoundedRandomGenerator.bound(randomGenerator));
+  }
+
+  /**
+   * Creates a {@link DifferentialEvolutionCrossover} from {@link DE_VARIANT} and other parameters.
+   *
+   * @param cr
+   * @param f
+   * @param variant
+   * @param randomGenerator
+   */
+  public static DifferentialEvolutionCrossover createWithSomeParameters(
+      double cr, double f, DE_VARIANT variant, RandomGenerator<Double> randomGenerator) {
+    return DifferentialEvolutionCrossover.createWithDetailedParameters(
         cr,
         f,
         variant,
@@ -124,7 +195,9 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
    * @param variant
    * @param jRandomGenerator
    * @param crRandomGenerator
+   * @deprecated Use instead {@link #createWithDetailedParameters(double, double, DE_VARIANT, BoundedRandomGenerator, BoundedRandomGenerator)}.
    */
+  @Deprecated
   public DifferentialEvolutionCrossover(
       double cr,
       double f,
@@ -143,6 +216,39 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
     this.crRandomGenerator = crRandomGenerator;
 
     solutionRepair = new RepairDoubleSolutionWithBoundValue();
+  }
+
+  /**
+   * Creates a {@link DifferentialEvolutionCrossover} from {@link DE_VARIANT} and other parameters.
+   *
+   * @param cr
+   * @param f
+   * @param variant
+   * @param jRandomGenerator
+   * @param crRandomGenerator
+   */
+  public static DifferentialEvolutionCrossover createWithDetailedParameters(
+      double cr,
+      double f,
+      DE_VARIANT variant,
+      BoundedRandomGenerator<Integer> jRandomGenerator,
+      BoundedRandomGenerator<Double> crRandomGenerator) {
+    int numberOfDifferenceVectors = analyzeNumberOfDifferenceVectors(variant);
+    DE_CROSSOVER_TYPE crossoverType = analyzeCrossoverType(variant);
+    DE_MUTATION_TYPE mutationType = analyzeMutationType(variant);
+
+    RepairDoubleSolution  solutionRepair = new RepairDoubleSolutionWithBoundValue();
+    
+    return new DifferentialEvolutionCrossover(
+        cr,
+        f,
+        variant,
+        numberOfDifferenceVectors,
+        crossoverType,
+        mutationType,
+        jRandomGenerator,
+        crRandomGenerator,
+        solutionRepair);
   }
 
   private static DE_MUTATION_TYPE analyzeMutationType(DE_VARIANT variant) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/PolynomialMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/PolynomialMutation.java
@@ -32,29 +32,75 @@ public class PolynomialMutation implements MutationOperator<DoubleSolution> {
 
   private RandomGenerator<Double> randomGenerator;
 
-  /** Constructor */
+  /**
+   * Constructor
+   * 
+   * @deprecated Use instead {@link #createWithDoubleDefaults()}.
+   */
+  @Deprecated
   public PolynomialMutation() {
     this(DEFAULT_PROBABILITY, DEFAULT_DISTRIBUTION_INDEX);
   }
 
-  /** Constructor */
+  /** Creates a {@link PolynomialMutation} with default values. */
+  public static PolynomialMutation createWithDoubleDefaults() {
+    return createWithDoubleDefaults(DEFAULT_PROBABILITY, DEFAULT_DISTRIBUTION_INDEX);
+  }
+
+  /**
+   * Constructor
+   * 
+   * @deprecated Use instead {@link #createFromDoubleProblem(DoubleProblem, double)}.
+   */
+  @Deprecated
   public PolynomialMutation(DoubleProblem problem, double distributionIndex) {
     this(1.0 / problem.getNumberOfVariables(), distributionIndex);
   }
 
-  /** Constructor */
+  /** Creates a {@link PolynomialMutation} from {@link DoubleProblem} and other parameters. */
+  public static PolynomialMutation createFromDoubleProblem(DoubleProblem problem, double distributionIndex) {
+    return createWithDoubleDefaults(1.0 / problem.getNumberOfVariables(), distributionIndex);
+  }
+
+  /**
+   * Constructor
+   * 
+   * @deprecated Use instead {@link #createFromDoubleProblem(DoubleProblem, double, RandomGenerator)}.
+   */
+  @Deprecated
   public PolynomialMutation(
       DoubleProblem problem, double distributionIndex, RandomGenerator<Double> randomGenerator) {
     this(1.0 / problem.getNumberOfVariables(), distributionIndex);
     this.randomGenerator = randomGenerator;
   }
 
-  /** Constructor */
+  /** Creates a {@link PolynomialMutation} from {@link DoubleProblem} and other parameters. */
+  public static PolynomialMutation createFromDoubleProblem(
+      DoubleProblem problem, double distributionIndex, RandomGenerator<Double> randomGenerator) {
+    return createWithDoubleDefaults(1.0 / problem.getNumberOfVariables(), distributionIndex, randomGenerator);
+  }
+
+  /**
+   * Constructor
+   * 
+   * @deprecated Use instead {@link #createWithDoubleDefaults(double, double)}.
+   */
+  @Deprecated
   public PolynomialMutation(double mutationProbability, double distributionIndex) {
     this(mutationProbability, distributionIndex, new RepairDoubleSolutionWithBoundValue());
   }
 
-  /** Constructor */
+  /** Creates a {@link PolynomialMutation} with default values and other parameters. */
+  public static PolynomialMutation createWithDoubleDefaults(double mutationProbability, double distributionIndex) {
+    return createWithDoubleDefaults(mutationProbability, distributionIndex, new RepairDoubleSolutionWithBoundValue());
+  }
+
+  /**
+   * Constructor
+   * 
+   * @deprecated Use instead {@link #createWithDoubleDefaults(double, double, RandomGenerator)}.
+   */
+  @Deprecated
   public PolynomialMutation(
       double mutationProbability,
       double distributionIndex,
@@ -66,10 +112,37 @@ public class PolynomialMutation implements MutationOperator<DoubleSolution> {
         randomGenerator);
   }
 
-  /** Constructor */
+  /** Creates a {@link PolynomialMutation} with default values and other parameters. */
+  public static PolynomialMutation createWithDoubleDefaults(
+      double mutationProbability,
+      double distributionIndex,
+      RandomGenerator<Double> randomGenerator) {
+    return new PolynomialMutation(
+        mutationProbability,
+        distributionIndex,
+        new RepairDoubleSolutionWithBoundValue(),
+        randomGenerator);
+  }
+
+  /**
+   * Constructor
+   * 
+   * @deprecated Use instead {@link #createWithDoubleDefaults(double, double, RepairDoubleSolution)}.
+   */
+  @Deprecated
   public PolynomialMutation(
       double mutationProbability, double distributionIndex, RepairDoubleSolution solutionRepair) {
     this(
+        mutationProbability,
+        distributionIndex,
+        solutionRepair,
+        () -> JMetalRandom.getInstance().nextDouble());
+  }
+
+  /** Creates a {@link PolynomialMutation} with default values and other parameters. */
+  public static PolynomialMutation createWithDoubleDefaults(
+      double mutationProbability, double distributionIndex, RepairDoubleSolution solutionRepair) {
+    return new PolynomialMutation(
         mutationProbability,
         distributionIndex,
         solutionRepair,

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/DifferentialEvolutionCrossoverTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/DifferentialEvolutionCrossoverTest.java
@@ -11,7 +11,7 @@ public class DifferentialEvolutionCrossoverTest {
 
   @Test
   public void shouldDefaultConstructorCreateADefaultOperator() {
-    DifferentialEvolutionCrossover crossover = new DifferentialEvolutionCrossover();
+    DifferentialEvolutionCrossover crossover = DifferentialEvolutionCrossover.createDefault();
 
     assertNotNull(crossover);
     assertEquals(0.5, crossover.getCr(), EPSILON);
@@ -21,7 +21,7 @@ public class DifferentialEvolutionCrossoverTest {
 
   @Test
   public void shouldSetCrChangeTheCrParameter() {
-    DifferentialEvolutionCrossover crossover = new DifferentialEvolutionCrossover();
+    DifferentialEvolutionCrossover crossover = DifferentialEvolutionCrossover.createDefault();
     crossover.setCr(0.9);
 
     assertEquals(0.9, crossover.getCr(), EPSILON);
@@ -29,7 +29,7 @@ public class DifferentialEvolutionCrossoverTest {
 
   @Test
   public void shouldSetCrChangeTheFParameter() {
-    DifferentialEvolutionCrossover crossover = new DifferentialEvolutionCrossover();
+    DifferentialEvolutionCrossover crossover = DifferentialEvolutionCrossover.createDefault();
     crossover.setF(0.9);
 
     assertEquals(0.9, crossover.getF(), EPSILON);
@@ -37,20 +37,20 @@ public class DifferentialEvolutionCrossoverTest {
 
   @Test
   public void shouldGetCrossoverProbabilityReturnOne() {
-    DifferentialEvolutionCrossover crossover = new DifferentialEvolutionCrossover();
+    DifferentialEvolutionCrossover crossover = DifferentialEvolutionCrossover.createDefault();
     assertEquals(1.0, crossover.getCrossoverProbability(), EPSILON);
   }
 
   @Test
   public void shouldGetNumberOfGeneratedChildrenReturnOne() {
-    DifferentialEvolutionCrossover crossover = new DifferentialEvolutionCrossover();
+    DifferentialEvolutionCrossover crossover = DifferentialEvolutionCrossover.createDefault();
     assertEquals(1.0, crossover.getNumberOfGeneratedChildren(), EPSILON);
   }
 
   @Test
   public void shouldRAND_1_BINVariantBeCorrectlyParsed() {
     DifferentialEvolutionCrossover crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     assertEquals(1, crossover.getNumberOfDifferenceVectors());
@@ -63,7 +63,7 @@ public class DifferentialEvolutionCrossoverTest {
   @Test
   public void shouldRAND_1_EXPVariantBeCorrectlyParsed() {
     DifferentialEvolutionCrossover crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_EXP);
 
     assertEquals(1, crossover.getNumberOfDifferenceVectors());
@@ -76,7 +76,7 @@ public class DifferentialEvolutionCrossoverTest {
     @Test
     public void shouldRAND_2_BINVariantBeCorrectlyParsed() {
         DifferentialEvolutionCrossover crossover =
-                new DifferentialEvolutionCrossover(
+                DifferentialEvolutionCrossover.createFromVariant(
                         0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.RAND_2_BIN);
 
         assertEquals(2, crossover.getNumberOfDifferenceVectors());
@@ -89,7 +89,7 @@ public class DifferentialEvolutionCrossoverTest {
     @Test
     public void shouldRAND_2_EXPVariantBeCorrectlyParsed() {
         DifferentialEvolutionCrossover crossover =
-                new DifferentialEvolutionCrossover(
+                DifferentialEvolutionCrossover.createFromVariant(
                         0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.RAND_2_EXP);
 
         assertEquals(2, crossover.getNumberOfDifferenceVectors());
@@ -102,7 +102,7 @@ public class DifferentialEvolutionCrossoverTest {
     @Test
     public void shouldBEST_1_BINVariantBeCorrectlyParsed() {
         DifferentialEvolutionCrossover crossover =
-                new DifferentialEvolutionCrossover(
+                DifferentialEvolutionCrossover.createFromVariant(
                         0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.BEST_1_BIN);
 
         assertEquals(1, crossover.getNumberOfDifferenceVectors());
@@ -115,7 +115,7 @@ public class DifferentialEvolutionCrossoverTest {
     @Test
     public void shouldBEST_1_EXPVariantBeCorrectlyParsed() {
         DifferentialEvolutionCrossover crossover =
-                new DifferentialEvolutionCrossover(
+                DifferentialEvolutionCrossover.createFromVariant(
                         0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.BEST_1_EXP);
 
         assertEquals(1, crossover.getNumberOfDifferenceVectors());
@@ -129,7 +129,7 @@ public class DifferentialEvolutionCrossoverTest {
     @Test
     public void shouldBEST_2_BINVariantBeCorrectlyParsed() {
         DifferentialEvolutionCrossover crossover =
-                new DifferentialEvolutionCrossover(
+                DifferentialEvolutionCrossover.createFromVariant(
                         0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.BEST_2_BIN);
 
         assertEquals(2, crossover.getNumberOfDifferenceVectors());
@@ -142,7 +142,7 @@ public class DifferentialEvolutionCrossoverTest {
     @Test
     public void shouldBEST_2_EXPVariantBeCorrectlyParsed() {
         DifferentialEvolutionCrossover crossover =
-                new DifferentialEvolutionCrossover(
+                DifferentialEvolutionCrossover.createFromVariant(
                         0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.BEST_2_EXP);
 
         assertEquals(2, crossover.getNumberOfDifferenceVectors());
@@ -155,7 +155,7 @@ public class DifferentialEvolutionCrossoverTest {
     @Test
     public void shouldRAND_TO_BEST_1_BINVariantBeCorrectlyParsed() {
         DifferentialEvolutionCrossover crossover =
-                new DifferentialEvolutionCrossover(
+                DifferentialEvolutionCrossover.createFromVariant(
                         0.1, 0.1, DifferentialEvolutionCrossover.DE_VARIANT.RAND_TO_BEST_1_BIN);
 
         assertEquals(1, crossover.getNumberOfDifferenceVectors());

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/CompositeMutationTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/CompositeMutationTest.java
@@ -31,7 +31,7 @@ public class CompositeMutationTest {
 
   @Test
   public void shouldConstructorCreateAValidOperatorWhenAddingASingleMutationOperator() {
-    PolynomialMutation mutation = new PolynomialMutation(0.9, 20.0);
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(0.9, 20.0);
     List<MutationOperator<?>> operatorList = new ArrayList<>();
     operatorList.add(mutation);
 
@@ -42,7 +42,7 @@ public class CompositeMutationTest {
 
   @Test
   public void shouldConstructorCreateAValidOperatorWhenAddingTwoMutationOperators() {
-    PolynomialMutation polynomialMutation = new PolynomialMutation(0.9, 20.0);
+    PolynomialMutation polynomialMutation = PolynomialMutation.createWithDoubleDefaults(0.9, 20.0);
     BitFlipMutation bitFlipMutation = new BitFlipMutation(0.9);
 
     List<MutationOperator<?>> operatorList = new ArrayList<>();
@@ -57,7 +57,7 @@ public class CompositeMutationTest {
   @Test
   public void shouldExecuteWorkProperlyWithASingleMutationOperator() {
     CompositeMutation operator =
-            new CompositeMutation(Arrays.asList(new PolynomialMutation(1.0, 20.0)));
+            new CompositeMutation(Arrays.asList(PolynomialMutation.createWithDoubleDefaults(1.0, 20.0)));
     DummyDoubleProblem problem = new DummyDoubleProblem();
     CompositeSolution solution = new CompositeSolution(Arrays.asList(problem.createSolution()));
 
@@ -72,7 +72,7 @@ public class CompositeMutationTest {
   public void shouldExecuteWorkProperlyWithTwoMutationOperators() {
     CompositeMutation operator =
             new CompositeMutation(
-                    Arrays.asList(new PolynomialMutation(1.0, 20.0), new BitFlipMutation(0.01)));
+                    Arrays.asList(PolynomialMutation.createWithDoubleDefaults(1.0, 20.0), new BitFlipMutation(0.01)));
 
     DummyDoubleProblem doubleProblem = new DummyDoubleProblem(2, 2, 0);
     CompositeSolution solution =
@@ -91,7 +91,7 @@ public class CompositeMutationTest {
   public void shouldExecuteRaiseAnExceptionIfTheTypesOfTheSolutionsDoNotMatchTheMutationOperators() {
     CompositeMutation operator =
             new CompositeMutation(
-                    Arrays.asList(new PolynomialMutation(1.0, 20.0), new BitFlipMutation(0.01)));
+                    Arrays.asList(PolynomialMutation.createWithDoubleDefaults(1.0, 20.0), new BitFlipMutation(0.01)));
 
     DummyDoubleProblem doubleProblem = new DummyDoubleProblem(2, 2, 0);
     CompositeSolution solution =

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/PolynomialMutationTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/PolynomialMutationTest.java
@@ -42,7 +42,7 @@ public class PolynomialMutationTest {
   
   @Test
   public void shouldConstructorWithoutParameterAssignTheDefaultValues() {
-    PolynomialMutation mutation = new PolynomialMutation() ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults() ;
     assertEquals(0.01, (Double) ReflectionTestUtils
         .getField(mutation, "mutationProbability"), EPSILON) ;
     assertEquals(20.0, (Double) ReflectionTestUtils
@@ -52,7 +52,7 @@ public class PolynomialMutationTest {
   @Test
   public void shouldConstructorWithProblemAndDistributionIndexParametersAssignTheCorrectValues() {
     DoubleProblem problem = new MockDoubleProblem(4) ;
-    PolynomialMutation mutation = new PolynomialMutation(problem, 10.0) ;
+    PolynomialMutation mutation = PolynomialMutation.createFromDoubleProblem(problem, 10.0) ;
     assertEquals(1.0/problem.getNumberOfVariables(), (Double) ReflectionTestUtils
         .getField(mutation, "mutationProbability"), EPSILON) ;
     assertEquals(10.0, (Double) ReflectionTestUtils
@@ -62,7 +62,7 @@ public class PolynomialMutationTest {
   @Test
   public void shouldConstructorAssignTheCorrectProbabilityValue() {
     double mutationProbability = 0.1 ;
-    PolynomialMutation mutation = new PolynomialMutation(mutationProbability, 2.0) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, 2.0) ;
     assertEquals(mutationProbability, (Double) ReflectionTestUtils
         .getField(mutation, "mutationProbability"), EPSILON) ;
   }
@@ -70,7 +70,7 @@ public class PolynomialMutationTest {
   @Test
   public void shouldConstructorAssignTheCorrectDistributionIndex() {
     double distributionIndex = 15.0 ;
-    PolynomialMutation mutation = new PolynomialMutation(0.1, distributionIndex) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(0.1, distributionIndex) ;
     assertEquals(distributionIndex, (Double) ReflectionTestUtils
         .getField(mutation, "distributionIndex"), EPSILON) ;
   }
@@ -78,36 +78,36 @@ public class PolynomialMutationTest {
   @Test (expected = InvalidProbabilityValueException.class)
   public void shouldConstructorFailWhenPassedANegativeProbabilityValue() {
     double mutationProbability = -0.1 ;
-    new PolynomialMutation(mutationProbability, 2.0) ;
+    PolynomialMutation.createWithDoubleDefaults(mutationProbability, 2.0) ;
   }
 
   @Test (expected = InvalidProbabilityValueException.class)
   public void shouldConstructorFailWhenPassedAValueHigherThanOne() {
     double mutationProbability = 1.1 ;
-    new PolynomialMutation(mutationProbability, 2.0) ;
+    PolynomialMutation.createWithDoubleDefaults(mutationProbability, 2.0) ;
   }
 
   @Test (expected = InvalidConditionException.class)
   public void shouldConstructorFailWhenPassedANegativeDistributionIndex() {
     double distributionIndex = -0.1 ;
-    new PolynomialMutation(0.1, distributionIndex) ;
+    PolynomialMutation.createWithDoubleDefaults(0.1, distributionIndex) ;
   }
 
   @Test
   public void shouldGetMutationProbabilityReturnTheRightValue() {
-    PolynomialMutation mutation = new PolynomialMutation(0.1, 20.0) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(0.1, 20.0) ;
     assertEquals(0.1, mutation.getMutationProbability(), EPSILON) ;
   }
 
   @Test
   public void shouldGetDistributionIndexReturnTheRightValue() {
-    PolynomialMutation mutation = new PolynomialMutation(0.1, 30.0) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(0.1, 30.0) ;
     assertEquals(30.0, mutation.getDistributionIndex(), EPSILON) ;
   }
 
   @Test (expected = NullParameterException.class)
   public void shouldExecuteWithNullParameterThrowAnException() {
-    PolynomialMutation mutation = new PolynomialMutation(0.1, 20.0) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(0.1, 20.0) ;
 
     mutation.execute(null) ;
   }
@@ -117,7 +117,7 @@ public class PolynomialMutationTest {
     double mutationProbability = 0.0;
     double distributionIndex = 20.0 ;
 
-    PolynomialMutation mutation = new PolynomialMutation(mutationProbability, distributionIndex) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, distributionIndex) ;
     DoubleProblem problem = new MockDoubleProblem(1) ;
     DoubleSolution solution = problem.createSolution() ;
     DoubleSolution oldSolution = (DoubleSolution)solution.copy() ;
@@ -136,7 +136,7 @@ public class PolynomialMutationTest {
 
     Mockito.when(randomGenerator.getRandomValue()).thenReturn(1.0) ;
 
-    PolynomialMutation mutation = new PolynomialMutation(mutationProbability, distributionIndex) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, distributionIndex) ;
     DoubleProblem problem = new MockDoubleProblem(1) ;
     DoubleSolution solution = problem.createSolution() ;
     DoubleSolution oldSolution = (DoubleSolution)solution.copy() ;
@@ -158,7 +158,7 @@ public class PolynomialMutationTest {
 
     Mockito.when(randomGenerator.getRandomValue()).thenReturn(0.005, 0.6) ;
 
-    PolynomialMutation mutation = new PolynomialMutation(mutationProbability, distributionIndex) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, distributionIndex) ;
     DoubleProblem problem = new MockDoubleProblem(1) ;
     DoubleSolution solution = problem.createSolution() ;
 
@@ -181,7 +181,7 @@ public class PolynomialMutationTest {
 
     Mockito.when(randomGenerator.getRandomValue()).thenReturn(0.005, 0.1) ;
 
-    PolynomialMutation mutation = new PolynomialMutation(mutationProbability, distributionIndex) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, distributionIndex) ;
     DoubleProblem problem = new MockDoubleProblem(1) ;
     DoubleSolution solution = problem.createSolution() ;
 
@@ -204,7 +204,7 @@ public class PolynomialMutationTest {
 
     Mockito.when(randomGenerator.getRandomValue()).thenReturn(0.005, 0.1) ;
 
-    PolynomialMutation mutation = new PolynomialMutation(mutationProbability, distributionIndex) ;
+    PolynomialMutation mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, distributionIndex) ;
 
     MockDoubleProblem problem = new MockDoubleProblem(1) ;
     ReflectionTestUtils.setField(problem, "lowerLimit", Arrays.asList(new Double[]{1.0}));
@@ -271,7 +271,7 @@ public class PolynomialMutationTest {
 		defaultGenerator.setRandomGenerator(auditor);
 		auditor.addListener((a) -> defaultUses[0]++);
 
-		new PolynomialMutation(crossoverProbability, alpha, solutionRepair).execute(solution);
+		PolynomialMutation.createWithDoubleDefaults(crossoverProbability, alpha, solutionRepair).execute(solution);
 		assertTrue("No use of the default generator", defaultUses[0] > 0);
 
 		// Test same configuration uses custom generator instead

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/CDGRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/CDGRunner.java
@@ -62,7 +62,7 @@ public class CDGRunner extends AbstractAlgorithmRunner {
     double cr = 1.0;
     double f = 0.5;
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     algorithm =

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/CellDERunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/CellDERunner.java
@@ -56,7 +56,7 @@ public class CellDERunner extends AbstractAlgorithmRunner {
     double cr = 0.5 ;
     double f = 0.5 ;
 
-    crossover = new DifferentialEvolutionCrossover(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN) ;
+    crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ESPEARunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ESPEARunner.java
@@ -55,7 +55,7 @@ public class ESPEARunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     ESPEABuilder<DoubleSolution> builder = new ESPEABuilder<>(problem, crossover, mutation);
     builder.setMaxEvaluations(25000);

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/GDE3BigDataRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/GDE3BigDataRunner.java
@@ -55,7 +55,7 @@ public class GDE3BigDataRunner {
 
     double cr = 1.5 ;
     double f = 0.5 ;
-    crossover = new DifferentialEvolutionCrossover(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN) ;
+    crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN) ;
 
     selection = new DifferentialEvolutionSelection() ;
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/GDE3Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/GDE3Runner.java
@@ -48,7 +48,7 @@ public class GDE3Runner extends AbstractAlgorithmRunner {
 
     double cr = 0.5;
     double f = 0.5;
-    crossover = new DifferentialEvolutionCrossover(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
+    crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     selection = new DifferentialEvolutionSelection();
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/GMOCellRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/GMOCellRunner.java
@@ -63,7 +63,7 @@ public class GMOCellRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection =
         new BinaryTournamentSelection<DoubleSolution>(

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/IBEARunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/IBEARunner.java
@@ -58,7 +58,7 @@ public class IBEARunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>() ;
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/MOMBI2Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/MOMBI2Runner.java
@@ -64,7 +64,7 @@ public class MOMBI2Runner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection =
         new BinaryTournamentSelection<DoubleSolution>(

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/MOMBIRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/MOMBIRunner.java
@@ -60,7 +60,7 @@ public class MOMBIRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection =
         new BinaryTournamentSelection<DoubleSolution>(

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/NSGAIIIRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/NSGAIIIRunner.java
@@ -51,7 +51,7 @@ public class NSGAIIIRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection = new BinaryTournamentSelection<DoubleSolution>();
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/PAESRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/PAESRunner.java
@@ -48,7 +48,7 @@ public class PAESRunner extends AbstractAlgorithmRunner {
 
     problem = ProblemUtils.loadProblem(problemName);
 
-    mutation = new PolynomialMutation(1.0 / problem.getNumberOfVariables(), 20.0) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(1.0 / problem.getNumberOfVariables(), 20.0) ;
 
     algorithm = new PAESBuilder<DoubleSolution>(problem)
             .setMutationOperator(mutation)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/PESA2Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/PESA2Runner.java
@@ -55,7 +55,7 @@ public class PESA2Runner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm =
         new PESA2Builder<DoubleSolution>(problem, crossover, mutation)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ParallelGDE3Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ParallelGDE3Runner.java
@@ -52,7 +52,7 @@ public class ParallelGDE3Runner extends AbstractAlgorithmRunner {
     double cr = 0.5;
     double f = 0.5;
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
     selection = new DifferentialEvolutionSelection();
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ParallelPESA2Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ParallelPESA2Runner.java
@@ -57,7 +57,7 @@ public class ParallelPESA2Runner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     SolutionListEvaluator<DoubleSolution> evaluator =
         new MultithreadedSolutionListEvaluator<DoubleSolution>(0);

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ensemble/Ensemble2DNSGAIISMPSOMOEAD.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ensemble/Ensemble2DNSGAIISMPSOMOEAD.java
@@ -91,7 +91,7 @@ public class Ensemble2DNSGAIISMPSOMOEAD extends AbstractAlgorithmRunner {
     AggregativeFunction aggregativeFunction = new Tschebyscheff();
 
     Algorithm<List<DoubleSolution>> moead =
-        new MOEADDE(
+        MOEADDE.create(
                 problem,
                 300,
                 cr,

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ensemble/Ensemble2DNSGAIISMPSOMOEAD.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ensemble/Ensemble2DNSGAIISMPSOMOEAD.java
@@ -61,7 +61,7 @@ public class Ensemble2DNSGAIISMPSOMOEAD extends AbstractAlgorithmRunner {
                 populationSize,
                 offspringPopulationSize,
                 new SBXCrossover(crossoverProbability, crossoverDistributionIndex),
-                new PolynomialMutation(mutationProbability, mutationDistributionIndex),
+                PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex),
                 termination)
             .withArchive(new NonDominatedSolutionListArchive<>());
 
@@ -76,7 +76,7 @@ public class Ensemble2DNSGAIISMPSOMOEAD extends AbstractAlgorithmRunner {
             (DoubleProblem) problem,
             swarmSize,
             leadersArchive,
-            new PolynomialMutation(mutationProbability, mutationDistributionIndex),
+            PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex),
             evaluation,
             termination,
             new NonDominatedSolutionListArchive<>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ensemble/Ensemble3DNSGAIISMPSOMOEAD.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ensemble/Ensemble3DNSGAIISMPSOMOEAD.java
@@ -62,7 +62,7 @@ public class Ensemble3DNSGAIISMPSOMOEAD extends AbstractAlgorithmRunner {
                 populationSize,
                 offspringPopulationSize,
                 new SBXCrossover(crossoverProbability, crossoverDistributionIndex),
-                new PolynomialMutation(mutationProbability, mutationDistributionIndex),
+                PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex),
                 termination)
             .withArchive(new NonDominatedSolutionListArchive<>());
 
@@ -77,7 +77,7 @@ public class Ensemble3DNSGAIISMPSOMOEAD extends AbstractAlgorithmRunner {
             (DoubleProblem) problem,
             swarmSize,
             leadersArchive,
-            new PolynomialMutation(mutationProbability, mutationDistributionIndex),
+            PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex),
             evaluation,
             termination,
             new NonDominatedSolutionListArchive<>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ensemble/Ensemble3DNSGAIISMPSOMOEAD.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/ensemble/Ensemble3DNSGAIISMPSOMOEAD.java
@@ -92,7 +92,7 @@ public class Ensemble3DNSGAIISMPSOMOEAD extends AbstractAlgorithmRunner {
     AggregativeFunction aggregativeFunction = new Tschebyscheff();
 
     Algorithm<List<DoubleSolution>> moead =
-        new MOEADDE(
+        MOEADDE.create(
                 problem,
                 495,
                 cr,

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/mocell/MOCellChangingMutationAndCrossoverProbabilitiesRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/mocell/MOCellChangingMutationAndCrossoverProbabilitiesRunner.java
@@ -69,7 +69,7 @@ public class MOCellChangingMutationAndCrossoverProbabilitiesRunner extends Abstr
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 
@@ -104,7 +104,7 @@ public class MOCellChangingMutationAndCrossoverProbabilitiesRunner extends Abstr
 
         if (evaluations > 10000) {
           crossoverOperator = new SBXCrossover(0.7, 20.0) ;
-          mutationOperator = new PolynomialMutation(0.001, 30.0) ;
+          mutationOperator = PolynomialMutation.createWithDoubleDefaults(0.001, 30.0) ;
         }
       }
     }

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/mocell/MOCellHVRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/mocell/MOCellHVRunner.java
@@ -63,7 +63,7 @@ public class MOCellHVRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/mocell/MOCellRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/mocell/MOCellRunner.java
@@ -61,7 +61,7 @@ public class MOCellRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEAD3DProblemWithChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEAD3DProblemWithChartExample.java
@@ -52,7 +52,7 @@ public class MOEAD3DProblemWithChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     double neighborhoodSelectionProbability = 1.0;
     int neighborhoodSize = 20;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEComponentBasedConfigurationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEComponentBasedConfigurationExample.java
@@ -91,7 +91,7 @@ public class MOEADDEComponentBasedConfigurationExample extends AbstractAlgorithm
     Evaluation<DoubleSolution> evaluation = new SequentialEvaluation<>(problem);
 
     algorithm =
-        new MOEADDE(
+        MOEADDE.create(
             evaluation,
             new RandomSolutionsCreation<>(problem, populationSize),
             new TerminationByEvaluations(150000),

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEComponentBasedConfigurationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEComponentBasedConfigurationExample.java
@@ -55,7 +55,7 @@ public class MOEADDEComponentBasedConfigurationExample extends AbstractAlgorithm
     double cr = 1.0;
     double f = 0.5;
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEComponentBasedConfigurationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEComponentBasedConfigurationExample.java
@@ -63,7 +63,7 @@ public class MOEADDEComponentBasedConfigurationExample extends AbstractAlgorithm
     mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
 
     DifferentialCrossoverVariation variation =
-        new DifferentialCrossoverVariation(1, crossover, mutation, subProblemIdGenerator);
+        DifferentialCrossoverVariation.createWithDefaultMatingPoolSize(1, crossover, mutation, subProblemIdGenerator);
 
     double neighborhoodSelectionProbability = 0.9;
     int neighborhoodSize = 20;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEComponentBasedConfigurationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEComponentBasedConfigurationExample.java
@@ -60,7 +60,7 @@ public class MOEADDEComponentBasedConfigurationExample extends AbstractAlgorithm
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     DifferentialCrossoverVariation variation =
         DifferentialCrossoverVariation.createWithDefaultMatingPoolSize(1, crossover, mutation, subProblemIdGenerator);

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEDefaultConfigurationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEDefaultConfigurationExample.java
@@ -46,7 +46,7 @@ public class MOEADDEDefaultConfigurationExample extends AbstractAlgorithmRunner 
     AggregativeFunction aggregativeFunction = new Tschebyscheff();
 
     algorithm =
-        new MOEADDE(
+        MOEADDE.create(
             problem,
             populationSize,
             cr,

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEWithRealTimeChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEWithRealTimeChartExample.java
@@ -45,7 +45,7 @@ public class MOEADDEWithRealTimeChartExample extends AbstractAlgorithmRunner {
     AggregativeFunction aggregativeFunction = new Tschebyscheff();
 
     algorithm =
-            new MOEADDE(
+            MOEADDE.create(
                     problem,
                     populationSize,
                     cr,

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEWithUnboundedNonDominatedArchiveExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDEWithUnboundedNonDominatedArchiveExample.java
@@ -55,7 +55,7 @@ public class MOEADDEWithUnboundedNonDominatedArchiveExample extends AbstractAlgo
     Archive<DoubleSolution> archive = new NonDominatedSolutionListArchive<>();
 
     algorithm =
-        new MOEADDE(
+        MOEADDE.create(
                 problem,
                 populationSize,
                 cr,

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDefaultConfiguration3DProblemExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDefaultConfiguration3DProblemExample.java
@@ -48,7 +48,7 @@ public class MOEADDefaultConfiguration3DProblemExample extends AbstractAlgorithm
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     double neighborhoodSelectionProbability = 1.0;
     int neighborhoodSize = 20;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDefaultConfigurationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADDefaultConfigurationExample.java
@@ -48,7 +48,7 @@ public class MOEADDefaultConfigurationExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
 
     double neighborhoodSelectionProbability = 0.9;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADStoppingByKeyboardExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADStoppingByKeyboardExample.java
@@ -48,7 +48,7 @@ public class MOEADStoppingByKeyboardExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     double neighborhoodSelectionProbability = 1.0;
     int neighborhoodSize = 20;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADStoppingByTimeExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADStoppingByTimeExample.java
@@ -48,7 +48,7 @@ public class MOEADStoppingByTimeExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     double neighborhoodSelectionProbability = 1.0;
     int neighborhoodSize = 20;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADWithChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADWithChartExample.java
@@ -51,7 +51,7 @@ public class MOEADWithChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     double neighborhoodSelectionProbability = 1.0;
     int neighborhoodSize = 20;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADWithCrowdingDistanceArchiveExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADWithCrowdingDistanceArchiveExample.java
@@ -51,7 +51,7 @@ public class MOEADWithCrowdingDistanceArchiveExample extends AbstractAlgorithmRu
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     double neighborhoodSelectionProbability = 1.0;
     int neighborhoodSize = 20;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADWithUnboundedNonDominatedArchiveExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/MOEADWithUnboundedNonDominatedArchiveExample.java
@@ -52,7 +52,7 @@ public class MOEADWithUnboundedNonDominatedArchiveExample extends AbstractAlgori
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     double neighborhoodSelectionProbability = 1.0;
     int neighborhoodSize = 20;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEAD3DProblemRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEAD3DProblemRunner.java
@@ -50,7 +50,7 @@ public class MOEAD3DProblemRunner extends AbstractAlgorithmRunner {
     double cr = 1.0;
     double f = 0.5;
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEAD3DProblemRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEAD3DProblemRunner.java
@@ -55,7 +55,7 @@ public class MOEAD3DProblemRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm =
         new MOEADBuilder(problem, MOEADBuilder.Variant.MOEAD)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADConstraintRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADConstraintRunner.java
@@ -56,7 +56,7 @@ public class MOEADConstraintRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm =
         new MOEADBuilder(problem, Variant.ConstraintMOEAD)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADConstraintRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADConstraintRunner.java
@@ -51,7 +51,7 @@ public class MOEADConstraintRunner extends AbstractAlgorithmRunner {
     double cr = 1.0;
     double f = 0.5;
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADDRARunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADDRARunner.java
@@ -50,7 +50,7 @@ public class MOEADDRARunner extends AbstractAlgorithmRunner {
     double cr = 1.0;
     double f = 0.5;
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADDRARunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADDRARunner.java
@@ -55,7 +55,7 @@ public class MOEADDRARunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm =
         new MOEADBuilder(problem, MOEADBuilder.Variant.MOEADDRA)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADDRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADDRunner.java
@@ -57,7 +57,7 @@ public class MOEADDRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     MOEADBuilder builder =  new MOEADBuilder(problem, MOEADBuilder.Variant.MOEADD);
     builder.setCrossover(crossover)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADIEpsilonRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADIEpsilonRunner.java
@@ -53,7 +53,7 @@ public class MOEADIEpsilonRunner extends AbstractAlgorithmRunner {
 
     double cr = 1.0 ;
     double f = 0.5 ;
-    crossover = new DifferentialEvolutionCrossover(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
+    crossover = DifferentialEvolutionCrossover.createFromVariant(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADIEpsilonRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADIEpsilonRunner.java
@@ -57,7 +57,7 @@ public class MOEADIEpsilonRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm = new MOEADBuilder(problem, Variant.MOEADIEPSILON)
             .setCrossover(crossover)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADRunner.java
@@ -50,7 +50,7 @@ public class MOEADRunner extends AbstractAlgorithmRunner {
     double cr = 1.0;
     double f = 0.5;
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADRunner.java
@@ -55,7 +55,7 @@ public class MOEADRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm =
         new MOEADBuilder(problem, MOEADBuilder.Variant.MOEAD)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADSTMRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADSTMRunner.java
@@ -55,7 +55,7 @@ public class MOEADSTMRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     algorithm =
         new MOEADBuilder(problem, MOEADBuilder.Variant.MOEADSTM)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADSTMRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/moead/jmetal5version/MOEADSTMRunner.java
@@ -50,7 +50,7 @@ public class MOEADSTMRunner extends AbstractAlgorithmRunner {
     double cr = 1.0;
     double f = 0.5;
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/GNSGAIIExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/GNSGAIIExample.java
@@ -47,7 +47,7 @@ public class GNSGAIIExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIComponentBasedConfigurationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIComponentBasedConfigurationExample.java
@@ -72,7 +72,7 @@ public class NSGAIIComponentBasedConfigurationExample extends AbstractAlgorithmR
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
     MutationOperator<DoubleSolution> mutation =
-        new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+        PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     CrossoverAndMutationVariation<DoubleSolution> variation =
         new CrossoverAndMutationVariation<>(offspringPopulationSize, crossover, mutation);

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIDefaultConfigurationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIDefaultConfigurationExample.java
@@ -43,7 +43,7 @@ public class NSGAIIDefaultConfigurationExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = populationSize;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIISteadyStateExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIISteadyStateExample.java
@@ -43,7 +43,7 @@ public class NSGAIISteadyStateExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 1;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIISteadyStateWithRealTimeChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIISteadyStateWithRealTimeChartExample.java
@@ -41,7 +41,7 @@ public class NSGAIISteadyStateWithRealTimeChartExample extends AbstractAlgorithm
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 1;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIStoppingByKeyboardExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIStoppingByKeyboardExample.java
@@ -43,7 +43,7 @@ public class NSGAIIStoppingByKeyboardExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIStoppingByTimeExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIStoppingByTimeExample.java
@@ -45,7 +45,7 @@ public class NSGAIIStoppingByTimeExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWith3DChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWith3DChartExample.java
@@ -47,7 +47,7 @@ public class NSGAIIWith3DChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithChartExample.java
@@ -47,7 +47,7 @@ public class NSGAIIWithChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithCrowdingDistanceArchiveExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithCrowdingDistanceArchiveExample.java
@@ -46,7 +46,7 @@ public class NSGAIIWithCrowdingDistanceArchiveExample extends AbstractAlgorithmR
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = populationSize;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithExperimentalNDSAlgorithmExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithExperimentalNDSAlgorithmExample.java
@@ -49,7 +49,7 @@ public class NSGAIIWithExperimentalNDSAlgorithmExample extends AbstractAlgorithm
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = populationSize;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithMNDSRankingExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithMNDSRankingExample.java
@@ -45,7 +45,7 @@ public class NSGAIIWithMNDSRankingExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = populationSize;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithMixedSolutionEncodingExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithMixedSolutionEncodingExample.java
@@ -43,7 +43,7 @@ public class NSGAIIWithMixedSolutionEncodingExample extends AbstractAlgorithmRun
     CompositeMutation mutation =
         new CompositeMutation(
             Arrays.asList(
-                new IntegerPolynomialMutation(0.1, 2.0), new PolynomialMutation(0.1, 20.0)));
+                new IntegerPolynomialMutation(0.1, 2.0), PolynomialMutation.createWithDoubleDefaults(0.1, 20.0)));
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithPlotli3DChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithPlotli3DChartExample.java
@@ -47,7 +47,7 @@ public class NSGAIIWithPlotli3DChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithPlotliChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithPlotliChartExample.java
@@ -48,7 +48,7 @@ public class NSGAIIWithPlotliChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithRealTimeChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithRealTimeChartExample.java
@@ -41,7 +41,7 @@ public class NSGAIIWithRealTimeChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithUnboundedNonDominatedArchiveExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/NSGAIIWithUnboundedNonDominatedArchiveExample.java
@@ -45,7 +45,7 @@ public class NSGAIIWithUnboundedNonDominatedArchiveExample extends AbstractAlgor
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = populationSize;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/ParallelNSGAIIExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/ParallelNSGAIIExample.java
@@ -47,7 +47,7 @@ public class ParallelNSGAIIExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
     int offspringPopulationSize = populationSize;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/DNSGAIIRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/DNSGAIIRunner.java
@@ -45,7 +45,7 @@ public class DNSGAIIRunner extends AbstractAlgorithmRunner {
     // mutation
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     // selection
     SelectionOperator<List<DoubleSolution>, DoubleSolution> selection = new BinaryTournamentSelection<>(

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/DynamicNSGAIIRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/DynamicNSGAIIRunner.java
@@ -35,7 +35,7 @@ public class DynamicNSGAIIRunner {
     // STEP 2. Create the algorithm
     CrossoverOperator<DoubleSolution> crossover = new SBXCrossover(0.9, 20.0);
     MutationOperator<DoubleSolution> mutation =
-        new PolynomialMutation(1.0 / problem.getNumberOfVariables(), 20.0);
+        PolynomialMutation.createWithDoubleDefaults(1.0 / problem.getNumberOfVariables(), 20.0);
     SelectionOperator<List<DoubleSolution>, DoubleSolution> selection =
         new BinaryTournamentSelection<>();
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAII45Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAII45Runner.java
@@ -62,7 +62,7 @@ public class NSGAII45Runner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIBigDataRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIBigDataRunner.java
@@ -63,7 +63,7 @@ public class NSGAIIBigDataRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIComposableSchafferProblemRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIComposableSchafferProblemRunner.java
@@ -55,7 +55,7 @@ public class NSGAIIComposableSchafferProblemRunner extends AbstractAlgorithmRunn
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
         new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIComposableSrinivasProblemRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIComposableSrinivasProblemRunner.java
@@ -56,7 +56,7 @@ public class NSGAIIComposableSrinivasProblemRunner extends AbstractAlgorithmRunn
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
         new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIEbesRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIEbesRunner.java
@@ -49,7 +49,7 @@ public class NSGAIIEbesRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIMeasuresRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIMeasuresRunner.java
@@ -64,7 +64,7 @@ public class NSGAIIMeasuresRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
             new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIMeasuresWithChartsRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIMeasuresWithChartsRunner.java
@@ -62,7 +62,7 @@ public class NSGAIIMeasuresWithChartsRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
             new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIMeasuresWithHypervolumeRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIMeasuresWithHypervolumeRunner.java
@@ -61,7 +61,7 @@ public class NSGAIIMeasuresWithHypervolumeRunner extends AbstractAlgorithmRunner
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIMeasuresWithQualityIndicatorRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIMeasuresWithQualityIndicatorRunner.java
@@ -65,7 +65,7 @@ public class NSGAIIMeasuresWithQualityIndicatorRunner extends AbstractAlgorithmR
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIRunner.java
@@ -62,7 +62,7 @@ public class NSGAIIRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
             new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIISteadyStateRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIISteadyStateRunner.java
@@ -60,7 +60,7 @@ public class NSGAIISteadyStateRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection = new BinaryTournamentSelection<DoubleSolution>();
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIStoppingByTimeRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/NSGAIIStoppingByTimeRunner.java
@@ -62,7 +62,7 @@ public class NSGAIIStoppingByTimeRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
         new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/ParallelNSGAIIRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/ParallelNSGAIIRunner.java
@@ -72,7 +72,7 @@ public class ParallelNSGAIIRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection = new BinaryTournamentSelection<DoubleSolution>();
 
@@ -139,7 +139,7 @@ public class ParallelNSGAIIRunner extends AbstractAlgorithmRunner {
 
       double mutationProbability = 1.0 / problem.getNumberOfVariables();
       double mutationDistributionIndex = 20.0;
-      mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+      mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
       selection = new BinaryTournamentSelection<DoubleSolution>(
               new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/RNSGAIIConstraintRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/RNSGAIIConstraintRunner.java
@@ -76,7 +76,7 @@ public class RNSGAIIConstraintRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
         new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/RNSGAIIRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/RNSGAIIRunner.java
@@ -76,7 +76,7 @@ public class RNSGAIIRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
         new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/RNSGAIIWithChartsRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/nsgaii/jmetal5version/RNSGAIIWithChartsRunner.java
@@ -86,7 +86,7 @@ public class RNSGAIIWithChartsRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(
         new RankingAndCrowdingDistanceComparator<DoubleSolution>());

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOStandardSettingsExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOStandardSettingsExample.java
@@ -41,7 +41,7 @@ public class SMPSOStandardSettingsExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     Evaluation<DoubleSolution> evaluation = new SequentialEvaluation<>(problem) ;
     Termination termination = new TerminationByEvaluations(50000) ;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOStoppingByKeyboardExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOStoppingByKeyboardExample.java
@@ -41,7 +41,7 @@ public class SMPSOStoppingByKeyboardExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     Evaluation<DoubleSolution> evaluation = new SequentialEvaluation<>(problem) ;
     Termination termination = new TerminationByKeyboard() ;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOWithPlotliChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOWithPlotliChartExample.java
@@ -46,7 +46,7 @@ public class SMPSOWithPlotliChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     Evaluation<DoubleSolution> evaluation = new SequentialEvaluation<>(problem) ;
     Termination termination = new TerminationByEvaluations(25000) ;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOWithRealTimeChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOWithRealTimeChartExample.java
@@ -37,7 +37,7 @@ public class SMPSOWithRealTimeChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     Evaluation<DoubleSolution> evaluation = new SequentialEvaluation<>(problem) ;
     Termination termination = new TerminationByEvaluations(25000) ;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOWithUnboundedNonDominatedArchiveExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/SMPSOWithUnboundedNonDominatedArchiveExample.java
@@ -44,7 +44,7 @@ public class SMPSOWithUnboundedNonDominatedArchiveExample extends AbstractAlgori
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     Evaluation<DoubleSolution> evaluation = new SequentialEvaluation<>(problem) ;
     Termination termination = new TerminationByEvaluations(50000) ;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/ParallelSMPSORunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/ParallelSMPSORunner.java
@@ -58,7 +58,7 @@ public class ParallelSMPSORunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     evaluator = new MultithreadedSolutionListEvaluator<DoubleSolution>(0) ;
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOBigDataRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOBigDataRunner.java
@@ -55,7 +55,7 @@ public class SMPSOBigDataRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     algorithm = new SMPSOBuilder(problem, archive)
             .setMutation(mutation)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOHv2Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOHv2Runner.java
@@ -65,7 +65,7 @@ public class SMPSOHv2Runner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     algorithm = new SMPSOBuilder(problem, archive)
         .setMutation(mutation)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOHvRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOHvRunner.java
@@ -65,7 +65,7 @@ public class SMPSOHvRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     algorithm = new SMPSOBuilder(problem, archive)
         .setMutation(mutation)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOMeasuresRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOMeasuresRunner.java
@@ -60,7 +60,7 @@ public class SMPSOMeasuresRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     int maxIterations = 250 ;
     int swarmSize = 100 ;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOMeasuresWithChartsRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSOMeasuresWithChartsRunner.java
@@ -60,7 +60,7 @@ public class SMPSOMeasuresWithChartsRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     int maxIterations = 3000 ;
     int swarmSize = 200 ;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSORunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpso/jmetal5version/SMPSORunner.java
@@ -55,7 +55,7 @@ public class SMPSORunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     algorithm = new SMPSOBuilder(problem, archive)
         .setMutation(mutation)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/SMPSORPChangingTheReferencePointsAndRealTimeChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/SMPSORPChangingTheReferencePointsAndRealTimeChartExample.java
@@ -54,7 +54,7 @@ public class SMPSORPChangingTheReferencePointsAndRealTimeChartExample {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int maxEvaluations = 25000;
     int swarmSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/SMPSORPWithMultipleReferencePointsAndRealTimeChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/SMPSORPWithMultipleReferencePointsAndRealTimeChartExample.java
@@ -50,7 +50,7 @@ public class SMPSORPWithMultipleReferencePointsAndRealTimeChartExample {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int maxEvaluations = 25000;
     int swarmSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/SMPSORPWithMultipleReferencePointsExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/SMPSORPWithMultipleReferencePointsExample.java
@@ -53,7 +53,7 @@ public class SMPSORPWithMultipleReferencePointsExample {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int maxEvaluations = 25000;
     int swarmSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/SMPSORPWithOneReferencePointExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/SMPSORPWithOneReferencePointExample.java
@@ -52,7 +52,7 @@ public class SMPSORPWithOneReferencePointExample {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int maxEvaluations = 25000;
     int swarmSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPChangingTheReferencePointsAndChartsRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPChangingTheReferencePointsAndChartsRunner.java
@@ -55,7 +55,7 @@ public class SMPSORPChangingTheReferencePointsAndChartsRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int maxIterations = 2500;
     int swarmSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1.java
@@ -55,7 +55,7 @@ public class SMPSORPChangingTheReferencePointsAndChartsRunnerZDT1 {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int maxIterations = 2500000;
     int swarmSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPWithMultipleReferencePointsAndChartsRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPWithMultipleReferencePointsAndChartsRunner.java
@@ -65,7 +65,7 @@ public class SMPSORPWithMultipleReferencePointsAndChartsRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     int maxIterations = 250;
     int swarmSize = 100 ;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPWithMultipleReferencePointsRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPWithMultipleReferencePointsRunner.java
@@ -51,7 +51,7 @@ public class SMPSORPWithMultipleReferencePointsRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int maxIterations = 250;
     int swarmSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPWithOneReferencePointRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smpsorp/jmetal5version/SMPSORPWithOneReferencePointRunner.java
@@ -50,7 +50,7 @@ public class SMPSORPWithOneReferencePointRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int maxIterations = 250;
     int swarmSize = 100;

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smsemoa/SMSEMOAStandardSettingsExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smsemoa/SMSEMOAStandardSettingsExample.java
@@ -43,7 +43,7 @@ public class SMSEMOAStandardSettingsExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smsemoa/SMSEMOAWithRealTimeChartExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smsemoa/SMSEMOAWithRealTimeChartExample.java
@@ -45,7 +45,7 @@ public class SMSEMOAWithRealTimeChartExample extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smsemoa/SMSEMOAWithUnboundedArchiveExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smsemoa/SMSEMOAWithUnboundedArchiveExample.java
@@ -44,7 +44,7 @@ public class SMSEMOAWithUnboundedArchiveExample extends AbstractAlgorithmRunner 
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     int populationSize = 100;
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smsemoa/jmetal5version/SMSEMOARunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/smsemoa/jmetal5version/SMSEMOARunner.java
@@ -61,7 +61,7 @@ public class SMSEMOARunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new RandomSelection<DoubleSolution>();
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/spea2/ParallelSPEA2Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/spea2/ParallelSPEA2Runner.java
@@ -62,7 +62,7 @@ public class ParallelSPEA2Runner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection =
         new BinaryTournamentSelection<DoubleSolution>(

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/spea2/SPEA2Runner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/spea2/SPEA2Runner.java
@@ -65,7 +65,7 @@ public class SPEA2Runner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables();
     double mutationDistributionIndex = 20.0;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex);
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/wasfga/GWASGFARunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/wasfga/GWASGFARunner.java
@@ -56,7 +56,7 @@ public class GWASGFARunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/wasfga/WASFGAMeasuresRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/wasfga/WASFGAMeasuresRunner.java
@@ -66,7 +66,7 @@ public class WASFGAMeasuresRunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/wasfga/WASFGAMeasuresRunner3D.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/multiobjective/wasfga/WASFGAMeasuresRunner3D.java
@@ -67,7 +67,7 @@ public class WASFGAMeasuresRunner3D extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     selection = new BinaryTournamentSelection<DoubleSolution>(new RankingAndCrowdingDistanceComparator<DoubleSolution>());
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/operator/PolynomialMutationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/operator/PolynomialMutationExample.java
@@ -57,7 +57,7 @@ public class PolynomialMutationExample {
     DoubleProblem problem ;
 
     problem = new Sphere(1) ;
-    MutationOperator<DoubleSolution> mutation = new PolynomialMutation(1.0, distributionIndex) ;
+    MutationOperator<DoubleSolution> mutation = PolynomialMutation.createWithDoubleDefaults(1.0, distributionIndex) ;
 
     DoubleSolution solution = problem.createSolution() ;
     solution.setVariable(0, 0.0);

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/singleobjective/DifferentialEvolutionRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/singleobjective/DifferentialEvolutionRunner.java
@@ -53,7 +53,7 @@ public class DifferentialEvolutionRunner {
     }
 
     crossover =
-        new DifferentialEvolutionCrossover(
+        DifferentialEvolutionCrossover.createFromVariant(
             0.5, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
     selection = new DifferentialEvolutionSelection();
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/singleobjective/GenerationalGeneticAlgorithmDoubleEncodingRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/singleobjective/GenerationalGeneticAlgorithmDoubleEncodingRunner.java
@@ -35,7 +35,7 @@ public class GenerationalGeneticAlgorithmDoubleEncodingRunner {
     CrossoverOperator<DoubleSolution> crossover =
             new SBXCrossover(0.9, 20.0) ;
     MutationOperator<DoubleSolution> mutation =
-            new PolynomialMutation(1.0 / problem.getNumberOfVariables(), 20.0) ;
+            PolynomialMutation.createWithDoubleDefaults(1.0 / problem.getNumberOfVariables(), 20.0) ;
     SelectionOperator<List<DoubleSolution>, DoubleSolution> selection = new BinaryTournamentSelection<DoubleSolution>() ;
 
     algorithm = new GeneticAlgorithmBuilder<>(problem, crossover, mutation)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/singleobjective/SMPSORunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/singleobjective/SMPSORunner.java
@@ -45,7 +45,7 @@ public class SMPSORunner extends AbstractAlgorithmRunner {
 
     double mutationProbability = 1.0 / problem.getNumberOfVariables() ;
     double mutationDistributionIndex = 20.0 ;
-    mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex) ;
+    mutation = PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex) ;
 
     algorithm = new SMPSOBuilder(problem, archive)
         .setMutation(mutation)

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/singleobjective/SteadyStateGeneticAlgorithmRunner.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/singleobjective/SteadyStateGeneticAlgorithmRunner.java
@@ -35,7 +35,7 @@ public class SteadyStateGeneticAlgorithmRunner {
     CrossoverOperator<DoubleSolution> crossoverOperator =
         new SBXCrossover(0.9, 20.0) ;
     MutationOperator<DoubleSolution> mutationOperator =
-        new PolynomialMutation(1.0 / problem.getNumberOfVariables(), 20.0) ;
+        PolynomialMutation.createWithDoubleDefaults(1.0 / problem.getNumberOfVariables(), 20.0) ;
     SelectionOperator<List<DoubleSolution>, DoubleSolution> selectionOperator = new BinaryTournamentSelection<DoubleSolution>() ;
 
     algorithm = new GeneticAlgorithmBuilder<DoubleSolution>(problem, crossoverOperator, mutationOperator)

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ConstraintProblemsStudy.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ConstraintProblemsStudy.java
@@ -114,7 +114,7 @@ public class ConstraintProblemsStudy {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 20),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0),
                 100)
                 .setMaxEvaluations(25000)
                 .build();
@@ -125,7 +125,7 @@ public class ConstraintProblemsStudy {
         Algorithm<List<DoubleSolution>> algorithm = new SPEA2Builder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 10.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .build();
         algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));
       }
@@ -135,7 +135,7 @@ public class ConstraintProblemsStudy {
         double mutationDistributionIndex = 20.0;
         Algorithm<List<DoubleSolution>> algorithm = new SMPSOBuilder((DoubleProblem) problemList.get(i).getProblem(),
                 new CrowdingDistanceArchive<DoubleSolution>(100))
-                .setMutation(new PolynomialMutation(mutationProbability, mutationDistributionIndex))
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex))
                 .setMaxIterations(250)
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
@@ -160,7 +160,7 @@ public class ConstraintProblemsStudy {
         Algorithm<List<DoubleSolution>> algorithm = new MOCellBuilder<DoubleSolution>(
                 (DoubleProblem) problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 20.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0))
                 .setSelectionOperator(new BinaryTournamentSelection<>())
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ConstraintProblemsStudy.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ConstraintProblemsStudy.java
@@ -147,7 +147,7 @@ public class ConstraintProblemsStudy {
         double f = 0.5;
 
         Algorithm<List<DoubleSolution>> algorithm = new GDE3Builder((DoubleProblem) problemList.get(i).getProblem())
-                .setCrossover(new DifferentialEvolutionCrossover(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN))
+                .setCrossover(DifferentialEvolutionCrossover.createFromVariant(cr, f, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN))
                 .setSelection(new DifferentialEvolutionSelection())
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/DTLZStudy.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/DTLZStudy.java
@@ -109,7 +109,7 @@ public class DTLZStudy {
         Algorithm<List<DoubleSolution>> algorithm = new SMPSOBuilder(
                 (DoubleProblem) problemList.get(i).getProblem(),
                 new CrowdingDistanceArchive<DoubleSolution>(100))
-                .setMutation(new PolynomialMutation(mutationProbability, mutationDistributionIndex))
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex))
                 .setMaxIterations(250)
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
@@ -121,7 +121,7 @@ public class DTLZStudy {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 20.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0),
                 100)
                 .build();
@@ -132,7 +132,7 @@ public class DTLZStudy {
         Algorithm<List<DoubleSolution>> algorithm = new SPEA2Builder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 10.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0))
                 .build();
         algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/NSGAIIStudy.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/NSGAIIStudy.java
@@ -103,7 +103,7 @@ public class NSGAIIStudy {
             new NSGAIIBuilder<>(
                     problemList.get(i).getProblem(),
                     new SBXCrossover(1.0, 5),
-                    new PolynomialMutation(
+                    PolynomialMutation.createWithDoubleDefaults(
                         1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 10.0),
                     100)
                 .setMaxEvaluations(25000)
@@ -116,7 +116,7 @@ public class NSGAIIStudy {
             new NSGAIIBuilder<>(
                     problemList.get(i).getProblem(),
                     new SBXCrossover(1.0, 20.0),
-                    new PolynomialMutation(
+                    PolynomialMutation.createWithDoubleDefaults(
                         1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 20.0),
                     100)
                 .setMaxEvaluations(25000)
@@ -129,7 +129,7 @@ public class NSGAIIStudy {
             new NSGAIIBuilder<>(
                     problemList.get(i).getProblem(),
                     new SBXCrossover(1.0, 40.0),
-                    new PolynomialMutation(
+                    PolynomialMutation.createWithDoubleDefaults(
                         1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 40.0),
                     10)
                 .setMaxEvaluations(25000)
@@ -142,7 +142,7 @@ public class NSGAIIStudy {
             new NSGAIIBuilder<>(
                     problemList.get(i).getProblem(),
                     new SBXCrossover(1.0, 80.0),
-                    new PolynomialMutation(
+                    PolynomialMutation.createWithDoubleDefaults(
                         1.0 / problemList.get(i).getProblem().getNumberOfVariables(), 80.0),
                     100)
                 .setMaxEvaluations(25000)

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/NSGAIIStudy2.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/NSGAIIStudy2.java
@@ -101,7 +101,7 @@ public class NSGAIIStudy2 {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 5),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         10.0),
                 100)
                 .setMaxEvaluations(25000)
@@ -113,7 +113,7 @@ public class NSGAIIStudy2 {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 20.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0),
                 100)
                 .setMaxEvaluations(25000)
@@ -124,7 +124,7 @@ public class NSGAIIStudy2 {
       for (int i = 0; i < problemList.size(); i++) {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<>(
                 problemList.get(i).getProblem(), new SBXCrossover(1.0, 40.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         40.0),
                 100)
                 .setMaxEvaluations(25000)
@@ -135,7 +135,7 @@ public class NSGAIIStudy2 {
       for (int i = 0; i < problemList.size(); i++) {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<>(
                 problemList.get(i).getProblem(), new SBXCrossover(1.0, 80.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         80.0),
                 100)
                 .setMaxEvaluations(25000)

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/WFGStudy.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/WFGStudy.java
@@ -111,7 +111,7 @@ public class WFGStudy {
         Algorithm<List<DoubleSolution>> algorithm = new SMPSOBuilder(
                 (DoubleProblem) problemList.get(i).getProblem(),
                 new CrowdingDistanceArchive<DoubleSolution>(100))
-                .setMutation(new PolynomialMutation(mutationProbability, mutationDistributionIndex))
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex))
                 .setMaxIterations(250)
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
@@ -123,7 +123,7 @@ public class WFGStudy {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 20.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0),
                 100)
                 .build();
@@ -134,7 +134,7 @@ public class WFGStudy {
         Algorithm<List<DoubleSolution>> algorithm = new SPEA2Builder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 10.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0))
                 .build();
         algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTScalabilityIStudy.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTScalabilityIStudy.java
@@ -107,7 +107,7 @@ public class ZDTScalabilityIStudy {
         Algorithm<List<DoubleSolution>> algorithm = new SMPSOBuilder(
                 (DoubleProblem) problemList.get(i).getProblem(),
                 new CrowdingDistanceArchive<DoubleSolution>(100))
-                .setMutation(new PolynomialMutation(mutationProbability, mutationDistributionIndex))
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex))
                 .setMaxIterations(250)
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
@@ -119,7 +119,7 @@ public class ZDTScalabilityIStudy {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 20.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0),
                 100)
                 .build();
@@ -130,7 +130,7 @@ public class ZDTScalabilityIStudy {
         Algorithm<List<DoubleSolution>> algorithm = new SPEA2Builder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 10.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0))
                 .build();
         algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTScalabilityIStudy2.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTScalabilityIStudy2.java
@@ -111,7 +111,7 @@ public class ZDTScalabilityIStudy2 {
         Algorithm<List<DoubleSolution>> algorithm = new SMPSOBuilder(
                 (DoubleProblem) problemList.get(i).getProblem(),
                 new CrowdingDistanceArchive<DoubleSolution>(100))
-                .setMutation(new PolynomialMutation(mutationProbability, mutationDistributionIndex))
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex))
                 .setMaxIterations(250)
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
@@ -123,7 +123,7 @@ public class ZDTScalabilityIStudy2 {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 20.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0),
                 100)
                 .build();
@@ -134,7 +134,7 @@ public class ZDTScalabilityIStudy2 {
         Algorithm<List<DoubleSolution>> algorithm = new SPEA2Builder<DoubleSolution>(
                 problemList.get(i).getProblem(),
                 new SBXCrossover(1.0, 10.0),
-                new PolynomialMutation(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / problemList.get(i).getProblem().getNumberOfVariables(),
                         20.0))
                 .build();
         algorithms.add(new ExperimentAlgorithm<>(algorithm, problemList.get(i), run));

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTStudy.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTStudy.java
@@ -129,7 +129,7 @@ public class ZDTStudy {
 
       for (var experimentProblem : problemList) {
         Algorithm<List<DoubleSolution>> algorithm = new MOEADBuilder(experimentProblem.getProblem(), MOEADBuilder.Variant.MOEAD)
-                .setCrossover(new DifferentialEvolutionCrossover(1.0, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN))
+                .setCrossover(DifferentialEvolutionCrossover.createFromVariant(1.0, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN))
                 .setMutation(new PolynomialMutation(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
                         20.0))
                 .setMaxEvaluations(25000)

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTStudy.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTStudy.java
@@ -108,7 +108,7 @@ public class ZDTStudy {
         Algorithm<List<DoubleSolution>> algorithm = new SMPSOBuilder(
                 (DoubleProblem) experimentProblem.getProblem(),
                 new CrowdingDistanceArchive<DoubleSolution>(100))
-                .setMutation(new PolynomialMutation(mutationProbability, mutationDistributionIndex))
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex))
                 .setMaxIterations(250)
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
@@ -120,7 +120,7 @@ public class ZDTStudy {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<DoubleSolution>(
                 experimentProblem.getProblem(),
                 new SBXCrossover(1.0, 20.0),
-                new PolynomialMutation(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
                         20.0),
                 100)
                 .build();
@@ -130,7 +130,7 @@ public class ZDTStudy {
       for (var experimentProblem : problemList) {
         Algorithm<List<DoubleSolution>> algorithm = new MOEADBuilder(experimentProblem.getProblem(), MOEADBuilder.Variant.MOEAD)
                 .setCrossover(DifferentialEvolutionCrossover.createFromVariant(1.0, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN))
-                .setMutation(new PolynomialMutation(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
                         20.0))
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTStudy2.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTStudy2.java
@@ -116,7 +116,7 @@ public class ZDTStudy2 {
         Algorithm<List<DoubleSolution>> algorithm = new SMPSOBuilder(
                 (DoubleProblem) experimentProblem.getProblem(),
                 new CrowdingDistanceArchive<DoubleSolution>(100))
-                .setMutation(new PolynomialMutation(mutationProbability, mutationDistributionIndex))
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(mutationProbability, mutationDistributionIndex))
                 .setMaxIterations(250)
                 .setSwarmSize(100)
                 .setSolutionListEvaluator(new SequentialSolutionListEvaluator<DoubleSolution>())
@@ -128,7 +128,7 @@ public class ZDTStudy2 {
         Algorithm<List<DoubleSolution>> algorithm = new NSGAIIBuilder<DoubleSolution>(
                 experimentProblem.getProblem(),
                 new SBXCrossover(1.0, 20.0),
-                new PolynomialMutation(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
+                PolynomialMutation.createWithDoubleDefaults(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
                         20.0),
                 100)
                 .build();
@@ -138,7 +138,7 @@ public class ZDTStudy2 {
       for (ExperimentProblem<DoubleSolution> experimentProblem : problemList) {
         Algorithm<List<DoubleSolution>> algorithm = new MOEADBuilder(experimentProblem.getProblem(), MOEADBuilder.Variant.MOEAD)
                 .setCrossover(DifferentialEvolutionCrossover.createFromVariant(1.0, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN))
-                .setMutation(new PolynomialMutation(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
+                .setMutation(PolynomialMutation.createWithDoubleDefaults(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
                         20.0))
                 .setMaxEvaluations(25000)
                 .setPopulationSize(100)

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTStudy2.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/studies/ZDTStudy2.java
@@ -137,7 +137,7 @@ public class ZDTStudy2 {
 
       for (ExperimentProblem<DoubleSolution> experimentProblem : problemList) {
         Algorithm<List<DoubleSolution>> algorithm = new MOEADBuilder(experimentProblem.getProblem(), MOEADBuilder.Variant.MOEAD)
-                .setCrossover(new DifferentialEvolutionCrossover(1.0, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN))
+                .setCrossover(DifferentialEvolutionCrossover.createFromVariant(1.0, 0.5, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN))
                 .setMutation(new PolynomialMutation(1.0 / experimentProblem.getProblem().getNumberOfVariables(),
                         20.0))
                 .setMaxEvaluations(25000)


### PR DESCRIPTION
# Context

The various classes implemented in jMetal can be more or less complex.
This complexity reflects especially in the number of arguments needed to instantiate them.
To help the user in dealing with this complexity, jMetal classes often implement several constructors.
Each constructor may assign default values to unknown arguments or compute them from the others.

# Problems

Several problems can be highlighted regarding this practice.

Regarding the presentation, we can highlight several limitations:
- Constructors lack expressiveness: all constructors have the same name despite having different arguments.
It may not look like a problem when each constructor just reduces the number of arguments by assigning more default values.
However, when the arguments are simply different, we lack the reason why some arguments are relevant here and not there.
- Constructors must have different types of parameters.
Creating different instances which require the same types of arguments imposes to trick in some way the constructors.
For instance, by changing the order of the arguments to make it look like different types.
Of course, it is at the risk of tricking the user too.

Regarding the content, we can also highlight several limitations:
- Constructors do not allow to have code before another constructor call (`this(...)` or `super(...)`).
Any preliminary computation must be done directly in the call or moved to static methods.
In any case, if several arguments use the same computation, we cannot factor them without using heavy tricks.
- All constructors are strictly bound to the generics of their class.
If we want to generalize a class to expand the possible generic values, we must do so for all the constructors.
For example, generalizing an implementation from `Solution<Double>` to `Solution<? extends Number>`.
As such, constructors which assign default values must generalize these default values too.
In this example, operators on `Double` must be generalized to operators on `Number`.
Although it may be easy for some basic values, generalization can become infeasible or tricky.

# Solution

Rather than using constructors, we should use static factory methods.
Constructors should only require all the arguments, with no default value.
Ideally, there should have only one constructor.

For example, instead of having:
```java
new DifferentialEvolutionCrossover();
new DifferentialEvolutionCrossover(CR, F, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
```

we have:
```java
DifferentialEvolutionCrossover.createDefault();
DifferentialEvolutionCrossover.createFromVariant(CR, F, DifferentialEvolutionCrossover.DE_VARIANT.RAND_1_BIN);
```

In this PR, I create the static factory methods but only deprecate the constructors.
This way nothing breaks and users get warnings to suggest updates.
However, I already do all the replacements in jMetal, so it is only useful for jMetal users.
If you think these constructors are not needed anymore, feel free to remove them or ask me to do so here.

I apply this pattern to the following classes:
- DifferentialCrossoverVariation
- DifferentialEvolutionCrossover
- PolynomialMutation
- MOEADDE

The PR is split in different commits for readability, so each class as a commit to:
- create its static factory methods
- replace its constructor calls

If you review the changes, you can do it by commit to keep it simple.

The focus on these classes is because I am working on them for the generalization process (#406).
By accepting these changes, I will be able to consider the constructors as relic of the past.
This way, I can just use simple tricks on them rather than add complexity to generalize them properly.
If we remove them, I won't have to care about them at all.

Other classes are expected to be generalized in #406.
If this PR is accepted, expect future PRs for other classes as well.

# Discussion

Static factory methods do solve the problems highlighted:
- Static factory methods can be named as needed, as opposed to constructors.
- Because of that, we can have the same types of parameters as much as we want.
We only need to choose a different name, preferably which highlight the actual difference.
- Static factory methods can do all the computation they want before to instantiate the class.
- Because of being static, they are not bound to the generic value of the class.
Each static factory method can specialize on a specific generic value.
When generalizing the class, the existing static factory methods can just remain how they are and new ones be added.

Additionally, if there are many static factory methods, you can create a separate factory class to lighten the class.
If the factory methods combinations are numerous, it can naturally evolve to a builder class.

However, there is a limit: the instances returned by static factory methods cannot be overriden.
When calling a constructor, you can also decide to override some of its methods at the same time.
But once the static factory method returns, the instance is already created.
But the same result can be achieved by using wrapper classes, like [decorators](https://en.wikipedia.org/wiki/Decorator_pattern) or [proxies](https://en.wikipedia.org/wiki/Proxy_pattern).
So it is not a blocking limitation, rather a different habit.

Although different, static factory methods can be compared to the [abstract factory pattern](https://en.wikipedia.org/wiki/Abstract_factory_pattern).
We could say it is like a "non abstract" abstract factory pattern, since we implement them immediately.
However, it should not be mixed with the [factory method pattern](https://en.wikipedia.org/wiki/Factory_method_pattern).
This one is about providing *to the class* a factory method to *instantiate a component* used in the class.
Here we provide a way to *instantiate the class* to *the user*, so we go the other way around.

You can find a more extensive description of the static factory methods in [an article of Joshua Bloch](https://www.drdobbs.com/jvm/creating-and-destroying-java-objects-par/208403883).
Some points are not relevant anymore (it was written for Java 6), but it draws additional advantages and inconvenients.