### PR TITLE
Making Random Generator Serializable

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/util/pseudorandom/BoundedRandomGenerator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/pseudorandom/BoundedRandomGenerator.java
@@ -1,5 +1,7 @@
 package org.uma.jmetal.util.pseudorandom;
 
+import java.io.Serializable;
+
 /**
  * A {@link BoundedRandomGenerator} aims to provide a random value within a
  * specific range. The range is inclusive, such that the lower bound and upper
@@ -17,7 +19,7 @@ package org.uma.jmetal.util.pseudorandom;
  *            The type of value to generate
  */
 @FunctionalInterface
-public interface BoundedRandomGenerator<Value extends Comparable<Value>> {
+public interface BoundedRandomGenerator<Value extends Comparable<Value>> extends Serializable {
 	/**
 	 * Generate a random value within the provided range.
 	 * 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/pseudorandom/RandomGenerator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/pseudorandom/RandomGenerator.java
@@ -1,5 +1,6 @@
 package org.uma.jmetal.util.pseudorandom;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,7 +20,7 @@ import java.util.function.Predicate;
  *            The type of value to generate
  */
 @FunctionalInterface
-public interface RandomGenerator<Value> {
+public interface RandomGenerator<Value> extends Serializable {
 	/**
 	 * Generate a random value.
 	 * 

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,9 +148,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
The title is pretty much self-explanatory. Almost all jMetal classes are Serializable, but the Random Generator class is not. Thus it is impossible to serialise classes that use a Random Generator object.