### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/jmetal-lab/src/main/java/org/uma/jmetal/lab/visualization/plot/impl/PlotSmile.java
+++ b/jmetal-lab/src/main/java/org/uma/jmetal/lab/visualization/plot/impl/PlotSmile.java
@@ -31,6 +31,7 @@ public class PlotSmile implements PlotFront {
       canvas.window() ;
     } catch (InterruptedException e) {
       e.printStackTrace();
+      Thread.currentThread().interrupt();
     } catch (InvocationTargetException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.