### PR TITLE
Generalyze Solution extensions

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2007.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2007.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.ObjectiveComparator;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
+import org.uma.jmetal.util.metadata.Metadata ;
 import org.uma.jmetal.util.neighborhood.impl.AdaptiveRandomNeighborhood;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.solutionattribute.impl.GenericSolutionAttribute;
@@ -41,6 +42,8 @@ public class StandardPSO2007 extends AbstractParticleSwarmOptimization<DoubleSol
   private double c;
   private JMetalRandom randomGenerator = JMetalRandom.getInstance();
   private DoubleSolution bestFoundParticle;
+  
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
 
   private int objectiveId;
 
@@ -148,8 +151,9 @@ public class StandardPSO2007 extends AbstractParticleSwarmOptimization<DoubleSol
   public void initializeVelocity(List<DoubleSolution> swarm) {
     for (int i = 0; i < swarm.size(); i++) {
       DoubleSolution particle = swarm.get(i);
+      List<Bounds<Double>> boundsList = boundsMetadata.read(particle) ;
       for (int j = 0; j < problem.getNumberOfVariables(); j++) {
-        Bounds<Double> bounds = particle.getBounds(j) ;
+        Bounds<Double> bounds = boundsList.get(j) ;
         speed[i][j] =
                 (randomGenerator.nextDouble(bounds.getLowerBound(), bounds.getUpperBound())
                         - particle.getVariable(j)) / 2.0;

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2011.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2011.java
@@ -9,6 +9,7 @@ import org.uma.jmetal.util.SolutionUtils;
 import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.ObjectiveComparator;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
+import org.uma.jmetal.util.metadata.Metadata ;
 import org.uma.jmetal.util.neighborhood.impl.AdaptiveRandomNeighborhood;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.impl.ExtendedPseudoRandomGenerator;
@@ -45,6 +46,8 @@ public class StandardPSO2011 extends AbstractParticleSwarmOptimization<DoubleSol
   private JMetalRandom randomGenerator ;
   private DoubleSolution bestFoundParticle;
   private double changeVelocity;
+  
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
 
   private int objectiveId;
 
@@ -156,8 +159,9 @@ public class StandardPSO2011 extends AbstractParticleSwarmOptimization<DoubleSol
   public void initializeVelocity(List<DoubleSolution> swarm) {
     for (int i = 0; i < swarmSize; i++) {
       DoubleSolution particle = swarm.get(i);
+      List<Bounds<Double>> boundsList = boundsMetadata.read(particle) ;
       for (int j = 0; j < problem.getNumberOfVariables(); j++) {
-        Bounds<Double> bounds = particle.getBounds(j) ;
+        Bounds<Double> bounds = boundsList.get(j) ;
         speed[i][j] = (randomGenerator.nextDouble(
                 bounds.getLowerBound() - particle.getVariable(0),
                 bounds.getUpperBound() - particle.getVariable(0)));

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/BLXAlphaCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/BLXAlphaCrossover.java
@@ -7,6 +7,7 @@ import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWith
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -25,6 +26,7 @@ public class BLXAlphaCrossover implements CrossoverOperator<DoubleSolution> {
   private double crossoverProbability;
   private double alpha ;
 
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
   private RepairDoubleSolution solutionRepair ;
 
   private RandomGenerator<Double> randomGenerator ;
@@ -104,8 +106,9 @@ public class BLXAlphaCrossover implements CrossoverOperator<DoubleSolution> {
     double lowerBound;
 
     if (randomGenerator.getRandomValue() <= probability) {
+      List<Bounds<Double>> boundsList = boundsMetadata.read(parent1);
       for (i = 0; i < parent1.getNumberOfVariables(); i++) {
-        Bounds<Double> bounds = parent1.getBounds(i);
+        Bounds<Double> bounds = boundsList.get(i);
         upperBound = bounds.getUpperBound();
         lowerBound = bounds.getLowerBound();
         valueX1 = parent1.getVariable(i);

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
@@ -7,6 +7,7 @@ import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWith
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.BoundedRandomGenerator;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
@@ -76,6 +77,7 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
   private BoundedRandomGenerator<Integer> jRandomGenerator;
   private BoundedRandomGenerator<Double> crRandomGenerator;
 
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
   private RepairDoubleSolution solutionRepair;
 
   /** Constructor */
@@ -414,11 +416,12 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
   }
 
   private void repairVariableValues(DoubleSolution solution) {
+    List<Bounds<Double>> boundsList = boundsMetadata.read(solution);
     IntStream.range(0, solution.getNumberOfVariables())
         .forEach(
             i ->
                 {
-                  Bounds<Double> bounds = solution.getBounds(i);
+                  Bounds<Double> bounds = boundsList.get(i);
                   solution.setVariable(
                       i,
                       solutionRepair.repairSolutionVariableValue(

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/SBXCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/SBXCrossover.java
@@ -7,6 +7,7 @@ import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWith
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -31,6 +32,7 @@ public class SBXCrossover implements CrossoverOperator<DoubleSolution> {
 
   private double distributionIndex ;
   private double crossoverProbability  ;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
   private RepairDoubleSolution solutionRepair ;
 
   private RandomGenerator<Double> randomGenerator ;
@@ -109,6 +111,7 @@ public class SBXCrossover implements CrossoverOperator<DoubleSolution> {
     double valueX1, valueX2;
 
     if (randomGenerator.getRandomValue() <= probability) {
+      List<Bounds<Double>> boundsList = boundsMetadata.read(parent1);
       for (i = 0; i < parent1.getNumberOfVariables(); i++) {
         valueX1 = parent1.getVariable(i);
         valueX2 = parent2.getVariable(i);
@@ -122,7 +125,7 @@ public class SBXCrossover implements CrossoverOperator<DoubleSolution> {
               y2 = valueX1;
             }
 
-            Bounds<Double> bounds = parent1.getBounds(i);
+            Bounds<Double> bounds = boundsList.get(i);
             lowerBound = bounds.getLowerBound();
             upperBound = bounds.getUpperBound();
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/CDGMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/CDGMutation.java
@@ -13,6 +13,8 @@
 
 package org.uma.jmetal.operator.mutation.impl;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
@@ -20,6 +22,7 @@ import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 /**
@@ -39,6 +42,7 @@ public class CDGMutation implements MutationOperator<DoubleSolution> {
   private static final double DEFAULT_DELTA = 0.5 ;
   private double delta ;
   private double mutationProbability ;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
   private RepairDoubleSolution solutionRepair ;
 
   private JMetalRandom randomGenerator ;
@@ -107,11 +111,12 @@ public class CDGMutation implements MutationOperator<DoubleSolution> {
   private void doMutation(double probability, DoubleSolution solution) {
     double rnd, deltaq, tempDelta;
     double y, yl, yu;
+    List<Bounds<Double>> boundsList = boundsMetadata.read(solution);
 
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenerator.nextDouble() <= probability) {
         y = solution.getVariable(i);
-        Bounds<Double> bounds = solution.getBounds(i);
+        Bounds<Double> bounds = boundsList.get(i);
         yl = bounds.getLowerBound() ;
         yu = bounds.getUpperBound() ;
         rnd = randomGenerator.nextDouble();

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/NonUniformMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/NonUniformMutation.java
@@ -1,9 +1,12 @@
 package org.uma.jmetal.operator.mutation.impl;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -21,6 +24,7 @@ public class NonUniformMutation implements MutationOperator<DoubleSolution> {
 
   private int currentIteration;
   private RandomGenerator<Double> randomGenenerator ;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
 
   /** Constructor */
   public NonUniformMutation(double mutationProbability, double perturbation, int maxIterations) {
@@ -93,12 +97,13 @@ public class NonUniformMutation implements MutationOperator<DoubleSolution> {
    * @param solution    The solution to mutate
    */
   public void doMutation(double probability, DoubleSolution solution){
+    List<Bounds<Double>> boundsList = boundsMetadata.read(solution);
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenenerator.getRandomValue() < probability) {
         double rand = randomGenenerator.getRandomValue();
         double tmp;
 
-        Bounds<Double> bounds = solution.getBounds(i);
+        Bounds<Double> bounds = boundsList.get(i);
         if (rand <= 0.5) {
           tmp = delta(bounds.getUpperBound() - solution.getVariable(i),
               perturbation);

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/PolynomialMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/PolynomialMutation.java
@@ -1,5 +1,7 @@
 package org.uma.jmetal.operator.mutation.impl;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
@@ -8,6 +10,7 @@ import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWith
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -29,6 +32,7 @@ public class PolynomialMutation implements MutationOperator<DoubleSolution> {
   private static final double DEFAULT_DISTRIBUTION_INDEX = 20.0;
   private double distributionIndex;
   private double mutationProbability;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
   private RepairDoubleSolution solutionRepair;
 
   private RandomGenerator<Double> randomGenerator;
@@ -175,11 +179,12 @@ public class PolynomialMutation implements MutationOperator<DoubleSolution> {
   private void doMutation(DoubleSolution solution) {
     double rnd, delta1, delta2, mutPow, deltaq;
     double y, yl, yu, val, xy;
+    List<Bounds<Double>> boundsList = boundsMetadata.read(solution);
 
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenerator.getRandomValue() <= mutationProbability) {
         y = solution.getVariable(i);
-        Bounds<Double> bounds = solution.getBounds(i);
+        Bounds<Double> bounds = boundsList.get(i);
         yl = bounds.getLowerBound();
         yu = bounds.getUpperBound();
         if (yl == yu) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/SimpleRandomMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/SimpleRandomMutation.java
@@ -1,9 +1,12 @@
 package org.uma.jmetal.operator.mutation.impl;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -16,6 +19,7 @@ import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 public class SimpleRandomMutation implements MutationOperator<DoubleSolution> {
   private double mutationProbability;
   private RandomGenerator<Double> randomGenerator;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
 
   /** Constructor */
   public SimpleRandomMutation(double probability) {
@@ -57,9 +61,10 @@ public class SimpleRandomMutation implements MutationOperator<DoubleSolution> {
 
   /** Implements the mutation operation */
   private void doMutation(double probability, DoubleSolution solution) {
+    List<Bounds<Double>> boundsList = boundsMetadata.read(solution);
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenerator.getRandomValue() <= probability) {
-        Bounds<Double> bounds = solution.getBounds(i);
+        Bounds<Double> bounds = boundsList.get(i);
         Double lowerBound = bounds.getLowerBound();
         Double upperBound = bounds.getUpperBound();
         Double randomValue = randomGenerator.getRandomValue();

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/UniformMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/UniformMutation.java
@@ -1,11 +1,14 @@
 package org.uma.jmetal.operator.mutation.impl;
 
+import java.util.List;
+
 import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -20,6 +23,7 @@ public class UniformMutation implements MutationOperator<DoubleSolution> {
   private double perturbation;
   private Double mutationProbability = null;
   private RandomGenerator<Double> randomGenerator;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
   private RepairDoubleSolution solutionRepair;
 
   /** Constructor */
@@ -78,6 +82,7 @@ public class UniformMutation implements MutationOperator<DoubleSolution> {
    * @param solution The solution to mutate
    */
   public void doMutation(double probability, DoubleSolution solution) {
+    List<Bounds<Double>> boundsList = boundsMetadata.read(solution);
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenerator.getRandomValue() < probability) {
         double rand = randomGenerator.getRandomValue();
@@ -85,7 +90,7 @@ public class UniformMutation implements MutationOperator<DoubleSolution> {
 
         tmp += solution.getVariable(i);
 
-        Bounds<Double> bounds = solution.getBounds(i);
+        Bounds<Double> bounds = boundsList.get(i);
         tmp =
             solutionRepair.repairSolutionVariableValue(
                 tmp, bounds.getLowerBound(), bounds.getUpperBound());

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/doublesolution/DoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/doublesolution/DoubleSolution.java
@@ -1,7 +1,13 @@
 package org.uma.jmetal.solution.doublesolution;
 
+import static java.util.stream.Collectors.*;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.bounds.Bounds;
+import org.uma.jmetal.util.metadata.Metadata;
 
 /**
  * Interface representing a double solutions
@@ -33,5 +39,16 @@ public interface DoubleSolution extends Solution<Double> {
     Double lowerBound = solution.getLowerBound(index);
     Double upperBound = solution.getUpperBound(index);
     return Bounds.create(lowerBound, upperBound);
+  }
+  
+  /**
+   * {@link Metadata} implementation for {@link #getBounds(int)}.
+   * 
+   * @return the {@link Metadata}
+   */
+  public static Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata() {
+    return solution -> IntStream.range(0, solution.getNumberOfVariables())//
+        .mapToObj(solution::getBounds)//
+        .collect(toList());
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/doublesolution/DoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/doublesolution/DoubleSolution.java
@@ -33,7 +33,10 @@ public interface DoubleSolution extends Solution<Double> {
    * same index may be counter productive in this case. This methods allows to
    * offer this optimization, although its default implementation just delegates
    * to the separate methods.
+   * 
+   * @deprecated Use {@link Metadata} for additional attributes of {@link Solution} or variables.
    */
+  @Deprecated
   default Bounds<Double> getBounds(int index) {
     DoubleSolution solution = this;
     Double lowerBound = solution.getLowerBound(index);

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/metadata/Metadata.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/metadata/Metadata.java
@@ -1,0 +1,9 @@
+package org.uma.jmetal.util.metadata;
+
+public interface Metadata<S, V> {
+  V read(S source);
+  
+  interface RW<S, V> extends Metadata<S, V> {
+    void write(S source, V value);
+  }
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/metadata/impl/CompositeMetadata.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/metadata/impl/CompositeMetadata.java
@@ -1,0 +1,53 @@
+package org.uma.jmetal.util.metadata.impl;
+
+import static java.util.function.Function.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.uma.jmetal.util.metadata.Metadata;
+
+public class CompositeMetadata<S, V> implements Metadata<S, V> {
+
+  private final Map<Predicate<S>, Metadata<S, V>> components = new LinkedHashMap<>();
+  private final Metadata<S, V> defautMetadata;
+
+  public CompositeMetadata(Metadata<S, V> defautMetadata) {
+    this.defautMetadata = defautMetadata;
+  }
+
+  public CompositeMetadata() {
+    this(source -> {
+      throw new IllegalArgumentException("No metadata for " + source);
+    });
+  }
+
+  public void put(Predicate<S> predicate, Metadata<S, V> metadata) {
+    components.put(predicate, metadata);
+  }
+
+  public <T, U> void put(Predicate<S> predicate, Function<S, T> transformSource, Metadata<T, U> metadata, Function<U, V> transformValue) {
+    put(predicate, transformSource.andThen(metadata::read).andThen(transformValue)::apply);
+  }
+
+  public <T> void put(Predicate<S> predicate, Function<S, T> transformSource, Metadata<T, V> metadata) {
+    put(predicate, transformSource, metadata, identity());
+  }
+
+  public <T> void put(Predicate<S> predicate, Metadata<S, T> metadata, Function<T, V> transformValue) {
+    put(predicate, identity(), metadata, transformValue);
+  }
+
+  @Override
+  public V read(S source) {
+    return components.entrySet().stream()//
+        .filter(entry -> entry.getKey().test(source))//
+        .map(entry -> entry.getValue())//
+        .findFirst()//
+        .orElse(defautMetadata)//
+        .read(source);
+  }
+
+}

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/metadata/impl/SolutionAttributeMetadata.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/metadata/impl/SolutionAttributeMetadata.java
@@ -1,0 +1,28 @@
+package org.uma.jmetal.util.metadata.impl;
+
+import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.util.metadata.Metadata;
+
+public class SolutionAttributeMetadata<S extends Solution<?>, V> implements Metadata.RW<S, V> {
+
+  private final String valueName;
+
+  public SolutionAttributeMetadata(String valueName) {
+    this.valueName = valueName;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public V read(S solution) {
+    V value = (V) solution.getAttribute(this);
+    if (value == null) {
+      throw new IllegalStateException("No " + valueName + " in attributes of " + solution);
+    }
+    return value;
+  }
+
+  @Override
+  public void write(S solution, V value) {
+    solution.setAttribute(this, value);
+  }
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/BLXAlphaCrossoverTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/BLXAlphaCrossoverTest.java
@@ -14,6 +14,7 @@ import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.exception.InvalidConditionException;
 import org.uma.jmetal.util.checking.exception.NullParameterException;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 import org.uma.jmetal.util.pseudorandom.impl.AuditableRandomGenerator;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.*;
  */
 public class BLXAlphaCrossoverTest {
   private static final double EPSILON = 0.00000000000001 ;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
 
   @Test
   public void shouldConstructorAssignTheCorrectProbabilityValue() {
@@ -149,8 +151,8 @@ public class BLXAlphaCrossoverTest {
 
     List<DoubleSolution> newSolutions = crossover.execute(solutions) ;
 
-    Bounds<Double> bounds0 = solutions.get(0).getBounds(0);
-    Bounds<Double> bounds1 = solutions.get(1).getBounds(0);
+    Bounds<Double> bounds0 = boundsMetadata.read(solutions.get(0)).get(0);
+    Bounds<Double> bounds1 = boundsMetadata.read(solutions.get(1)).get(0);
     assertThat(newSolutions.get(0).getVariable(0), Matchers
         .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(0), Matchers
@@ -210,8 +212,8 @@ public class BLXAlphaCrossoverTest {
 
     List<DoubleSolution> newSolutions = crossover.execute(solutions) ;
 
-    Bounds<Double> bounds0 = solutions.get(0).getBounds(0);
-    Bounds<Double> bounds1 = solutions.get(1).getBounds(0);
+    Bounds<Double> bounds0 = boundsMetadata.read(solutions.get(0)).get(0);
+    Bounds<Double> bounds1 = boundsMetadata.read(solutions.get(1)).get(0);
     assertThat(newSolutions.get(0).getVariable(0), Matchers
         .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(0), Matchers

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/SBXCrossoverTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/SBXCrossoverTest.java
@@ -14,6 +14,7 @@ import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.exception.InvalidConditionException;
 import org.uma.jmetal.util.checking.exception.InvalidProbabilityValueException;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 import org.uma.jmetal.util.pseudorandom.impl.AuditableRandomGenerator;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.*;
  */
 public class SBXCrossoverTest {
   private static final double EPSILON = 0.00000000000001 ;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
 
   @Test
   public void shouldConstructorAssignTheCorrectProbabilityValue() {
@@ -145,8 +147,8 @@ public class SBXCrossoverTest {
 
     List<DoubleSolution> newSolutions = crossover.execute(solutions) ;
 
-    Bounds<Double> bounds0 = solutions.get(0).getBounds(0);
-    Bounds<Double> bounds1 = solutions.get(1).getBounds(0);
+    Bounds<Double> bounds0 = boundsMetadata.read(solutions.get(0)).get(0);
+    Bounds<Double> bounds1 = boundsMetadata.read(solutions.get(1)).get(0);
     assertThat(newSolutions.get(0).getVariable(0), Matchers
         .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(0), Matchers
@@ -206,8 +208,8 @@ public class SBXCrossoverTest {
 
     List<DoubleSolution> newSolutions = crossover.execute(solutions) ;
 
-    Bounds<Double> bounds0 = solutions.get(0).getBounds(0);
-    Bounds<Double> bounds1 = solutions.get(1).getBounds(0);
+    Bounds<Double> bounds0 = boundsMetadata.read(solutions.get(0)).get(0);
+    Bounds<Double> bounds1 = boundsMetadata.read(solutions.get(1)).get(0);
     assertThat(newSolutions.get(0).getVariable(0), Matchers
         .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(0), Matchers

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/PolynomialMutationTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/PolynomialMutationTest.java
@@ -15,6 +15,7 @@ import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.exception.InvalidConditionException;
 import org.uma.jmetal.util.checking.exception.InvalidProbabilityValueException;
 import org.uma.jmetal.util.checking.exception.NullParameterException;
+import org.uma.jmetal.util.metadata.Metadata;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 import org.uma.jmetal.util.pseudorandom.impl.AuditableRandomGenerator;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.*;
  */
 public class PolynomialMutationTest {
   private static final double EPSILON = 0.00000000000001 ;
+  private final Metadata<DoubleSolution, List<Bounds<Double>>> boundsMetadata = DoubleSolution.boundsMetadata();
   
   @Test
   public void shouldConstructorWithoutParameterAssignTheDefaultValues() {
@@ -165,7 +167,7 @@ public class PolynomialMutationTest {
 
     mutation.execute(solution) ;
 
-    Bounds<Double> bounds = solution.getBounds(0);
+    Bounds<Double> bounds = boundsMetadata.read(solution).get(0);
     assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(bounds.getLowerBound()));
     assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(bounds.getUpperBound())) ;
     verify(randomGenerator, times(2)).getRandomValue();
@@ -188,7 +190,7 @@ public class PolynomialMutationTest {
 
     mutation.execute(solution) ;
 
-    Bounds<Double> bounds = solution.getBounds(0);
+    Bounds<Double> bounds = boundsMetadata.read(solution).get(0);
     assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(bounds.getLowerBound())) ;
     assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(bounds.getUpperBound())) ;
     verify(randomGenerator, times(2)).getRandomValue();


### PR DESCRIPTION
Aim to address the first section of #411 on a specific `Solution` extension. Here are the available extensions and the number of references found by Eclipse:
- BinarySolution (502 references)
- DoubleSolution (3 563 references)
- IntegerSolution (485 references)
- IntegerDoubleSolution [deprecated] (22 references)
- PermutationSolution (85 references)
- SequenceSolution (4 references)

I don't ignore IntegerDoubleSolution although it is already deprecated.
We will need to confirm that nothing active (not deprecated) uses it.

The references do not count the references of the specific implementations.
It looked to me that we mainly use interfaces, so let's rely on that here.

Since they all add 1 or 2 methods, they are comparable in terms of refactoring efforts.
The number of references thus gives a reliable idea of their priority.
Since DoubleSolution is by far the most used, I will start by this one to cover as much use cases as possible.

The first step is to simplify the types hierarchy by replacing `DoubleSolution` by the generic interface `Solution<Double>`. We can rely on its attributes to store additional data:
- [x] Create a Metadata interface to read/write additional values from/in solutions, like this one : https://github.com/jMetal/jMetal/commit/ed79bba42a9bf11a83aa347eb9a1072e870b3372
- [x] Provide a Metadata implementation for `DoubleSolution.getBounds()`, like here for legacy lower/upper bounds: https://github.com/jMetal/jMetal/commit/1215981aaaa534fd37aa7b4b16c21ed37ee6bbac
- [ ] Progressively refactor all the components to use the Metadata objects instead of the `Solution` method, using these implementation by default. As discussed earlier, I will favor factory methods over constructors.
- [ ] After having no specific dependency anymore, replace all the `DoubleSolution` by the more generic `Solution<Double>`