### PR TITLE
Use constructor arg to get number of variables in UF9

### DIFF
--- a/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/UF/UF9.java
+++ b/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/UF/UF9.java
@@ -38,7 +38,7 @@ public class UF9 extends AbstractDoubleProblem {
     upperLimit.add(1.0);
     lowerLimit.add(0.0);
     upperLimit.add(1.0);
-    for (int i = 2; i < numberOfVariables(); i++) {
+    for (int i = 2; i < numberOfVariables; i++) {
       lowerLimit.add(-2.0);
       upperLimit.add(2.0);
     }


### PR DESCRIPTION
Calling the UF9 constructor results in a NullPointerException because it's calling the function `numberOfVariables()` which requires the `bounds` to be set.  Instead, use the argument `numberOfVariables`.

```
    [junit] Cannot invoke "java.util.List.size()" because "this.bounds" is null
    [junit] java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because "this.bounds" is null
    [junit] 	at org.uma.jmetal.problem.doubleproblem.impl.AbstractDoubleProblem.numberOfVariables(AbstractDoubleProblem.java:27)
    [junit] 	at org.uma.jmetal.problem.multiobjective.UF.UF9.<init>(UF9.java:41)
    [junit] 	at org.uma.jmetal.problem.multiobjective.UF.UF9.<init>(UF9.java:20)
```