### PR TITLE
Make the default logger respect JVM parameter

### DIFF
--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/experiment/SwarmIntelligenceStudy10000Final.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/experiment/SwarmIntelligenceStudy10000Final.java
@@ -11,7 +11,7 @@ import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
 import org.uma.jmetal.component.algorithm.ParticleSwarmOptimizationAlgorithm;
 import org.uma.jmetal.lab.experiment.Experiment;
 import org.uma.jmetal.lab.experiment.ExperimentBuilder;
-import org.uma.jmetal.lab.experiment.component.impl.ComputeQualityIndicators;
+import org.uma.jmetal.lab.experiment.component.impl.GenerateBoxplotsWithR;
 import org.uma.jmetal.lab.experiment.util.ExperimentAlgorithm;
 import org.uma.jmetal.lab.experiment.util.ExperimentProblem;
 import org.uma.jmetal.problem.Problem;
@@ -110,9 +110,9 @@ public class SwarmIntelligenceStudy10000Final {
             .setNumberOfCores(8)
             .build();
 
-   //new ExecuteAlgorithms<>(experiment).run();
+    /*
+   new ExecuteAlgorithms<>(experiment).run();
    new ComputeQualityIndicators<>(experiment).run();
-   /*
    new GenerateLatexTablesWithStatistics(experiment).run();
    new GenerateWilcoxonTestTablesWithR<>(experiment).run();
    new GenerateFriedmanHolmTestTables<>(experiment).run();
@@ -120,6 +120,8 @@ public class SwarmIntelligenceStudy10000Final {
     new GenerateHtmlPages<>(experiment, StudyVisualizer.TYPE_OF_FRONT_TO_SHOW.MEDIAN).run();
 
     */
+    new GenerateBoxplotsWithR<>(experiment).setRows(3).setColumns(3).setDisplayNotch().run();
+
   }
   /**
    * The algorithm list is composed of pairs {@link Algorithm} + {@link Problem} which form part of

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/JMetalLogger.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/JMetalLogger.java
@@ -30,7 +30,8 @@ public class JMetalLogger implements Serializable {
 
 	static {
 		/*
-		 * Configure the loggers with the default configuration. If the
+		 * Configure the loggers with the default configuration and the
+		 * `java.util.logging.config.file` JVM property, if provided. If the
 		 * configuration method is called manually, this default configuration
 		 * will be called before anyway, leading to 2 configuration calls,
 		 * although only the last one is considered. This is a trade off to
@@ -39,7 +40,11 @@ public class JMetalLogger implements Serializable {
 		 * have at least the default configuration.
 		 */
 		try {
-			configureLoggers(null);
+			var value = System.getProperty("java.util.logging.config.file");
+			if (value != null)
+				configureLoggers(new File(value));
+			else
+				configureLoggers(null);
 		} catch (IOException e) {
 			throw new RuntimeException(
 					"Impossible to configure the loggers in a static way", e);


### PR DESCRIPTION
This change forces the default logger to respect the JVM parameter `-Djava.util.logging.config.file`.

The previous implementations created the log file in disk even if you tried to override it executing `JMetalLogger.configureLoggers` again.


Github seems to be acting up, for some reason the commit https://github.com/jMetal/jMetal/commit/4be75b5a23a916b39b9bf125ca6b121b26ea4740, is being shown as part of this PR even if it was pushed before and is already part of the main branch.