### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mosa/cooling/impl/Logarithmic.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/mosa/cooling/impl/Logarithmic.java
@@ -9,6 +9,6 @@ public class Logarithmic implements CoolingScheme {
 
   @Override
   public double updateTemperature(double temperature, int iteration) {
-    return Math.log(iteration) / Math.log(iteration + 1) * temperature ;
+    return Math.log(iteration) / Math.log(iteration + 1D ) * temperature ;
   }
 }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2184: 'Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.