### PR TITLE
Bump weka dependency from 3.8.1 to 3.8.5

### DIFF
--- a/jmetal-core/pom.xml
+++ b/jmetal-core/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>nz.ac.waikato.cms.weka</groupId>
             <artifactId>weka-stable</artifactId>
-            <version>3.8.1</version>
+            <version>3.8.5</version>
         </dependency>
         <dependency>
             <groupId>com.github.mbuzdalov</groupId>


### PR DESCRIPTION
Update weka dependency to solve duplicate class in new Java module system. Fix #435