### PR TITLE
Factor bounds

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSS.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSS.java
@@ -9,6 +9,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.SolutionUtils;
 import org.uma.jmetal.util.archive.Archive;
 import org.uma.jmetal.util.archive.impl.CrowdingDistanceArchive;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.CrowdingDistanceComparator;
 import org.uma.jmetal.util.comparator.DominanceComparator;
 import org.uma.jmetal.util.comparator.EqualSolutionsComparator;
@@ -151,11 +152,11 @@ public class ABYSS extends AbstractScatterSearch<DoubleSolution, List<DoubleSolu
       frequency[range][i]++;
       sumOfFrequencyValues[i]++;
 
-      double low = ((DoubleProblem)problem).getLowerBound(i) + range *
-          (((DoubleProblem)problem).getUpperBound(i) -
-              ((DoubleProblem)problem).getLowerBound(i)) / numberOfSubRanges;
-      double high = low + (((DoubleProblem)problem).getUpperBound(i) -
-          ((DoubleProblem)problem).getLowerBound(i)) / numberOfSubRanges;
+      Bounds<Double> bounds = ((DoubleProblem)problem).getBoundsForVariables().get(i) ;
+      Double lowerBound = bounds.getLowerBound() ;
+      Double upperBound = bounds.getUpperBound() ;
+      double low = lowerBound + range * (upperBound - lowerBound) / numberOfSubRanges ;
+      double high = low + (upperBound - lowerBound) / numberOfSubRanges ;
 
       value = randomGenerator.nextDouble(low, high);
       solution.setVariable(i, value);

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/dmopso/DMOPSO.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/dmopso/DMOPSO.java
@@ -4,6 +4,7 @@ import org.uma.jmetal.algorithm.Algorithm;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.evaluator.impl.SequentialSolutionListEvaluator;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
@@ -122,8 +123,8 @@ public class DMOPSO implements Algorithm<List<DoubleSolution>> {
     deltaMax = new double[problem.getNumberOfVariables()];
     deltaMin = new double[problem.getNumberOfVariables()];
     for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      deltaMax[i] = (problem.getUpperBound(i) -
-              problem.getLowerBound(i)) / 2.0;
+      Bounds<Double> bounds = problem.getBoundsForVariables().get(i) ;
+      deltaMax[i] = (bounds.getUpperBound() - bounds.getLowerBound()) / 2.0 ;
       deltaMin[i] = -deltaMax[i];
     }
   }
@@ -398,12 +399,15 @@ public class DMOPSO implements Algorithm<List<DoubleSolution>> {
     DoubleSolution particle = getSwarm().get(part) ;
 
     for(int var = 0; var < particle.getNumberOfVariables(); var++){
-      if (particle.getVariable(var) < problem.getLowerBound(var)) {
-        particle.setVariable(var, problem.getLowerBound(var));
+      Bounds<Double> bounds = problem.getBoundsForVariables().get(var) ;
+      Double lowerBound = bounds.getLowerBound() ;
+      Double upperBound = bounds.getUpperBound() ;
+      if (particle.getVariable(var) < lowerBound) {
+        particle.setVariable(var, lowerBound);
         speed[part][var] = speed[part][var] * changeVelocity1;
       }
-      if (particle.getVariable(var) > problem.getUpperBound(var)) {
-        particle.setVariable(var, problem.getUpperBound(var));
+      if (particle.getVariable(var) > upperBound) {
+        particle.setVariable(var, upperBound);
         speed[part][var] = speed[part][var] * changeVelocity2;
       }
     }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/omopso/OMOPSO.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/omopso/OMOPSO.java
@@ -7,6 +7,7 @@ import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.archive.impl.CrowdingDistanceArchive;
 import org.uma.jmetal.util.archive.impl.NonDominatedSolutionListArchive;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.CrowdingDistanceComparator;
 import org.uma.jmetal.util.comparator.DominanceComparator;
 import org.uma.jmetal.util.comparator.EpsilonDominanceComparator;
@@ -179,12 +180,15 @@ public class OMOPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Li
       DoubleSolution particle = swarm.get(i);
       for (int var = 0; var < particle.getNumberOfVariables(); var++) {
         particle.setVariable(var, particle.getVariable(var) + speed[i][var]);
-        if (particle.getVariable(var) < problem.getLowerBound(var)) {
-          particle.setVariable(var, problem.getLowerBound(var));
+        Bounds<Double> bounds = problem.getBoundsForVariables().get(var) ;
+        Double lowerBound = bounds.getLowerBound() ;
+        Double upperBound = bounds.getUpperBound() ;
+        if (particle.getVariable(var) < lowerBound) {
+          particle.setVariable(var, lowerBound);
           speed[i][var] = speed[i][var] * -1.0;
         }
-        if (particle.getVariable(var) > problem.getUpperBound(var)) {
-          particle.setVariable(var, problem.getUpperBound(var));
+        if (particle.getVariable(var) > upperBound) {
+          particle.setVariable(var, upperBound);
           speed[i][var] = speed[i][var] * -1.0;
         }
       }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSO.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSO.java
@@ -5,6 +5,7 @@ import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.archive.BoundedArchive;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.DominanceComparator;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
@@ -94,7 +95,8 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
     deltaMax = new double[problem.getNumberOfVariables()];
     deltaMin = new double[problem.getNumberOfVariables()];
     for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      deltaMax[i] = (problem.getUpperBound(i) - problem.getLowerBound(i)) / 2.0;
+      Bounds<Double> bounds = problem.getBoundsForVariables().get(i) ;
+      deltaMax[i] = (bounds.getUpperBound() - bounds.getLowerBound()) / 2.0;
       deltaMin[i] = -deltaMax[i];
     }
   }
@@ -199,12 +201,15 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
       for (int j = 0; j < particle.getNumberOfVariables(); j++) {
         particle.setVariable(j, particle.getVariable(j) + speed[i][j]);
 
-        if (particle.getVariable(j) < problem.getLowerBound(j)) {
-          particle.setVariable(j, problem.getLowerBound(j));
+        Bounds<Double> bounds = problem.getBoundsForVariables().get(j) ;
+        Double lowerBound = bounds.getLowerBound() ;
+        Double upperBound = bounds.getUpperBound() ;
+        if (particle.getVariable(j) < lowerBound) {
+          particle.setVariable(j, lowerBound);
           speed[i][j] = speed[i][j] * changeVelocity1;
         }
-        if (particle.getVariable(j) > problem.getUpperBound(j)) {
-          particle.setVariable(j, problem.getUpperBound(j));
+        if (particle.getVariable(j) > upperBound) {
+          particle.setVariable(j, upperBound);
           speed[i][j] = speed[i][j] * changeVelocity2;
         }
       }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSORP.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/smpso/SMPSORP.java
@@ -19,6 +19,7 @@ import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.archive.BoundedArchive;
 import org.uma.jmetal.util.archivewithreferencepoint.ArchiveWithReferencePoint;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.DominanceComparator;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.measure.Measurable;
@@ -128,7 +129,8 @@ public class SMPSORP
     deltaMax = new double[problem.getNumberOfVariables()];
     deltaMin = new double[problem.getNumberOfVariables()];
     for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      deltaMax[i] = (problem.getUpperBound(i) - problem.getLowerBound(i)) / 2.0;
+      Bounds<Double> bounds = problem.getBoundsForVariables().get(i) ;
+      deltaMax[i] = (bounds.getUpperBound() - bounds.getLowerBound()) / 2.0;
       deltaMin[i] = -deltaMax[i];
     }
 
@@ -249,12 +251,15 @@ public class SMPSORP
       for (int j = 0; j < particle.getNumberOfVariables(); j++) {
         particle.setVariable(j, particle.getVariable(j) + speed[i][j]);
 
-        if (particle.getVariable(j) < problem.getLowerBound(j)) {
-          particle.setVariable(j, problem.getLowerBound(j));
+        Bounds<Double> bounds = problem.getBoundsForVariables().get(j) ;
+        Double lowerBound = bounds.getLowerBound() ;
+        Double upperBound = bounds.getUpperBound() ;
+        if (particle.getVariable(j) < lowerBound) {
+          particle.setVariable(j, lowerBound);
           speed[i][j] = speed[i][j] * changeVelocity1;
         }
-        if (particle.getVariable(j) > problem.getUpperBound(j)) {
-          particle.setVariable(j, problem.getUpperBound(j));
+        if (particle.getVariable(j) > upperBound) {
+          particle.setVariable(j, upperBound);
           speed[i][j] = speed[i][j] * changeVelocity2;
         }
       }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/evolutionstrategy/CovarianceMatrixAdaptationEvolutionStrategy.java
@@ -5,6 +5,7 @@ import org.uma.jmetal.algorithm.singleobjective.evolutionstrategy.util.CMAESUtil
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.ObjectiveComparator;
 
 import java.util.*;
@@ -509,11 +510,8 @@ public class CovarianceMatrixAdaptationEvolutionStrategy
       }
 
       double value = distributionMean[i] + sigma * sum;
-      if (value > ((DoubleProblem)getProblem()).getUpperBound(i)) {
-        value = ((DoubleProblem)getProblem()).getUpperBound(i);
-      } else if (value < ((DoubleProblem)getProblem()).getLowerBound(i)) {
-        value = ((DoubleProblem)getProblem()).getLowerBound(i);
-      }
+      Bounds<Double> bounds = ((DoubleProblem)getProblem()).getBoundsForVariables().get(i) ;
+      value = bounds.restrict(value);
 
       solution.setVariable(i, value);
     }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2007.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2007.java
@@ -5,6 +5,7 @@ import org.uma.jmetal.operator.Operator;
 import org.uma.jmetal.operator.selection.impl.BestSolutionSelection;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.ObjectiveComparator;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.neighborhood.impl.AdaptiveRandomNeighborhood;
@@ -148,8 +149,9 @@ public class StandardPSO2007 extends AbstractParticleSwarmOptimization<DoubleSol
     for (int i = 0; i < swarm.size(); i++) {
       DoubleSolution particle = swarm.get(i);
       for (int j = 0; j < problem.getNumberOfVariables(); j++) {
+        Bounds<Double> bounds = particle.getBounds(j) ;
         speed[i][j] =
-                (randomGenerator.nextDouble(particle.getLowerBound(j), particle.getUpperBound(j))
+                (randomGenerator.nextDouble(bounds.getLowerBound(), bounds.getUpperBound())
                         - particle.getVariable(j)) / 2.0;
       }
     }
@@ -189,12 +191,15 @@ public class StandardPSO2007 extends AbstractParticleSwarmOptimization<DoubleSol
       for (int var = 0; var < particle.getNumberOfVariables(); var++) {
         particle.setVariable(var, particle.getVariable(var) + speed[i][var]);
 
-        if (particle.getVariable(var) < problem.getLowerBound(var)) {
-          particle.setVariable(var, problem.getLowerBound(var));
+        Bounds<Double> bounds = problem.getBoundsForVariables().get(var) ;
+        Double lowerBound = bounds.getLowerBound() ;
+        Double upperBound = bounds.getUpperBound() ;
+        if (particle.getVariable(var) < lowerBound) {
+          particle.setVariable(var, lowerBound);
           speed[i][var] = 0;
         }
-        if (particle.getVariable(var) > problem.getUpperBound(var)) {
-          particle.setVariable(var, problem.getUpperBound(var));
+        if (particle.getVariable(var) > upperBound) {
+          particle.setVariable(var, upperBound);
           speed[i][var] = 0;
         }
       }

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2011.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/singleobjective/particleswarmoptimization/StandardPSO2011.java
@@ -6,6 +6,7 @@ import org.uma.jmetal.operator.selection.impl.BestSolutionSelection;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.SolutionUtils;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.comparator.ObjectiveComparator;
 import org.uma.jmetal.util.evaluator.SolutionListEvaluator;
 import org.uma.jmetal.util.neighborhood.impl.AdaptiveRandomNeighborhood;
@@ -156,9 +157,10 @@ public class StandardPSO2011 extends AbstractParticleSwarmOptimization<DoubleSol
     for (int i = 0; i < swarmSize; i++) {
       DoubleSolution particle = swarm.get(i);
       for (int j = 0; j < problem.getNumberOfVariables(); j++) {
+        Bounds<Double> bounds = particle.getBounds(j) ;
         speed[i][j] = (randomGenerator.nextDouble(
-                particle.getLowerBound(j) - particle.getVariable(0),
-                particle.getUpperBound(j) - particle.getVariable(0)));
+                bounds.getLowerBound() - particle.getVariable(0),
+                bounds.getUpperBound() - particle.getVariable(0)));
       }
     }
   }
@@ -235,12 +237,15 @@ public class StandardPSO2011 extends AbstractParticleSwarmOptimization<DoubleSol
       for (int var = 0; var < particle.getNumberOfVariables(); var++) {
         particle.setVariable(var, particle.getVariable(var) + speed[i][var]);
 
-        if (particle.getVariable(var) < problem.getLowerBound(var)) {
-          particle.setVariable(var, problem.getLowerBound(var));
+        Bounds<Double> bounds = problem.getBoundsForVariables().get(var) ;
+        Double lowerBound = bounds.getLowerBound() ;
+        Double upperBound = bounds.getUpperBound() ;
+        if (particle.getVariable(var) < lowerBound) {
+          particle.setVariable(var, lowerBound);
           speed[i][var] = changeVelocity * speed[i][var];
         }
-        if (particle.getVariable(var) > problem.getUpperBound(var)) {
-          particle.setVariable(var, problem.getUpperBound(var));
+        if (particle.getVariable(var) > upperBound) {
+          particle.setVariable(var, upperBound);
           speed[i][var] = changeVelocity * speed[i][var];
         }
       }

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/abyss/ABYSSTest.java
@@ -302,13 +302,15 @@ public class ABYSSTest {
     }
 
     @Override
+    @Deprecated
     public Double getLowerBound(int index) {
-      return super.getUpperBound(index);
+      return super.getBoundsForVariables().get(index).getUpperBound();
     }
 
     @Override
+    @Deprecated
     public Double getUpperBound(int index) {
-      return super.getUpperBound(index);
+      return super.getBoundsForVariables().get(index).getUpperBound();
     }
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/BLXAlphaCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/BLXAlphaCrossover.java
@@ -5,6 +5,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
@@ -104,8 +105,9 @@ public class BLXAlphaCrossover implements CrossoverOperator<DoubleSolution> {
 
     if (randomGenerator.getRandomValue() <= probability) {
       for (i = 0; i < parent1.getNumberOfVariables(); i++) {
-        upperBound = parent1.getUpperBound(i);
-        lowerBound = parent1.getLowerBound(i);
+        Bounds<Double> bounds = parent1.getBounds(i);
+        upperBound = bounds.getUpperBound();
+        lowerBound = bounds.getLowerBound();
         valueX1 = parent1.getVariable(i);
         valueX2 = parent2.getVariable(i);
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/DifferentialEvolutionCrossover.java
@@ -5,6 +5,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
 import org.uma.jmetal.util.pseudorandom.BoundedRandomGenerator;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
@@ -416,12 +417,15 @@ public class DifferentialEvolutionCrossover implements CrossoverOperator<DoubleS
     IntStream.range(0, solution.getNumberOfVariables())
         .forEach(
             i ->
-                solution.setVariable(
-                    i,
-                    solutionRepair.repairSolutionVariableValue(
-                        solution.getVariable(i),
-                        solution.getLowerBound(i),
-                        solution.getUpperBound(i))));
+                {
+                  Bounds<Double> bounds = solution.getBounds(i);
+                  solution.setVariable(
+                      i,
+                      solutionRepair.repairSolutionVariableValue(
+                          solution.getVariable(i),
+                          bounds.getLowerBound(),
+                          bounds.getUpperBound()));
+                });
   }
 
   private double mutate(Double[][] parent, int index) {

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/IntegerSBXCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/IntegerSBXCrossover.java
@@ -3,6 +3,7 @@ package org.uma.jmetal.operator.crossover.impl;
 import org.uma.jmetal.operator.crossover.CrossoverOperator;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -103,8 +104,9 @@ public class IntegerSBXCrossover implements CrossoverOperator<IntegerSolution> {
               y2 = valueX1;
             }
 
-            yL = parent1.getLowerBound(i);
-            yu = parent1.getUpperBound(i);
+            Bounds<Integer> bounds = parent1.getBounds(i);
+            yL = bounds.getLowerBound();
+            yu = bounds.getUpperBound();
             rand = randomGenerator.getRandomValue();
             beta = 1.0 + (2.0 * (y1 - yL) / (y2 - y1));
             alpha = 2.0 - Math.pow(beta, -(distributionIndex + 1.0));

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/SBXCrossover.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/crossover/impl/SBXCrossover.java
@@ -5,6 +5,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
@@ -121,8 +122,9 @@ public class SBXCrossover implements CrossoverOperator<DoubleSolution> {
               y2 = valueX1;
             }
 
-            lowerBound = parent1.getLowerBound(i);
-            upperBound = parent1.getUpperBound(i);
+            Bounds<Double> bounds = parent1.getBounds(i);
+            lowerBound = bounds.getLowerBound();
+            upperBound = bounds.getUpperBound();
 
             rand = randomGenerator.getRandomValue();
             beta = 1.0 + (2.0 * (y1 - lowerBound) / (y2 - y1));

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/CDGMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/CDGMutation.java
@@ -19,6 +19,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 /**
@@ -110,8 +111,9 @@ public class CDGMutation implements MutationOperator<DoubleSolution> {
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenerator.nextDouble() <= probability) {
         y = solution.getVariable(i);
-        yl = solution.getLowerBound(i) ;
-        yu = solution.getUpperBound(i) ;
+        Bounds<Double> bounds = solution.getBounds(i);
+        yl = bounds.getLowerBound() ;
+        yu = bounds.getUpperBound() ;
         rnd = randomGenerator.nextDouble();
           
         tempDelta = Math.pow(rnd, -delta);

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/IntegerPolynomialMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/IntegerPolynomialMutation.java
@@ -6,6 +6,7 @@ import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -104,8 +105,9 @@ public class IntegerPolynomialMutation implements MutationOperator<IntegerSoluti
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenerator.getRandomValue() <= probability) {
         y = (double)solution.getVariable(i);
-        yl = (double)solution.getLowerBound(i) ;
-        yu = (double)solution.getUpperBound(i) ;
+        Bounds<Integer> bounds = solution.getBounds(i);
+        yl = (double)bounds.getLowerBound() ;
+        yu = (double)bounds.getUpperBound() ;
         if (yl == yu) {
           y = yl ;
         } else {

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/NonUniformMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/NonUniformMutation.java
@@ -3,6 +3,7 @@ package org.uma.jmetal.operator.mutation.impl;
 import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -97,21 +98,18 @@ public class NonUniformMutation implements MutationOperator<DoubleSolution> {
         double rand = randomGenenerator.getRandomValue();
         double tmp;
 
+        Bounds<Double> bounds = solution.getBounds(i);
         if (rand <= 0.5) {
-          tmp = delta(solution.getUpperBound(i) - solution.getVariable(i),
+          tmp = delta(bounds.getUpperBound() - solution.getVariable(i),
               perturbation);
           tmp += solution.getVariable(i);
         } else {
-          tmp = delta(solution.getLowerBound(i) - solution.getVariable(i),
+          tmp = delta(bounds.getLowerBound() - solution.getVariable(i),
               perturbation);
           tmp += solution.getVariable(i);
         }
 
-        if (tmp < solution.getLowerBound(i)) {
-          tmp = solution.getLowerBound(i);
-        } else if (tmp > solution.getUpperBound(i)) {
-          tmp = solution.getUpperBound(i);
-        }
+        tmp = bounds.restrict(tmp);
         solution.setVariable(i, tmp);
       }
     }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/PolynomialMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/PolynomialMutation.java
@@ -6,6 +6,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
@@ -178,8 +179,9 @@ public class PolynomialMutation implements MutationOperator<DoubleSolution> {
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenerator.getRandomValue() <= mutationProbability) {
         y = solution.getVariable(i);
-        yl = solution.getLowerBound(i);
-        yu = solution.getUpperBound(i);
+        Bounds<Double> bounds = solution.getBounds(i);
+        yl = bounds.getLowerBound();
+        yu = bounds.getUpperBound();
         if (yl == yu) {
           y = yl;
         } else {

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/SimpleRandomMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/SimpleRandomMutation.java
@@ -3,6 +3,7 @@ package org.uma.jmetal.operator.mutation.impl;
 import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -58,10 +59,11 @@ public class SimpleRandomMutation implements MutationOperator<DoubleSolution> {
   private void doMutation(double probability, DoubleSolution solution) {
     for (int i = 0; i < solution.getNumberOfVariables(); i++) {
       if (randomGenerator.getRandomValue() <= probability) {
-        Double value =
-            solution.getLowerBound(i)
-                + ((solution.getUpperBound(i) - solution.getLowerBound(i))
-                    * randomGenerator.getRandomValue());
+        Bounds<Double> bounds = solution.getBounds(i);
+        Double lowerBound = bounds.getLowerBound();
+        Double upperBound = bounds.getUpperBound();
+        Double randomValue = randomGenerator.getRandomValue();
+        Double value = lowerBound + ((upperBound - lowerBound) * randomValue);
 
         solution.setVariable(i, value);
       }

--- a/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/UniformMutation.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/operator/mutation/impl/UniformMutation.java
@@ -5,6 +5,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.RepairDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 
@@ -84,9 +85,10 @@ public class UniformMutation implements MutationOperator<DoubleSolution> {
 
         tmp += solution.getVariable(i);
 
+        Bounds<Double> bounds = solution.getBounds(i);
         tmp =
             solutionRepair.repairSolutionVariableValue(
-                tmp, solution.getLowerBound(i), solution.getUpperBound(i));
+                tmp, bounds.getLowerBound(), bounds.getUpperBound());
 
         solution.setVariable(i, tmp);
       }

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
@@ -1,8 +1,10 @@
 package org.uma.jmetal.problem;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.uma.jmetal.util.bounds.Bounds;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A {@link BoundedProblem} is a {@link Problem} for which solution boundaries
@@ -21,18 +23,31 @@ public interface BoundedProblem<T extends Number & Comparable<T>, S> extends Pro
    * @param index
    *          index of the variable
    * @return lower bound of the variable
+   * @deprecated Use {@link #getBoundsForVariables()}.{@link List#get(int) get(int)}.{@link Bounds#getLowerBound() getLowerBound()} instead.
    */
+  @Deprecated
   T getLowerBound(int index);
 
   /**
    * @param index
    *          index of the variable
    * @return upper bound of the variable
+   * @deprecated Use {@link #getBoundsForVariables()}.{@link List#get(int) get(int)}.{@link Bounds#getUpperBound() getUpperBound()} instead.
    */
+  @Deprecated
   T getUpperBound(int index);
 
   /**
    * @return A list with pairs <lower bound, upper bound> for each of the decision variables
+   * @deprecated Use {@link #getBoundsForVariables()} instead.
    */
+  @Deprecated
   List<Pair<T, T>> getBounds() ;
+
+  /**
+   * @return A list with {@link Bounds} <lower bound, upper bound> for each of the decision variables
+   */
+  default List<Bounds<T>> getBoundsForVariables() {
+    return getBounds().stream().map(Bounds::fromPair).collect(Collectors.toList());
+  }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/doubleproblem/impl/AbstractDoubleProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/doubleproblem/impl/AbstractDoubleProblem.java
@@ -1,11 +1,11 @@
 package org.uma.jmetal.problem.doubleproblem.impl;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.uma.jmetal.problem.AbstractGenericProblem;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
 
 import java.util.List;
@@ -16,20 +16,26 @@ import java.util.stream.IntStream;
 public abstract class AbstractDoubleProblem extends AbstractGenericProblem<DoubleSolution>
     implements DoubleProblem {
 
-  protected List<Pair<Double, Double>> bounds;
+  protected List<Bounds<Double>> bounds;
 
+  /**
+   * @deprecated Use {@link #getBoundsForVariables()} instead.
+   */
+  @Deprecated
   public List<Pair<Double, Double>> getVariableBounds() {
-    return bounds;
+    return bounds.stream().map(Bounds<Double>::toPair).collect(Collectors.toList());
   }
 
   @Override
+  @Deprecated
   public Double getUpperBound(int index) {
-    return getVariableBounds().get(index).getRight();
+    return getBoundsForVariables().get(index).getUpperBound();
   }
 
   @Override
+  @Deprecated
   public Double getLowerBound(int index) {
-    return getVariableBounds().get(index).getLeft();
+    return getBoundsForVariables().get(index).getLowerBound();
   }
 
   public void setVariableBounds(List<Double> lowerBounds, List<Double> upperBounds) {
@@ -41,17 +47,23 @@ public abstract class AbstractDoubleProblem extends AbstractGenericProblem<Doubl
 
     bounds =
         IntStream.range(0, lowerBounds.size())
-            .mapToObj(i -> new ImmutablePair<>(lowerBounds.get(i), upperBounds.get(i)))
+            .mapToObj(i -> Bounds.create(lowerBounds.get(i), upperBounds.get(i)))
             .collect(Collectors.toList());
   }
 
   @Override
   public DoubleSolution createSolution() {
-    return new DefaultDoubleSolution(bounds, getNumberOfObjectives(), getNumberOfConstraints());
+    return new DefaultDoubleSolution(getNumberOfObjectives(), getNumberOfConstraints(), bounds);
   }
 
   @Override
+  @Deprecated
   public List<Pair<Double, Double>> getBounds() {
+    return getVariableBounds();
+  }
+  
+  @Override
+  public List<Bounds<Double>> getBoundsForVariables() {
     return bounds;
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/doubleproblem/impl/ComposableDoubleProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/doubleproblem/impl/ComposableDoubleProblem.java
@@ -1,14 +1,15 @@
 package org.uma.jmetal.problem.doubleproblem.impl;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -41,7 +42,7 @@ public class ComposableDoubleProblem implements DoubleProblem {
 
   private List<Function<Double[], Double>> objectiveFunctions;
   private List<Function<Double[], Double>> constraints;
-  private List<Pair<Double, Double>> bounds;
+  private List<Bounds<Double>> bounds;
   private String name;
 
   public ComposableDoubleProblem() {
@@ -63,7 +64,7 @@ public class ComposableDoubleProblem implements DoubleProblem {
   }
 
   public ComposableDoubleProblem addVariable(double lowerBound, double upperBound) {
-    bounds.add(new ImmutablePair<>(lowerBound, upperBound));
+    bounds.add(Bounds.create(lowerBound, upperBound));
     return this;
   }
 
@@ -94,22 +95,30 @@ public class ComposableDoubleProblem implements DoubleProblem {
   }
 
   @Override
+  @Deprecated
   public Double getLowerBound(int index) {
-    return bounds.get(index).getLeft();
+    return bounds.get(index).getLowerBound();
   }
 
   @Override
+  @Deprecated
   public Double getUpperBound(int index) {
-    return bounds.get(index).getRight();
+    return bounds.get(index).getUpperBound();
   }
 
   @Override
   public DoubleSolution createSolution() {
-    return new DefaultDoubleSolution(bounds, getNumberOfObjectives(), getNumberOfConstraints());
+    return new DefaultDoubleSolution(getNumberOfObjectives(), getNumberOfConstraints(), bounds);
   }
 
   @Override
+  @Deprecated
   public List<Pair<Double, Double>> getBounds() {
+    return bounds.stream().map(Bounds<Double>::toPair).collect(Collectors.toList());
+  }
+  
+  @Override
+  public List<Bounds<Double>> getBoundsForVariables() {
     return bounds;
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/integerproblem/impl/AbstractIntegerProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/integerproblem/impl/AbstractIntegerProblem.java
@@ -1,11 +1,11 @@
 package org.uma.jmetal.problem.integerproblem.impl;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.uma.jmetal.problem.AbstractGenericProblem;
 import org.uma.jmetal.problem.integerproblem.IntegerProblem;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.solution.integersolution.impl.DefaultIntegerSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.Check;
 
 import java.util.List;
@@ -16,20 +16,26 @@ import java.util.stream.IntStream;
 public abstract class AbstractIntegerProblem extends AbstractGenericProblem<IntegerSolution>
   implements IntegerProblem {
 
-  protected List<Pair<Integer, Integer>> bounds;
+  protected List<Bounds<Integer>> bounds;
 
+  /**
+   * @deprecated USe {@link #getBoundsForVariables()} instead.
+   */
+  @Deprecated
   public List<Pair<Integer, Integer>> getVariableBounds() {
-    return bounds;
+    return bounds.stream().map(Bounds<Integer>::toPair).collect(Collectors.toList());
   }
 
   @Override
+  @Deprecated
   public Integer getUpperBound(int index) {
-    return getVariableBounds().get(index).getRight();
+    return getBoundsForVariables().get(index).getUpperBound();
   }
 
   @Override
+  @Deprecated
   public Integer getLowerBound(int index) {
-    return getVariableBounds().get(index).getLeft();
+    return getBoundsForVariables().get(index).getLowerBound();
   }
 
   public void setVariableBounds(List<Integer> lowerBounds, List<Integer> upperBounds) {
@@ -41,17 +47,23 @@ public abstract class AbstractIntegerProblem extends AbstractGenericProblem<Inte
 
     bounds =
         IntStream.range(0, lowerBounds.size())
-            .mapToObj(i -> new ImmutablePair<>(lowerBounds.get(i), upperBounds.get(i)))
+            .mapToObj(i -> Bounds.create(lowerBounds.get(i), upperBounds.get(i)))
             .collect(Collectors.toList());
   }
 
   @Override
   public IntegerSolution createSolution() {
-    return new DefaultIntegerSolution(getVariableBounds(), getNumberOfObjectives());
+    return new DefaultIntegerSolution(getNumberOfObjectives(), getBoundsForVariables());
   }
 
   @Override
+  @Deprecated
   public List<Pair<Integer, Integer>> getBounds() {
-    return bounds ;
+    return getVariableBounds() ;
+  }
+  
+  @Override
+  public List<Bounds<Integer>> getBoundsForVariables() {
+    return bounds;
   }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/doublesolution/DoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/doublesolution/DoubleSolution.java
@@ -1,6 +1,7 @@
 package org.uma.jmetal.solution.doublesolution;
 
 import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.util.bounds.Bounds;
 
 /**
  * Interface representing a double solutions
@@ -8,6 +9,29 @@ import org.uma.jmetal.solution.Solution;
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
 public interface DoubleSolution extends Solution<Double> {
+  /**
+   * @deprecated Use {@link #getBounds(int)}{@link Bounds#getLowerBound()
+   *             .getLowerBound()} instead.
+   */
+  @Deprecated
   Double getLowerBound(int index) ;
+  /**
+   * @deprecated Use {@link #getBounds(int)}{@link Bounds#getLowerBound()
+   *             .getLowerBound()} instead.
+   */
+  @Deprecated
   Double getUpperBound(int index) ;
+  
+  /**
+   * It is often the case that we use both bounds together. Searching twice the
+   * same index may be counter productive in this case. This methods allows to
+   * offer this optimization, although its default implementation just delegates
+   * to the separate methods.
+   */
+  default Bounds<Double> getBounds(int index) {
+    DoubleSolution solution = this;
+    Double lowerBound = solution.getLowerBound(index);
+    Double upperBound = solution.getUpperBound(index);
+    return Bounds.create(lowerBound, upperBound);
+  }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/doublesolution/impl/DefaultDoubleSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/doublesolution/impl/DefaultDoubleSolution.java
@@ -3,10 +3,12 @@ package org.uma.jmetal.solution.doublesolution.impl;
 import org.apache.commons.lang3.tuple.Pair;
 import org.uma.jmetal.solution.AbstractSolution;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Defines an implementation of a double solution. Each variable is given by a pair <lower bound, upper bound>.
@@ -15,27 +17,53 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public class DefaultDoubleSolution extends AbstractSolution<Double> implements DoubleSolution {
-  protected List<Pair<Double, Double>> bounds ;
+  protected List<Bounds<Double>> bounds ;
 
-  /** Constructor */
+  /**
+   * Constructor
+   * 
+   * @deprecated Use {@link #DefaultDoubleSolution(int, int, List)} instead.
+   */
+  @Deprecated
   public DefaultDoubleSolution(
       List<Pair<Double, Double>> bounds,
       int numberOfObjectives,
       int numberOfConstraints) {
-    super(bounds.size(), numberOfObjectives, numberOfConstraints) ;
-
-    this.bounds = bounds ;
-
-    for (int i = 0 ; i < bounds.size(); i++) {
-      setVariable(i, JMetalRandom.getInstance().nextDouble(bounds.get(i).getLeft(), bounds.get(i).getRight())); ;
-    }
+    this(numberOfObjectives, numberOfConstraints, bounds.stream().map(Bounds::fromPair).collect(Collectors.toList())) ;
   }
 
   /** Constructor */
   public DefaultDoubleSolution(
+      int numberOfObjectives,
+      int numberOfConstraints,
+      List<Bounds<Double>> boundsList) {
+    super(boundsList.size(), numberOfObjectives, numberOfConstraints) ;
+
+    this.bounds = boundsList ;
+
+    for (int i = 0 ; i < boundsList.size(); i++) {
+      Bounds<Double> bounds = boundsList.get(i);
+      setVariable(i, JMetalRandom.getInstance().nextDouble(bounds.getLowerBound(), bounds.getUpperBound())); ;
+    }
+  }
+
+  /**
+   * Constructor
+   * 
+   * @deprecated Use {@link #DefaultDoubleSolution(int, List)} instead.
+   */
+  @Deprecated
+  public DefaultDoubleSolution(
       List<Pair<Double, Double>> bounds,
       int numberOfObjectives) {
     this(bounds, numberOfObjectives, 0) ;
+  }
+
+  /** Constructor */
+  public DefaultDoubleSolution(
+      int numberOfObjectives,
+      List<Bounds<Double>> boundsList) {
+    this(numberOfObjectives, 0, boundsList) ;
   }
 
   /** Copy constructor */
@@ -58,14 +86,29 @@ public class DefaultDoubleSolution extends AbstractSolution<Double> implements D
     attributes = new HashMap<Object, Object>(solution.attributes) ;
   }
 
+  /**
+   * @deprecated Use {@link #getBounds(int)}{@link Bounds#getLowerBound()
+   *             .getLowerBound()} instead.
+   */
+  @Deprecated
   @Override
   public Double getLowerBound(int index) {
-    return this.bounds.get(index).getLeft() ;
+    return this.bounds.get(index).getLowerBound() ;
   }
 
+  /**
+   * @deprecated Use {@link #getBounds(int)}{@link Bounds#getUpperBound()
+   *             .getUpperBound()} instead.
+   */
+  @Deprecated
   @Override
   public Double getUpperBound(int index) {
-    return this.bounds.get(index).getRight() ;
+    return this.bounds.get(index).getUpperBound() ;
+  }
+  
+  @Override
+  public Bounds<Double> getBounds(int index) {
+    return this.bounds.get(index);
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/integersolution/IntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/integersolution/IntegerSolution.java
@@ -1,6 +1,7 @@
 package org.uma.jmetal.solution.integersolution;
 
 import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.util.bounds.Bounds;
 
 /**
  * Interface representing a integer solutions
@@ -8,6 +9,29 @@ import org.uma.jmetal.solution.Solution;
  * @author Antonio J. Nebro <antonio@lcc.uma.es>
  */
 public interface IntegerSolution extends Solution<Integer> {
+  /**
+   * @deprecated Use {@link #getBounds(int)}{@link Bounds#getLowerBound()
+   *             .getLowerBound()} instead.
+   */
+  @Deprecated
   Integer getLowerBound(int index) ;
+  /**
+   * @deprecated Use {@link #getBounds(int)}{@link Bounds#getUpperBound()
+   *             .getUpperBound()} instead.
+   */
+  @Deprecated
   Integer getUpperBound(int index) ;
+  
+  /**
+   * It is often the case that we use both bounds together. Searching twice the
+   * same index may be counter productive in this case. This methods allows to
+   * offer this optimization, although its default implementation just delegates
+   * to the separate methods.
+   */
+  default Bounds<Integer> getBounds(int index) {
+    IntegerSolution solution = this;
+    Integer lowerBound = solution.getLowerBound(index);
+    Integer upperBound = solution.getUpperBound(index);
+    return Bounds.create(lowerBound, upperBound);
+  }
 }

--- a/jmetal-core/src/main/java/org/uma/jmetal/solution/integersolution/impl/DefaultIntegerSolution.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/solution/integersolution/impl/DefaultIntegerSolution.java
@@ -3,10 +3,12 @@ package org.uma.jmetal.solution.integersolution.impl;
 import org.apache.commons.lang3.tuple.Pair;
 import org.uma.jmetal.solution.AbstractSolution;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Defines an implementation of an integer solution
@@ -15,27 +17,49 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public class DefaultIntegerSolution extends AbstractSolution<Integer> implements IntegerSolution {
-  protected List<Pair<Integer, Integer>> bounds;
+  protected List<Bounds<Integer>> bounds;
 
-  /** Constructor */
+  /**
+   * Constructor
+   * 
+   * @deprecated Use {@link #DefaultIntegerSolution(int, int, List)} instead.
+   */
+  @Deprecated
   public DefaultIntegerSolution(List<Pair<Integer, Integer>> bounds, int numberOfObjectives, int numberOfConstraints) {
-    super(bounds.size(), numberOfObjectives, numberOfConstraints);
-
-    this.bounds = bounds ;
-
-    for (int i = 0; i < bounds.size(); i++) {
-      setVariable(
-          i, JMetalRandom.getInstance().nextInt(bounds.get(i).getLeft(), bounds.get(i).getRight()));
-    }
+    this(numberOfObjectives, numberOfConstraints, bounds.stream().map(Bounds::fromPair).collect(Collectors.toList()));
   }
 
   /** Constructor */
+  public DefaultIntegerSolution(int numberOfObjectives, int numberOfConstraints, List<Bounds<Integer>> boundsList) {
+    super(boundsList.size(), numberOfObjectives, numberOfConstraints);
+
+    this.bounds = boundsList ;
+
+    for (int i = 0; i < boundsList.size(); i++) {
+      Bounds<Integer> bounds = boundsList.get(i);
+      setVariable(
+          i, JMetalRandom.getInstance().nextInt(bounds.getLowerBound(), bounds.getUpperBound()));
+    }
+  }
+
+  /**
+   * Constructor
+   * 
+   * @deprecated Use {@link #DefaultIntegerSolution(int, List)} instead.
+   */
+  @Deprecated
   public DefaultIntegerSolution(
       List<Pair<Integer, Integer>> bounds,
       int numberOfObjectives) {
     this(bounds, numberOfObjectives, 0) ;
   }
 
+  /** Constructor */
+  public DefaultIntegerSolution(
+      int numberOfObjectives,
+      List<Bounds<Integer>> bounds) {
+    this(numberOfObjectives, 0, bounds) ;
+  }
 
   /** Copy constructor */
   public DefaultIntegerSolution(DefaultIntegerSolution solution) {
@@ -58,14 +82,29 @@ public class DefaultIntegerSolution extends AbstractSolution<Integer> implements
     attributes = new HashMap<>(solution.attributes);
   }
 
+  /**
+   * @deprecated Use {@link #getBounds(int)}{@link Bounds#getLowerBound()
+   *             .getLowerBound()} instead.
+   */
   @Override
+  @Deprecated
   public Integer getLowerBound(int index) {
-    return this.bounds.get(index).getLeft();
+    return this.bounds.get(index).getLowerBound();
   }
 
+  /**
+   * @deprecated Use {@link #getBounds(int)}{@link Bounds#getUpperBound()
+   *             .getUpperBound()} instead.
+   */
   @Override
+  @Deprecated
   public Integer getUpperBound(int index) {
-    return this.bounds.get(index).getRight();
+    return this.bounds.get(index).getUpperBound();
+  }
+  
+  @Override
+  public Bounds<Integer> getBounds(int index) {
+    return this.bounds.get(index);
   }
 
   @Override

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/impl/ArtificialDecisionMakerDecisionTree.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/artificialdecisionmaker/impl/ArtificialDecisionMakerDecisionTree.java
@@ -7,6 +7,7 @@ import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.util.artificialdecisionmaker.ArtificialDecisionMaker;
 import org.uma.jmetal.util.artificialdecisionmaker.DecisionTreeEstimator;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.comparator.ObjectiveComparator;
 import org.uma.jmetal.util.distance.impl.EuclideanDistanceBetweenSolutionsInObjectiveSpace;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
@@ -84,8 +85,9 @@ public class ArtificialDecisionMakerDecisionTree<S extends Solution<?>> extends 
     if(problem instanceof BoundedProblem){
       BoundedProblem<?, ?> aux =(BoundedProblem<?, ?>)problem;
       for (int i = 0; i < numberOfObjectives ; i++) {
-        idealOjectiveVector.add(aux.getLowerBound(i).doubleValue());
-        nadirObjectiveVector.add(aux.getUpperBound(i).doubleValue());
+        Bounds<?> bounds = aux.getBoundsForVariables().get(i);
+        idealOjectiveVector.add(((Number) bounds.getLowerBound()).doubleValue());
+        nadirObjectiveVector.add(((Number) bounds.getUpperBound()).doubleValue());
       }
     }
     if(asp==null)

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/bounds/Bounds.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/bounds/Bounds.java
@@ -1,0 +1,111 @@
+package org.uma.jmetal.util.bounds;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Describes a pair of lower and upper bounds for a {@link Comparable} value.
+ *
+ * @param <T>
+ *          the type of {@link Bounds}
+ */
+public interface Bounds<T extends Comparable<T>> {
+  /** @return the lower limit of these {@link Bounds} */
+  T getLowerBound();
+
+  /** @return the upper limit of these {@link Bounds} */
+  T getUpperBound();
+
+  /**
+   * Restrict the given value within these {@link Bounds}. If the value is lower,
+   * it is replaced by {@link #getLowerBound()}. If the value is higher, it is
+   * replaced by {@link #getUpperBound()}. Otherwise it is returned as provided.
+   * 
+   * @param value
+   *          the value to restrict
+   * @return the value or one of the limits
+   */
+  default T restrict(T value) {
+    T lowerBound = getLowerBound();
+    if (lowerBound.compareTo(value) > 0) {
+      return lowerBound;
+    }
+
+    T upperBound = getUpperBound();
+    if (upperBound.compareTo(value) < 0) {
+      return upperBound;
+    }
+
+    return value;
+  }
+
+  /**
+   * Create a {@link Bounds} with the given lower and upper limits.
+   * 
+   * @param <T>
+   *          the type of {@link Bounds}
+   * @param lowerBound
+   *          the lowest limit
+   * @param upperBound
+   *          the highest limit
+   * @return a {@link Bounds} with the given limits
+   */
+  public static <T extends Comparable<T>> Bounds<T> create(T lowerBound, T upperBound) {
+    if (lowerBound == null) {
+      throw new IllegalArgumentException("null lower bound");
+    } else if (upperBound == null) {
+      throw new IllegalArgumentException("null upper bound");
+    } else if (lowerBound.compareTo(upperBound) > 0) {
+      throw new IllegalArgumentException(
+          String.format("lower bound (%s) must be below upper bound (%s)", lowerBound, upperBound));
+    } else {
+      return new Bounds<T>() {
+        @Override
+        public T getLowerBound() {
+          return lowerBound;
+        }
+
+        @Override
+        public T getUpperBound() {
+          return upperBound;
+        }
+      };
+    }
+  }
+
+  /**
+   * Utility method to convert a legacy {@link Pair} into a {@link Bounds}. The
+   * resulting {@link Bounds} represents the state of the {@link Pair} at call
+   * time. Later changes of the {@link Pair} do not reflect on the previously
+   * created {@link Bounds}. It allows to not keep a reference on the {@link Pair}
+   * instance, which can be garbage collected.
+   * 
+   * @param <T>
+   *          the type of elements
+   * @param pair
+   *          the {@link Pair} to translate
+   * @return the resulting {@link Bounds}
+   * @deprecated This method is here for legacy purpose. Do not use since it
+   *             should disappear soon.
+   */
+  @Deprecated
+  public static <T extends Comparable<T>> Bounds<T> fromPair(Pair<T, T> pair) {
+    return create(pair.getLeft(), pair.getRight());
+  }
+
+  /**
+   * Utility method to convert this {@link Bounds} into a legacy {@link Pair}. The
+   * resulting {@link Pair} represents the state of the {@link Bounds} at call
+   * time. Later changes of the {@link Bounds} do not reflect on the previously
+   * created {@link Pair}. It allows to not keep a reference on the {@link Bounds}
+   * instance, which can be garbage collected.
+   * 
+   * @return a {@link Pair} representing this {@link Bounds}
+   * @deprecated This method is here for legacy purpose. Do not use since it
+   *             should disappear soon.
+   */
+  @Deprecated
+  default public Pair<T, T> toPair() {
+    return new ImmutablePair<>(getLowerBound(), getUpperBound());
+  }
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/BLXAlphaCrossoverTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/BLXAlphaCrossoverTest.java
@@ -1,7 +1,5 @@
 package org.uma.jmetal.operator.crossover;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -13,6 +11,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.exception.InvalidConditionException;
 import org.uma.jmetal.util.checking.exception.NullParameterException;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
@@ -150,14 +149,16 @@ public class BLXAlphaCrossoverTest {
 
     List<DoubleSolution> newSolutions = crossover.execute(solutions) ;
 
+    Bounds<Double> bounds0 = solutions.get(0).getBounds(0);
+    Bounds<Double> bounds1 = solutions.get(1).getBounds(0);
     assertThat(newSolutions.get(0).getVariable(0), Matchers
-        .greaterThanOrEqualTo(solutions.get(0).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(0), Matchers
-        .lessThanOrEqualTo(solutions.get(1).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds1.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(0), Matchers
-        .lessThanOrEqualTo(solutions.get(0).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds0.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(0), Matchers
-        .greaterThanOrEqualTo(solutions.get(1).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds1.getLowerBound())) ;
     verify(randomGenerator, times(3)).getRandomValue();
   }
 
@@ -209,22 +210,24 @@ public class BLXAlphaCrossoverTest {
 
     List<DoubleSolution> newSolutions = crossover.execute(solutions) ;
 
+    Bounds<Double> bounds0 = solutions.get(0).getBounds(0);
+    Bounds<Double> bounds1 = solutions.get(1).getBounds(0);
     assertThat(newSolutions.get(0).getVariable(0), Matchers
-        .greaterThanOrEqualTo(solutions.get(0).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(0), Matchers
-        .lessThanOrEqualTo(solutions.get(1).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds1.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(0), Matchers
-        .lessThanOrEqualTo(solutions.get(0).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds0.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(0), Matchers
-        .greaterThanOrEqualTo(solutions.get(1).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds1.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(1), Matchers
-        .greaterThanOrEqualTo(solutions.get(0).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(1), Matchers
-        .lessThanOrEqualTo(solutions.get(1).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds1.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(1), Matchers
-        .lessThanOrEqualTo(solutions.get(0).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds0.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(1), Matchers
-        .greaterThanOrEqualTo(solutions.get(1).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds1.getLowerBound())) ;
     verify(randomGenerator, times(5)).getRandomValue();
   }
 
@@ -265,11 +268,11 @@ public class BLXAlphaCrossoverTest {
 		int alpha = 20;
 		RepairDoubleSolutionWithBoundValue solutionRepair = new RepairDoubleSolutionWithBoundValue();
 
-    List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(0.0, 1.0)) ;
+    List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(0.0, 1.0)) ;
 
 		List<DoubleSolution> solutions = new LinkedList<>();
-		solutions.add(new DefaultDoubleSolution(bounds, 2));
-		solutions.add(new DefaultDoubleSolution(bounds, 2));
+		solutions.add(new DefaultDoubleSolution(2, bounds));
+		solutions.add(new DefaultDoubleSolution(2, bounds));
 
 		// Check configuration leads to use default generator by default
 		final int[] defaultUses = { 0 };

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/IntegerSBXCrossoverTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/IntegerSBXCrossoverTest.java
@@ -1,12 +1,11 @@
 package org.uma.jmetal.operator.crossover;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.uma.jmetal.operator.crossover.impl.IntegerSBXCrossover;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.solution.integersolution.impl.DefaultIntegerSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.impl.AuditableRandomGenerator;
 
@@ -24,10 +23,10 @@ public class IntegerSBXCrossoverTest {
 		// Configuration
 		List<IntegerSolution> parents = new LinkedList<>();
 
-		List<Pair<Integer, Integer>> bounds = Arrays.asList(new ImmutablePair<>(0, 1)) ;
+		List<Bounds<Integer>> bounds = Arrays.asList(Bounds.create(0, 1)) ;
 
-		parents.add(new DefaultIntegerSolution(bounds, 2));
-		parents.add(new DefaultIntegerSolution(bounds, 2));
+		parents.add(new DefaultIntegerSolution(2, bounds));
+		parents.add(new DefaultIntegerSolution(2, bounds));
 
 		// Check configuration leads to use default generator by default
 		final int[] defaultUses = { 0 };

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/NullCrossoverTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/NullCrossoverTest.java
@@ -90,12 +90,12 @@ public class NullCrossoverTest {
       solution.setObjective(1, randomGenerator.nextDouble());
     }
 
-    @Override public Double getLowerBound(int index) {
-      return super.getUpperBound(index);
+    @Override @Deprecated public Double getLowerBound(int index) {
+      return super.getBoundsForVariables().get(index).getUpperBound();
     }
 
-    @Override public Double getUpperBound(int index) {
-      return super.getUpperBound(index);
+    @Override @Deprecated public Double getUpperBound(int index) {
+      return super.getBoundsForVariables().get(index).getUpperBound();
     }
   }
 }

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/SBXCrossoverTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/crossover/SBXCrossoverTest.java
@@ -1,7 +1,5 @@
 package org.uma.jmetal.operator.crossover;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -13,6 +11,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.exception.InvalidConditionException;
 import org.uma.jmetal.util.checking.exception.InvalidProbabilityValueException;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
@@ -146,14 +145,16 @@ public class SBXCrossoverTest {
 
     List<DoubleSolution> newSolutions = crossover.execute(solutions) ;
 
+    Bounds<Double> bounds0 = solutions.get(0).getBounds(0);
+    Bounds<Double> bounds1 = solutions.get(1).getBounds(0);
     assertThat(newSolutions.get(0).getVariable(0), Matchers
-        .greaterThanOrEqualTo(solutions.get(0).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(0), Matchers
-        .lessThanOrEqualTo(solutions.get(1).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds1.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(0), Matchers
-        .lessThanOrEqualTo(solutions.get(0).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds0.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(0), Matchers
-        .greaterThanOrEqualTo(solutions.get(1).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds1.getLowerBound())) ;
     verify(randomGenerator, times(4)).getRandomValue();
   }
 
@@ -205,22 +206,24 @@ public class SBXCrossoverTest {
 
     List<DoubleSolution> newSolutions = crossover.execute(solutions) ;
 
+    Bounds<Double> bounds0 = solutions.get(0).getBounds(0);
+    Bounds<Double> bounds1 = solutions.get(1).getBounds(0);
     assertThat(newSolutions.get(0).getVariable(0), Matchers
-        .greaterThanOrEqualTo(solutions.get(0).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(0), Matchers
-        .lessThanOrEqualTo(solutions.get(1).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds1.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(0), Matchers
-        .lessThanOrEqualTo(solutions.get(0).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds0.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(0), Matchers
-        .greaterThanOrEqualTo(solutions.get(1).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds1.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(1), Matchers
-        .greaterThanOrEqualTo(solutions.get(0).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds0.getLowerBound())) ;
     assertThat(newSolutions.get(0).getVariable(1), Matchers
-        .lessThanOrEqualTo(solutions.get(1).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds1.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(1), Matchers
-        .lessThanOrEqualTo(solutions.get(0).getUpperBound(0))) ;
+        .lessThanOrEqualTo(bounds0.getUpperBound())) ;
     assertThat(newSolutions.get(1).getVariable(1), Matchers
-        .greaterThanOrEqualTo(solutions.get(1).getLowerBound(0))) ;
+        .greaterThanOrEqualTo(bounds1.getLowerBound())) ;
     verify(randomGenerator, times(7)).getRandomValue();
   }
 
@@ -291,10 +294,10 @@ public class SBXCrossoverTest {
 
 		List<DoubleSolution> solutions = new LinkedList<>();
 
-    List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(0.0, 1.0)) ;
+    List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(0.0, 1.0)) ;
 
-		solutions.add(new DefaultDoubleSolution(bounds, 2));
-		solutions.add(new DefaultDoubleSolution(bounds, 2));
+		solutions.add(new DefaultDoubleSolution(2, bounds));
+		solutions.add(new DefaultDoubleSolution(2, bounds));
 
 		// Check configuration leads to use default generator by default
 		final int[] defaultUses = { 0 };

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/IntegerPolynomialMutationTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/IntegerPolynomialMutationTest.java
@@ -1,7 +1,5 @@
 package org.uma.jmetal.operator.mutation;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -14,6 +12,7 @@ import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.solution.integersolution.impl.DefaultIntegerSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.RandomGenerator;
 import org.uma.jmetal.util.pseudorandom.impl.AuditableRandomGenerator;
@@ -152,9 +151,9 @@ public class IntegerPolynomialMutationTest {
 
     mutation.execute(solution) ;
 
-    assertThat(solution.getVariable(0), Matchers
-        .greaterThanOrEqualTo(solution.getLowerBound(0))) ;
-    assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(solution.getUpperBound(0))) ;
+    Bounds<Integer> bounds = solution.getBounds(0);
+    assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(bounds.getLowerBound()));
+    assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(bounds.getUpperBound())) ;
     verify(randomGenerator, times(2)).getRandomValue();
   }
 
@@ -176,8 +175,9 @@ public class IntegerPolynomialMutationTest {
 
     mutation.execute(solution) ;
 
-    assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(solution.getLowerBound(0))) ;
-    assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(solution.getUpperBound(0))) ;
+    Bounds<Integer> bounds = solution.getBounds(0);
+    assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(bounds.getLowerBound())) ;
+    assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(bounds.getUpperBound())) ;
     verify(randomGenerator, times(2)).getRandomValue();
   }
 
@@ -247,9 +247,9 @@ public class IntegerPolynomialMutationTest {
 		int alpha = 20;
 		RepairDoubleSolutionWithBoundValue solutionRepair = new RepairDoubleSolutionWithBoundValue();
 
-    List<Pair<Integer, Integer>> bounds = Arrays.asList(new ImmutablePair<>(0, 2), new ImmutablePair<>(0, 2)) ;
+    List<Bounds<Integer>> bounds = Arrays.asList(Bounds.create(0, 2), Bounds.create(0, 2)) ;
 
-    IntegerSolution solution = new DefaultIntegerSolution(bounds, 2);
+    IntegerSolution solution = new DefaultIntegerSolution(2, bounds);
 
 		// Check configuration leads to use default generator by default
 		final int[] defaultUses = { 0 };

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/NonUniformMutationTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/NonUniformMutationTest.java
@@ -1,11 +1,10 @@
 package org.uma.jmetal.operator.mutation;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import org.uma.jmetal.operator.mutation.impl.NonUniformMutation;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.impl.AuditableRandomGenerator;
 
@@ -21,9 +20,9 @@ public class NonUniformMutationTest {
 	public void testJMetalRandomGeneratorNotUsedWhenCustomRandomGeneratorProvided() {
 		// Configuration
 
-		List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(0.0, 1.0)) ;
+		List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(0.0, 1.0)) ;
 
-		DoubleSolution solution = new DefaultDoubleSolution(bounds, 2);
+		DoubleSolution solution = new DefaultDoubleSolution(2, bounds);
 
 		// Check configuration leads to use default generator by default
 		final int[] defaultUses = { 0 };

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/PolynomialMutationTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/PolynomialMutationTest.java
@@ -1,7 +1,5 @@
 package org.uma.jmetal.operator.mutation;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -13,6 +11,7 @@ import org.uma.jmetal.problem.doubleproblem.impl.AbstractDoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.exception.InvalidConditionException;
 import org.uma.jmetal.util.checking.exception.InvalidProbabilityValueException;
 import org.uma.jmetal.util.checking.exception.NullParameterException;
@@ -166,9 +165,9 @@ public class PolynomialMutationTest {
 
     mutation.execute(solution) ;
 
-    assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(
-        solution.getLowerBound(0))) ;
-    assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(solution.getUpperBound(0))) ;
+    Bounds<Double> bounds = solution.getBounds(0);
+    assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(bounds.getLowerBound()));
+    assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(bounds.getUpperBound())) ;
     verify(randomGenerator, times(2)).getRandomValue();
   }
 
@@ -189,8 +188,9 @@ public class PolynomialMutationTest {
 
     mutation.execute(solution) ;
 
-    assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(solution.getLowerBound(0))) ;
-    assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(solution.getUpperBound(0))) ;
+    Bounds<Double> bounds = solution.getBounds(0);
+    assertThat(solution.getVariable(0), Matchers.greaterThanOrEqualTo(bounds.getLowerBound())) ;
+    assertThat(solution.getVariable(0), Matchers.lessThanOrEqualTo(bounds.getUpperBound())) ;
     verify(randomGenerator, times(2)).getRandomValue();
   }
 
@@ -243,7 +243,7 @@ public class PolynomialMutationTest {
 
     @Override
     public DoubleSolution createSolution() {
-      return new DefaultDoubleSolution(getVariableBounds(), getNumberOfObjectives()) ;
+      return new DefaultDoubleSolution(getNumberOfObjectives(), getBoundsForVariables()) ;
     }
 
     /** Evaluate() method */
@@ -261,8 +261,8 @@ public class PolynomialMutationTest {
 		int alpha = 20;
 		RepairDoubleSolutionWithBoundValue solutionRepair = new RepairDoubleSolutionWithBoundValue();
 
-    List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(0.0, 1.0)) ;
-    DoubleSolution solution = new DefaultDoubleSolution(bounds, 2) ;
+    List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(0.0, 1.0)) ;
+    DoubleSolution solution = new DefaultDoubleSolution(2, bounds) ;
 
 		// Check configuration leads to use default generator by default
 		final int[] defaultUses = { 0 };

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/SimpleRandomMutationTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/SimpleRandomMutationTest.java
@@ -1,11 +1,10 @@
 package org.uma.jmetal.operator.mutation;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import org.uma.jmetal.operator.mutation.impl.SimpleRandomMutation;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.impl.AuditableRandomGenerator;
 
@@ -21,8 +20,8 @@ public class SimpleRandomMutationTest {
 	public void testJMetalRandomGeneratorNotUsedWhenCustomRandomGeneratorProvided() {
 		// Configuration
 
-		List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(0.0, 1.0)) ;
-		DoubleSolution solution = new DefaultDoubleSolution(bounds, 2) ;
+		List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(0.0, 1.0)) ;
+		DoubleSolution solution = new DefaultDoubleSolution(2, bounds) ;
 
 		// Check configuration leads to use default generator by default
 		final int[] defaultUses = { 0 };

--- a/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/UniformMutationTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/operator/mutation/UniformMutationTest.java
@@ -1,12 +1,11 @@
 package org.uma.jmetal.operator.mutation;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import org.uma.jmetal.operator.mutation.impl.UniformMutation;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.solution.util.repairsolution.impl.RepairDoubleSolutionWithBoundValue;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 import org.uma.jmetal.util.pseudorandom.impl.AuditableRandomGenerator;
 
@@ -21,8 +20,8 @@ public class UniformMutationTest {
 	@Test
 	public void testJMetalRandomGeneratorNotUsedWhenCustomRandomGeneratorProvided() {
 		// Configuration
-		List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(0.0, 1.0)) ;
-		DoubleSolution solution = new DefaultDoubleSolution(bounds, 2) ;
+		List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(0.0, 1.0)) ;
+		DoubleSolution solution = new DefaultDoubleSolution(2, bounds) ;
 
 		// Check configuration leads to use default generator by default
 		final int[] defaultUses = { 0 };

--- a/jmetal-core/src/test/java/org/uma/jmetal/solution/compositesolution/CompositeSolutionTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/solution/compositesolution/CompositeSolutionTest.java
@@ -1,11 +1,11 @@
 package org.uma.jmetal.solution.compositesolution;
 
-import org.apache.commons.lang3.tuple.MutablePair;
 import org.junit.Test;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.solution.integersolution.impl.DefaultIntegerSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 
 import java.util.Arrays;
 
@@ -17,7 +17,7 @@ public class CompositeSolutionTest {
   public void shouldConstructorCreateAValidNotNullCompositeSolutionComposedOfASolution() {
     DoubleSolution doubleSolution =
             new DefaultDoubleSolution(
-                    Arrays.asList(new MutablePair<>(3.0, 5.0)), 3, 0);
+                    3, 0, Arrays.asList(Bounds.create(3.0, 5.0)));
 
     assertNotNull(new CompositeSolution(Arrays.asList(doubleSolution))) ;
   }
@@ -26,10 +26,10 @@ public class CompositeSolutionTest {
   public void shouldConstructorRaiseAnExceptionIfTheNumberOfObjectivesIsIncoherent() {
     DoubleSolution doubleSolution =
             new DefaultDoubleSolution(
-                    Arrays.asList(new MutablePair<>(3.0, 5.0)), 3, 0);
+                    3, 0, Arrays.asList(Bounds.create(3.0, 5.0)));
     IntegerSolution integerSolution =
             new DefaultIntegerSolution(
-                    Arrays.asList(new MutablePair<>(2, 10)), 2, 0);
+                    2, 0, Arrays.asList(Bounds.create(2, 10)));
 
     new CompositeSolution(Arrays.asList(doubleSolution, integerSolution)) ;
   }
@@ -41,10 +41,10 @@ public class CompositeSolutionTest {
     int numberOfConstraints = 1;
     DoubleSolution doubleSolution =
         new DefaultDoubleSolution(
-            Arrays.asList(new MutablePair<>(3.0, 5.0)), numberOfObjectives, numberOfConstraints);
+            numberOfObjectives, numberOfConstraints, Arrays.asList(Bounds.create(3.0, 5.0)));
     IntegerSolution integerSolution =
         new DefaultIntegerSolution(
-            Arrays.asList(new MutablePair<>(2, 10)), numberOfObjectives, numberOfConstraints);
+            numberOfObjectives, numberOfConstraints, Arrays.asList(Bounds.create(2, 10)));
 
     CompositeSolution solution =
         new CompositeSolution(Arrays.asList(doubleSolution, integerSolution));
@@ -66,12 +66,12 @@ public class CompositeSolutionTest {
     int numberOfConstraints = 1;
     DoubleSolution doubleSolution =
         new DefaultDoubleSolution(
-            Arrays.asList(new MutablePair<>(3.0, 5.0), new MutablePair<>(1.0, 3.0)),
             numberOfObjectives,
-            numberOfConstraints);
+            numberOfConstraints,
+            Arrays.asList(Bounds.create(3.0, 5.0), Bounds.create(1.0, 3.0)));
     IntegerSolution integerSolution =
         new DefaultIntegerSolution(
-            Arrays.asList(new MutablePair<>(2, 10)), numberOfObjectives, numberOfConstraints);
+            numberOfObjectives, numberOfConstraints, Arrays.asList(Bounds.create(2, 10)));
 
     CompositeSolution solution =
         new CompositeSolution(Arrays.asList(doubleSolution, integerSolution));

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/bounds/BoundsTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/bounds/BoundsTest.java
@@ -1,0 +1,54 @@
+package org.uma.jmetal.util.bounds;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class BoundsTest {
+
+  @Test
+  void testCreateStoresGivenLowerBound() {
+    assertEquals(123, Bounds.create(123, 456).getLowerBound());
+  }
+
+  @Test
+  void testCreateStoresGivenUpperBound() {
+    assertEquals(456, Bounds.create(123, 456).getUpperBound());
+  }
+
+  @Test
+  void testCreateRejectsNullLowerBound() {
+    assertThrows(IllegalArgumentException.class, () -> Bounds.create(null, 456));
+  }
+
+  @Test
+  void testCreateRejectsNullUpperBound() {
+    assertThrows(IllegalArgumentException.class, () -> Bounds.create(123, null));
+  }
+
+  @Test
+  void testCreateRejectsLowerBoundHigherThanUpperBound() {
+    assertThrows(IllegalArgumentException.class, () -> Bounds.create(456, 123));
+  }
+
+  @Test
+  void testCreateAcceptsLowerBoundEqualsUpperBound() {
+    assertDoesNotThrow(() -> Bounds.create(123, 123));
+  }
+
+  @Test
+  void testRestrictToLowerBoundWhenTooSmall() {
+    assertEquals(123, Bounds.create(123, 456).restrict(0));
+  }
+
+  @Test
+  void testRestrictToUpperBoundWhenTooBig() {
+    assertEquals(456, Bounds.create(123, 456).restrict(999));
+  }
+
+  @Test
+  void testRestrictKeepsUnchangedWhenInRange() {
+    assertEquals(333, Bounds.create(123, 456).restrict(333));
+  }
+
+}

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/front/impl/ArrayFrontTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/front/impl/ArrayFrontTest.java
@@ -1,7 +1,5 @@
 package org.uma.jmetal.util.front.impl;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -12,6 +10,7 @@ import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.solution.integersolution.impl.DefaultIntegerSolution;
 import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.checking.exception.InvalidConditionException;
 import org.uma.jmetal.util.front.Front;
 import org.uma.jmetal.util.point.Point;
@@ -102,9 +101,9 @@ public class ArrayFrontTest {
   public void shouldCreateAnArrayFrontFromAListOfSolutionsHavingOneDoubleSolutionObject() {
     int numberOfObjectives = 3;
 
-    List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(-1.0, 1.0));
+    List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(-1.0, 1.0));
     List<DoubleSolution> list =
-        Arrays.asList(new DefaultDoubleSolution(bounds, numberOfObjectives));
+        Arrays.asList(new DefaultDoubleSolution(numberOfObjectives, bounds));
     Front front = new ArrayFront(list);
 
     assertNotNull(ReflectionTestUtils.getField(front, "points"));
@@ -116,11 +115,11 @@ public class ArrayFrontTest {
   public void shouldCreateAnArrayFrontFromAListOfSolutionsHavingTwoDoubleSolutionObject() {
     int numberOfObjectives = 3;
 
-    List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(-1.0, 1.0));
+    List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(-1.0, 1.0));
     List<DoubleSolution> list =
         Arrays.asList(
-            new DefaultDoubleSolution(bounds, numberOfObjectives),
-            new DefaultDoubleSolution(bounds, numberOfObjectives));
+            new DefaultDoubleSolution(numberOfObjectives, bounds),
+            new DefaultDoubleSolution(numberOfObjectives, bounds));
     Front front = new ArrayFront(list);
 
     assertNotNull(ReflectionTestUtils.getField(front, "points"));
@@ -132,11 +131,11 @@ public class ArrayFrontTest {
   public void shouldCreateAnArrayFrontFromAListOfSolutionsHavingOneSingleSolutionObject() {
     int numberOfObjectives = 3;
 
-    List<Pair<Integer, Integer>> bounds = Arrays.asList(new ImmutablePair<>(0, 1)) ;
+    List<Bounds<Integer>> bounds = Arrays.asList(Bounds.create(0, 1)) ;
 
     List<IntegerSolution> list =
         Arrays.asList(
-            new DefaultIntegerSolution(bounds, numberOfObjectives)) ;
+            new DefaultIntegerSolution(numberOfObjectives, bounds)) ;
     Front front = new ArrayFront(list);
 
     assertNotNull(ReflectionTestUtils.getField(front, "points"));
@@ -160,15 +159,15 @@ public class ArrayFrontTest {
   public void shouldCreateAnArrayFrontFromASolutionListResultInTwoEqualsFronts() {
     int numberOfObjectives = 3;
 
-    List<Pair<Integer, Integer>> bounds = Arrays.asList(new ImmutablePair<>(0, 1)) ;
+    List<Bounds<Integer>> bounds = Arrays.asList(Bounds.create(0, 1)) ;
 
     IntegerSolution solution1 =
-        new DefaultIntegerSolution(bounds, numberOfObjectives);
+        new DefaultIntegerSolution(numberOfObjectives, bounds);
     solution1.setObjective(0, 2);
     solution1.setObjective(0, 235);
     solution1.setObjective(0, -123);
     IntegerSolution solution2 =
-        new DefaultIntegerSolution(bounds, numberOfObjectives);
+        new DefaultIntegerSolution(numberOfObjectives, bounds);
     solution2.setObjective(0, -13234);
     solution2.setObjective(0, 523);
     solution2.setObjective(0, -123423455);

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/solutionattribute/impl/DominanceRankingTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/solutionattribute/impl/DominanceRankingTest.java
@@ -1,11 +1,10 @@
 package org.uma.jmetal.util.solutionattribute.impl;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import org.uma.jmetal.solution.Solution;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.solutionattribute.Ranking;
 
 import java.util.ArrayList;
@@ -21,7 +20,7 @@ import static org.junit.Assert.assertEquals;
  */
 @Deprecated
 public class DominanceRankingTest {
-  private List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(0.0, 1.0)) ;
+  private List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(0.0, 1.0)) ;
 
   @Test
   public void shouldTheRankingOfAnEmptyPopulationReturnZeroSubfronts() {
@@ -35,11 +34,11 @@ public class DominanceRankingTest {
   @Test
   public void shouldTheRankingOfAnEmptyPopulationReturnOneSubfronts(){
     //problem = new DummyProblem(2) ;
-    List<Pair<Double, Double>> bounds = Arrays.asList(new ImmutablePair<>(0.0, 1.0)) ;
+    List<Bounds<Double>> bounds = Arrays.asList(Bounds.create(0.0, 1.0)) ;
     List<DoubleSolution> population = Arrays.<DoubleSolution>asList(
-            new DefaultDoubleSolution(bounds, 2),
-            new DefaultDoubleSolution(bounds, 2),
-            new DefaultDoubleSolution(bounds, 2));
+            new DefaultDoubleSolution(2, bounds),
+            new DefaultDoubleSolution(2, bounds),
+            new DefaultDoubleSolution(2, bounds));
 
     Ranking<DoubleSolution> ranking = new DominanceRanking<DoubleSolution>() ;
     ranking.computeRanking(population) ;
@@ -51,10 +50,10 @@ public class DominanceRankingTest {
   public void shouldRankingOfAPopulationWithTwoNonDominatedSolutionsReturnOneSubfront() {
     List<DoubleSolution>population = new ArrayList<>() ;
 
-    DoubleSolution solution = new DefaultDoubleSolution(bounds, 2) ;
+    DoubleSolution solution = new DefaultDoubleSolution(2, bounds) ;
     solution.setObjective(0, 2.0);
     solution.setObjective(1, 3.0);
-    DoubleSolution solution2 = new DefaultDoubleSolution(bounds, 2);
+    DoubleSolution solution2 = new DefaultDoubleSolution(2, bounds);
     solution2.setObjective(0, 1.0);
     solution2.setObjective(1, 6.0);
 
@@ -79,10 +78,10 @@ public class DominanceRankingTest {
   public void shouldRankingOfAPopulationWithTwoDominatedSolutionsReturnTwoSubfronts() {
     List<DoubleSolution>population = new ArrayList<>() ;
 
-    DoubleSolution solution = new DefaultDoubleSolution(bounds, 2);
+    DoubleSolution solution = new DefaultDoubleSolution(2, bounds);
     solution.setObjective(0, 2.0);
     solution.setObjective(1, 3.0);
-    DoubleSolution solution2 = new DefaultDoubleSolution(bounds, 2) ;
+    DoubleSolution solution2 = new DefaultDoubleSolution(2, bounds) ;
     solution2.setObjective(0, 3.0);
     solution2.setObjective(1, 6.0);
 
@@ -112,13 +111,13 @@ public class DominanceRankingTest {
   public void shouldRankingOfAPopulationWithThreeDominatedSolutionsReturnThreeSubfronts() {
     List<DoubleSolution>population = new ArrayList<>() ;
 
-    DoubleSolution solution = new DefaultDoubleSolution(bounds, 2);
+    DoubleSolution solution = new DefaultDoubleSolution(2, bounds);
     solution.setObjective(0, 2.0);
     solution.setObjective(1, 3.0);
-    DoubleSolution solution2 = new DefaultDoubleSolution(bounds, 2) ;
+    DoubleSolution solution2 = new DefaultDoubleSolution(2, bounds) ;
     solution2.setObjective(0, 3.0);
     solution2.setObjective(1, 6.0);
-    DoubleSolution solution3 = new DefaultDoubleSolution(bounds, 2);
+    DoubleSolution solution3 = new DefaultDoubleSolution(2, bounds);
     solution3.setObjective(0, 4.0);
     solution3.setObjective(1, 8.0);
 
@@ -152,19 +151,19 @@ public class DominanceRankingTest {
   public void shouldRankingOfAPopulationWithFiveSolutionsWorkProperly() {
     List<DoubleSolution>population = new ArrayList<>() ;
 
-    DoubleSolution solution = new DefaultDoubleSolution(bounds, 2);
+    DoubleSolution solution = new DefaultDoubleSolution(2, bounds);
     solution.setObjective(0, 1.0);
     solution.setObjective(1, 0.0);
-    DoubleSolution solution2 = new DefaultDoubleSolution(bounds, 2) ;
+    DoubleSolution solution2 = new DefaultDoubleSolution(2, bounds) ;
     solution2.setObjective(0, 0.6);
     solution2.setObjective(1, 0.6);
-    DoubleSolution solution3 = new DefaultDoubleSolution(bounds, 2) ;
+    DoubleSolution solution3 = new DefaultDoubleSolution(2, bounds) ;
     solution3.setObjective(0, 0.5);
     solution3.setObjective(1, 0.5);
-    DoubleSolution solution4 = new DefaultDoubleSolution(bounds, 2) ;
+    DoubleSolution solution4 = new DefaultDoubleSolution(2, bounds) ;
     solution4.setObjective(0, 1.1);
     solution4.setObjective(1, 0.0);
-    DoubleSolution solution5 = new DefaultDoubleSolution(bounds, 2) ;
+    DoubleSolution solution5 = new DefaultDoubleSolution(2, bounds) ;
     solution5.setObjective(0, 0.0);
     solution5.setObjective(1, 1.0);
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/operator/BLXAlphaCrossoverExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/operator/BLXAlphaCrossoverExample.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.problem.multiobjective.Kursawe;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.comparator.DoubleVariableComparator;
 import org.uma.jmetal.util.fileoutput.SolutionListOutput;
 import org.uma.jmetal.util.fileoutput.impl.DefaultFileOutputContext;
@@ -84,11 +85,12 @@ public class BLXAlphaCrossoverExample {
 
   private static double[][] classify(
       List<DoubleSolution> solutions, DoubleProblem problem, int granularity) {
-    double grain = (problem.getUpperBound(0) - problem.getLowerBound(0)) / granularity;
+    Bounds<Double> bounds = problem.getBoundsForVariables().get(0);
+    double grain = (bounds.getUpperBound() - bounds.getLowerBound()) / granularity;
     double[][] classifier = new double[granularity][];
     for (int i = 0; i < granularity; i++) {
       classifier[i] = new double[2];
-      classifier[i][0] = problem.getLowerBound(0) + i * grain;
+      classifier[i][0] = bounds.getLowerBound() + i * grain;
       classifier[i][1] = 0;
     }
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/operator/IntegerPolynomialMutationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/operator/IntegerPolynomialMutationExample.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.problem.integerproblem.IntegerProblem;
 import org.uma.jmetal.problem.singleobjective.NIntegerMin;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.comparator.IntegerVariableComparator;
 
 import java.io.FileNotFoundException;
@@ -78,11 +79,12 @@ public class IntegerPolynomialMutationExample {
   }
 
   private static double[][] classify(List<IntegerSolution> solutions, IntegerProblem problem, int granularity) {
-    double grain = (problem.getUpperBound(0) - problem.getLowerBound(0)) / granularity ;
+    Bounds<Integer> bounds = problem.getBoundsForVariables().get(0);
+    double grain = (bounds.getUpperBound() - bounds.getLowerBound()) / granularity ;
     double[][] classifier = new double[granularity][] ;
     for (int i = 0 ; i < granularity; i++) {
       classifier[i] = new double[2] ;
-      classifier[i][0] = problem.getLowerBound(0) + i * grain ;
+      classifier[i][0] = bounds.getLowerBound() + i * grain ;
       classifier[i][1] = 0 ;
     }
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/operator/IntegerSBXCrossoverExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/operator/IntegerSBXCrossoverExample.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.problem.integerproblem.IntegerProblem;
 import org.uma.jmetal.problem.multiobjective.NMMin;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.comparator.IntegerVariableComparator;
 
 import java.util.ArrayList;
@@ -82,11 +83,12 @@ public class IntegerSBXCrossoverExample {
   }
 
   private static double[][] classify(List<IntegerSolution> solutions, IntegerProblem problem, int granularity) {
-    double grain = (problem.getUpperBound(0) - problem.getLowerBound(0)) / granularity ;
+    Bounds<Integer> bounds = problem.getBoundsForVariables().get(0);
+    double grain = (bounds.getUpperBound() - bounds.getLowerBound()) / granularity ;
     double[][] classifier = new double[granularity][] ;
     for (int i = 0 ; i < granularity; i++) {
       classifier[i] = new double[2] ;
-      classifier[i][0] = problem.getLowerBound(0) + i * grain ;
+      classifier[i][0] = bounds.getLowerBound() + i * grain ;
       classifier[i][1] = 0 ;
     }
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/operator/PolynomialMutationExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/operator/PolynomialMutationExample.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.problem.singleobjective.Sphere;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.comparator.DoubleVariableComparator;
 
 import java.io.FileNotFoundException;
@@ -76,11 +77,12 @@ public class PolynomialMutationExample {
   }
 
   private static double[][] classify(List<DoubleSolution> solutions, DoubleProblem problem, int granularity) {
-    double grain = (problem.getUpperBound(0) - problem.getLowerBound(0)) / granularity ;
+    Bounds<Double> bounds = problem.getBoundsForVariables().get(0);
+    double grain = (bounds.getUpperBound() - bounds.getLowerBound()) / granularity ;
     double[][] classifier = new double[granularity][] ;
     for (int i = 0 ; i < granularity; i++) {
       classifier[i] = new double[2] ;
-      classifier[i][0] = problem.getLowerBound(0) + i * grain ;
+      classifier[i][0] = bounds.getLowerBound() + i * grain ;
       classifier[i][1] = 0 ;
     }
 

--- a/jmetal-example/src/main/java/org/uma/jmetal/example/operator/SBXCrossoverExample.java
+++ b/jmetal-example/src/main/java/org/uma/jmetal/example/operator/SBXCrossoverExample.java
@@ -8,6 +8,7 @@ import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.problem.multiobjective.Kursawe;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.comparator.DoubleVariableComparator;
 import org.uma.jmetal.util.fileoutput.SolutionListOutput;
 import org.uma.jmetal.util.fileoutput.impl.DefaultFileOutputContext;
@@ -86,11 +87,12 @@ public class SBXCrossoverExample {
   }
 
   private static double[][] classify(List<DoubleSolution> solutions, DoubleProblem problem, int granularity) {
-    double grain = (problem.getUpperBound(0) - problem.getLowerBound(0)) / granularity ;
+    Bounds<Double> bounds = problem.getBoundsForVariables().get(0);
+    double grain = (bounds.getUpperBound() - bounds.getLowerBound()) / granularity ;
     double[][] classifier = new double[granularity][] ;
     for (int i = 0 ; i < granularity; i++) {
       classifier[i] = new double[2] ;
-      classifier[i][0] = problem.getLowerBound(0) + i * grain ;
+      classifier[i][0] = bounds.getLowerBound() + i * grain ;
       classifier[i][1] = 0 ;
     }
 

--- a/jmetal-experimental/src/main/java/org/uma/jmetal/experimental/componentbasedalgorithm/algorithm/multiobjective/smpso/SMPSO.java
+++ b/jmetal-experimental/src/main/java/org/uma/jmetal/experimental/componentbasedalgorithm/algorithm/multiobjective/smpso/SMPSO.java
@@ -7,6 +7,7 @@ import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.archive.BoundedArchive;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.comparator.DominanceComparator;
 import org.uma.jmetal.util.observable.Observable;
 import org.uma.jmetal.util.observable.ObservableEntity;
@@ -145,7 +146,8 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
     deltaMax = new double[problem.getNumberOfVariables()];
     deltaMin = new double[problem.getNumberOfVariables()];
     for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      deltaMax[i] = (problem.getUpperBound(i) - problem.getLowerBound(i)) / 2.0;
+      Bounds<Double> bounds = problem.getBoundsForVariables().get(i);
+      deltaMax[i] = (bounds.getUpperBound() - bounds.getLowerBound()) / 2.0;
       deltaMin[i] = -deltaMax[i];
     }
 
@@ -277,12 +279,15 @@ public class SMPSO extends AbstractParticleSwarmOptimization<DoubleSolution, Lis
       for (int j = 0; j < particle.getNumberOfVariables(); j++) {
         particle.setVariable(j, particle.getVariable(j) + speed[i][j]);
 
-        if (particle.getVariable(j) < problem.getLowerBound(j)) {
-          particle.setVariable(j, problem.getLowerBound(j));
+        Bounds<Double> bounds = problem.getBoundsForVariables().get(j);
+        Double lowerBound = bounds.getLowerBound();
+        Double upperBound = bounds.getUpperBound();
+        if (particle.getVariable(j) < lowerBound) {
+          particle.setVariable(j, lowerBound);
           speed[i][j] = speed[i][j] * changeVelocity1;
         }
-        if (particle.getVariable(j) > problem.getUpperBound(j)) {
-          particle.setVariable(j, problem.getUpperBound(j));
+        if (particle.getVariable(j) > upperBound) {
+          particle.setVariable(j, upperBound);
           speed[i][j] = speed[i][j] * changeVelocity2;
         }
       }

--- a/jmetal-experimental/src/main/java/org/uma/jmetal/experimental/componentbasedalgorithm/algorithm/multiobjective/smpso/SMPSORP.java
+++ b/jmetal-experimental/src/main/java/org/uma/jmetal/experimental/componentbasedalgorithm/algorithm/multiobjective/smpso/SMPSORP.java
@@ -21,6 +21,7 @@ import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.archive.BoundedArchive;
 import org.uma.jmetal.util.archivewithreferencepoint.ArchiveWithReferencePoint;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.comparator.DominanceComparator;
 import org.uma.jmetal.util.measure.impl.BasicMeasure;
 import org.uma.jmetal.util.measure.impl.CountingMeasure;
@@ -134,7 +135,8 @@ public class SMPSORP
     deltaMax = new double[problem.getNumberOfVariables()];
     deltaMin = new double[problem.getNumberOfVariables()];
     for (int i = 0; i < problem.getNumberOfVariables(); i++) {
-      deltaMax[i] = (problem.getUpperBound(i) - problem.getLowerBound(i)) / 2.0;
+      Bounds<Double> bounds = problem.getBoundsForVariables().get(i);
+      deltaMax[i] = (bounds.getUpperBound() - bounds.getLowerBound()) / 2.0;
       deltaMin[i] = -deltaMax[i];
     }
 
@@ -282,12 +284,15 @@ public class SMPSORP
       for (int j = 0; j < particle.getNumberOfVariables(); j++) {
         particle.setVariable(j, particle.getVariable(j) + speed[i][j]);
 
-        if (particle.getVariable(j) < problem.getLowerBound(j)) {
-          particle.setVariable(j, problem.getLowerBound(j));
+        Bounds<Double> bounds = problem.getBoundsForVariables().get(j);
+        Double lowerBound = bounds.getLowerBound();
+        Double upperBound = bounds.getUpperBound();
+        if (particle.getVariable(j) < lowerBound) {
+          particle.setVariable(j, lowerBound);
           speed[i][j] = speed[i][j] * changeVelocity1;
         }
-        if (particle.getVariable(j) > problem.getUpperBound(j)) {
-          particle.setVariable(j, problem.getUpperBound(j));
+        if (particle.getVariable(j) > upperBound) {
+          particle.setVariable(j, upperBound);
           speed[i][j] = speed[i][j] * changeVelocity2;
         }
       }

--- a/jmetal-experimental/src/main/java/org/uma/jmetal/experimental/componentbasedalgorithm/catalogue/solutionscreation/impl/LatinHypercubeSamplingSolutionsCreation.java
+++ b/jmetal-experimental/src/main/java/org/uma/jmetal/experimental/componentbasedalgorithm/catalogue/solutionscreation/impl/LatinHypercubeSamplingSolutionsCreation.java
@@ -5,6 +5,7 @@ import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.util.NormalizeUtils;
+import org.uma.jmetal.util.bounds.Bounds;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,15 +33,16 @@ public class LatinHypercubeSamplingSolutionsCreation
     List<DoubleSolution> solutionList = new ArrayList<>(numberOfSolutionsToCreate);
     for (int i = 0; i < numberOfSolutionsToCreate; i++) {
       DoubleSolution newSolution =
-          new DefaultDoubleSolution(problem.getBounds(), problem.getNumberOfObjectives());
+          new DefaultDoubleSolution(problem.getNumberOfObjectives(), problem.getBoundsForVariables());
       for (int j = 0; j < problem.getNumberOfVariables(); j++) {
         // newSolution.setVariable(j, (double)latinHypercube[i][j]/numberOfSolutionsToCreate);
+        Bounds<Double> bounds = problem.getBoundsForVariables().get(j);
         newSolution.setVariable(
             j,
             NormalizeUtils.normalize(
                 latinHypercube[i][j],
-                problem.getLowerBound(j),
-                problem.getUpperBound(j),
+                bounds.getLowerBound(),
+                bounds.getUpperBound(),
                 0,
                 numberOfSolutionsToCreate));
       }

--- a/jmetal-experimental/src/main/java/org/uma/jmetal/experimental/componentbasedalgorithm/catalogue/solutionscreation/impl/ScatterSearchSolutionsCreation.java
+++ b/jmetal-experimental/src/main/java/org/uma/jmetal/experimental/componentbasedalgorithm/catalogue/solutionscreation/impl/ScatterSearchSolutionsCreation.java
@@ -4,6 +4,7 @@ import org.uma.jmetal.experimental.componentbasedalgorithm.catalogue.solutionscr
 import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ public class ScatterSearchSolutionsCreation implements SolutionsCreation<DoubleS
     for (int i = 0; i < numberOfSolutionsToCreate; i++) {
       List<Double> variables = generateVariables();
       DoubleSolution newSolution =
-          new DefaultDoubleSolution(problem.getBounds(), problem.getNumberOfObjectives());
+          new DefaultDoubleSolution(problem.getNumberOfObjectives(), problem.getBoundsForVariables());
       for (int j = 0; j < problem.getNumberOfVariables(); j++) {
         newSolution.setVariable(j, variables.get(j));
       }
@@ -74,10 +75,11 @@ public class ScatterSearchSolutionsCreation implements SolutionsCreation<DoubleS
       frequency[range][i]++;
       sumOfFrequencyValues[i]++;
 
-      double low =
-          problem.getLowerBound(i)
-              + range * (problem.getUpperBound(i) - problem.getLowerBound(i)) / numberOfSubRanges;
-      double high = low + (problem.getUpperBound(i) - problem.getLowerBound(i)) / numberOfSubRanges;
+      Bounds<Double> bounds = problem.getBoundsForVariables().get(i);
+      Double lowerBound = bounds.getLowerBound();
+      Double upperBound = bounds.getUpperBound();
+      double low = lowerBound + range * (upperBound - lowerBound) / numberOfSubRanges;
+      double high = low + (upperBound - lowerBound) / numberOfSubRanges;
 
       vars.add(i, JMetalRandom.getInstance().nextDouble(low, high));
     }

--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/experiment/component/impl/GenerateReferenceParetoSetAndFrontFromDoubleSolutions.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/experiment/component/impl/GenerateReferenceParetoSetAndFrontFromDoubleSolutions.java
@@ -11,6 +11,7 @@ import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.JMetalException;
 import org.uma.jmetal.util.JMetalLogger;
 import org.uma.jmetal.util.archive.impl.NonDominatedSolutionListArchive;
+import org.uma.jmetal.util.bounds.Bounds;
 import org.uma.jmetal.util.fileoutput.SolutionListOutput;
 import org.uma.jmetal.util.front.Front;
 import org.uma.jmetal.util.front.impl.ArrayFront;
@@ -244,14 +245,29 @@ public class GenerateReferenceParetoSetAndFrontFromDoubleSolutions implements Ex
       return null;
     }
 
+	/**
+	 * @deprecated Use {@link #getBounds(int)}{@link Bounds#getLowerBound()
+	 *             .getLowerBound()} instead.
+	 */
+	@Deprecated
     @Override
     public Double getLowerBound(int index) {
       return null;
     }
 
+	/**
+	 * @deprecated Use {@link #getBounds(int)}{@link Bounds#getUpperBound()
+	 *             .getUpperBound()} instead.
+	 */
+	@Deprecated
     @Override
     public Double getUpperBound(int index) {
       return null;
+    }
+    
+    @Override
+    public Bounds<Double> getBounds(int index) {
+    	return null;
     }
   }
 }

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/MixedIntegerDoubleProblem.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/MixedIntegerDoubleProblem.java
@@ -1,13 +1,12 @@
 package org.uma.jmetal.problem.multiobjective;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.uma.jmetal.problem.AbstractGenericProblem;
 import org.uma.jmetal.solution.compositesolution.CompositeSolution;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.solution.integersolution.IntegerSolution;
 import org.uma.jmetal.solution.integersolution.impl.DefaultIntegerSolution;
+import org.uma.jmetal.util.bounds.Bounds ;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,8 +24,8 @@ import java.util.List;
 public class MixedIntegerDoubleProblem extends AbstractGenericProblem<CompositeSolution> {
   private int valueN;
   private int valueM;
-  private List<Pair<Integer, Integer>> integerBounds;
-  private List<Pair<Double, Double>> doubleBounds;
+  private List<Bounds<Integer>> integerBounds;
+  private List<Bounds<Double>> doubleBounds;
 
   public MixedIntegerDoubleProblem() {
     this(10, 10, 100, -100, -1000, +1000);
@@ -50,11 +49,11 @@ public class MixedIntegerDoubleProblem extends AbstractGenericProblem<CompositeS
     doubleBounds = new ArrayList<>(numberOfDoubleVariables);
 
     for (int i = 0; i < numberOfIntegerVariables; i++) {
-      integerBounds.add(new ImmutablePair<>(lowerBound, upperBound));
+      integerBounds.add(Bounds.create(lowerBound, upperBound));
     }
 
     for (int i = 0; i < numberOfDoubleVariables; i++) {
-      doubleBounds.add(new ImmutablePair<>((double) lowerBound, (double) upperBound));
+      doubleBounds.add(Bounds.create((double) lowerBound, (double) upperBound));
     }
   }
 
@@ -85,8 +84,8 @@ public class MixedIntegerDoubleProblem extends AbstractGenericProblem<CompositeS
 
   @Override
   public CompositeSolution createSolution() {
-    IntegerSolution integerSolution = new DefaultIntegerSolution(integerBounds, getNumberOfObjectives(), getNumberOfConstraints()) ;
-    DoubleSolution doubleSolution = new DefaultDoubleSolution(doubleBounds, getNumberOfObjectives(), getNumberOfConstraints()) ;
+    IntegerSolution integerSolution = new DefaultIntegerSolution(getNumberOfObjectives(), getNumberOfConstraints(), integerBounds) ;
+    DoubleSolution doubleSolution = new DefaultDoubleSolution(getNumberOfObjectives(), getNumberOfConstraints(), doubleBounds) ;
     return new CompositeSolution(Arrays.asList(integerSolution, doubleSolution));
   }
 }

--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF09.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/maf/MaF09.java
@@ -2,6 +2,7 @@ package org.uma.jmetal.problem.multiobjective.maf;
 
 import org.uma.jmetal.problem.doubleproblem.impl.AbstractDoubleProblem;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.bounds.Bounds ;
 import org.uma.jmetal.util.pseudorandom.JMetalRandom;
 
 import java.awt.geom.Point2D;
@@ -158,7 +159,8 @@ public class MaF09 extends AbstractDoubleProblem {
     while (infeasible) {
       //re-generate a random variable
       for (int i = 0; i < numberOfVariables_; i++) {
-        x[i] = generV(getLowerBound(i), getUpperBound(i));
+        Bounds<Double> bounds = getBoundsForVariables().get(i) ;
+        x[i] = generV(bounds.getLowerBound(), bounds.getUpperBound());
         solution.setVariable(i, x[i]);
       }
       infeasible = if_infeasible(x);


### PR DESCRIPTION
We basically always call them together:
```java
solution.getLowerBound(i)
solution.getUpperBound(i)
```
Depending on the implementation, it means we systematically do twice the search.
Since we always ask them together, let's just put them together and search once:
```java
bounds = solution.getBounds(i);
bounds.getLowerBound()
bounds.getUpperBound()
```

This PR does exactly that (and deprecates the two legacy methods) for the two solution interfaces concerned with this issue:
- `DoubleSolution`
- `IntegerSolution`

It also covers the related bounded problems.

Since lower and upper bounds are stored in `Pair` in some places, we replace them by proper `Bounds` to avoid conversion overhead. Again, constructors and getters based on `Pair` are deprecated and replaced by ones using `Bounds`.

All use the same generic interface which can be applied to any `Comparable` type:
```java
interface Bounds<T extends Comparable<T>>
```
so feel free to reuse if you have bounds elsewhere, like for `RepairDoubleSolution` which also use lower and upper bounds.

A coincidental advantage is that it simplifies the refactoring for #411 (more specifically #413 and later PRs).