### PR TITLE
Make bounds in BoundedProblem comparable

### DIFF
--- a/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/problem/BoundedProblem.java
@@ -16,7 +16,7 @@ import java.util.List;
  * @param <S>
  *          Type of {@link Problem} solutions
  */
-public interface BoundedProblem<T extends Number, S> extends Problem<S> {
+public interface BoundedProblem<T extends Number & Comparable<T>, S> extends Problem<S> {
   /**
    * @param index
    *          index of the variable


### PR DESCRIPTION
There is no sense in bounds not being comparable since bounds should be compared to values to check them.

Adding this generics enforces it at compilation time and unlock future generic refactoring.