### PR TITLE
fix: expose AGE-MOEA tuning configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,7 @@ docs/_templates
 
 testoutput
 
+.codex-age-cp.txt
+**/.codex-age-cp.txt
+plot_outputs/
+

--- a/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/agemoea/util/AGEMOEAEnvironmentalSelection.java
+++ b/jmetal-algorithm/src/main/java/org/uma/jmetal/algorithm/multiobjective/agemoea/util/AGEMOEAEnvironmentalSelection.java
@@ -68,6 +68,8 @@ public class AGEMOEAEnvironmentalSelection<S extends Solution<?>> {
      * @param front
      */
     public void computeSurvivalScore(List<S> front){
+        resetState();
+
         // list to keep track of solutions selected when assigning the survival scores
         List<Integer> selected = new ArrayList<>();
 
@@ -221,7 +223,7 @@ public class AGEMOEAEnvironmentalSelection<S extends Solution<?>> {
         for (S solution : front){
             double[] normalizedObjective = solution.objectives().clone();
             for(int i=0; i<this.numberOfObjectives; i++){
-                if (intercepts != null && intercepts.size() == 0)
+                if (intercepts != null && !intercepts.isEmpty())
                     normalizedObjective[i] = normalizedObjective[i] / intercepts.get(i);
             }
             double value =  this.minkowskiDistance(normalizedObjective, idealPoint, P);
@@ -329,6 +331,11 @@ public class AGEMOEAEnvironmentalSelection<S extends Solution<?>> {
 
     public static String getAttributeId() {
         return attributeId;
+    }
+
+    private void resetState() {
+        P = 1.0;
+        intercepts = null;
     }
 
     public List<Double> computeIdealPoint(List<S> population) {

--- a/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/agemoea/util/AGEMOEAEnvironmentalSelectionTest.java
+++ b/jmetal-algorithm/src/test/java/org/uma/jmetal/algorithm/multiobjective/agemoea/util/AGEMOEAEnvironmentalSelectionTest.java
@@ -5,6 +5,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import org.uma.jmetal.problem.doubleproblem.impl.FakeDoubleProblem;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.solution.doublesolution.impl.DefaultDoubleSolution;
 import org.uma.jmetal.util.ranking.Ranking;
 import org.uma.jmetal.util.ranking.impl.FastNonDominatedSortRanking;
@@ -170,5 +172,69 @@ public class AGEMOEAEnvironmentalSelectionTest {
 
         AGEMOEAEnvironmentalSelection es = new AGEMOEAEnvironmentalSelection(2);
         assertEquals(0.0, es.point2LineDistance(P, A, B));
+    }
+
+    @Test
+    public void testAssignConvergenceScoreNormalizesObjectivesWhenInterceptsAreAvailable() {
+        FakeDoubleProblem problem = new FakeDoubleProblem(2, 2, 0);
+        DoubleSolution solution = solutionWithObjectives(problem, 1.0, 1.0);
+
+        TestEnvironmentalSelection environmentalSelection = new TestEnvironmentalSelection(2);
+        environmentalSelection.setState(1.0, List.of(2.0, 2.0));
+
+        environmentalSelection.assignConvergenceScores(List.of(solution));
+
+        assertEquals(1.0,
+            solution.attributes().get(AGEMOEAEnvironmentalSelection.getAttributeId()));
+    }
+
+    @Test
+    public void testExecuteResetsTheInternalStateBeforeScoringAnotherPopulation() {
+        FakeDoubleProblem problem = new FakeDoubleProblem(2, 2, 0);
+        TestEnvironmentalSelection environmentalSelection = new TestEnvironmentalSelection(2);
+
+        List<DoubleSolution> firstPopulation = List.of(
+            solutionWithObjectives(problem, 1.0, 0.0),
+            solutionWithObjectives(problem, 0.0, 1.0),
+            solutionWithObjectives(problem, 1.0 / Math.sqrt(2.0), 1.0 / Math.sqrt(2.0)));
+
+        environmentalSelection.execute(firstPopulation, 3);
+
+        DoubleSolution dominatedSolution = solutionWithObjectives(problem, 2.0, 2.0);
+        List<DoubleSolution> secondPopulation = List.of(
+            solutionWithObjectives(problem, 0.0, 1.0),
+            solutionWithObjectives(problem, 1.0, 0.0),
+            dominatedSolution);
+
+        environmentalSelection.execute(secondPopulation, 3);
+
+        assertEquals(4.0,
+            dominatedSolution.attributes().get(AGEMOEAEnvironmentalSelection.getAttributeId()));
+    }
+
+    private DoubleSolution solutionWithObjectives(
+        FakeDoubleProblem problem, double firstObjective, double secondObjective) {
+        DoubleSolution solution = problem.createSolution();
+        solution.objectives()[0] = firstObjective;
+        solution.objectives()[1] = secondObjective;
+
+        return solution;
+    }
+
+    private static class TestEnvironmentalSelection
+        extends AGEMOEAEnvironmentalSelection<DoubleSolution> {
+
+        TestEnvironmentalSelection(int numberOfObjectives) {
+            super(numberOfObjectives);
+        }
+
+        void setState(double p, List<Double> intercepts) {
+            P = p;
+            this.intercepts = new ArrayList<>(intercepts);
+        }
+
+        void assignConvergenceScores(List<DoubleSolution> front) {
+            assignConvergenceScore(front);
+        }
     }
 }

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/autoconfigurablealgorithm/AutoAGEMOEA.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/autoconfigurablealgorithm/AutoAGEMOEA.java
@@ -1,0 +1,298 @@
+package org.uma.jmetal.auto.autoconfigurablealgorithm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.uma.jmetal.auto.parameter.CategoricalIntegerParameter;
+import org.uma.jmetal.auto.parameter.CategoricalParameter;
+import org.uma.jmetal.auto.parameter.IntegerParameter;
+import org.uma.jmetal.auto.parameter.Parameter;
+import org.uma.jmetal.auto.parameter.PositiveIntegerValue;
+import org.uma.jmetal.auto.parameter.RealParameter;
+import org.uma.jmetal.auto.parameter.StringParameter;
+import org.uma.jmetal.auto.parameter.catalogue.CreateInitialSolutionsParameter;
+import org.uma.jmetal.auto.parameter.catalogue.CrossoverParameter;
+import org.uma.jmetal.auto.parameter.catalogue.MutationParameter;
+import org.uma.jmetal.auto.parameter.catalogue.ProbabilityParameter;
+import org.uma.jmetal.auto.parameter.catalogue.RepairDoubleSolutionStrategyParameter;
+import org.uma.jmetal.auto.parameter.catalogue.SelectionParameter;
+import org.uma.jmetal.auto.parameter.catalogue.VariationParameter;
+import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
+import org.uma.jmetal.component.algorithm.multiobjective.AGEMOEABuilder;
+import org.uma.jmetal.component.catalogue.common.solutionscreation.SolutionsCreation;
+import org.uma.jmetal.component.catalogue.common.termination.impl.TerminationByEvaluations;
+import org.uma.jmetal.component.catalogue.ea.replacement.Replacement;
+import org.uma.jmetal.component.catalogue.ea.replacement.impl.AGEMOEAReplacement;
+import org.uma.jmetal.component.catalogue.ea.replacement.impl.agemoea.AGEMOEA2EnvironmentalSelection;
+import org.uma.jmetal.component.catalogue.ea.replacement.impl.agemoea.AGEMOEAEnvironmentalSelection;
+import org.uma.jmetal.component.catalogue.ea.replacement.impl.agemoea.SurvivalScoreComparator;
+import org.uma.jmetal.component.catalogue.ea.selection.Selection;
+import org.uma.jmetal.component.catalogue.ea.variation.Variation;
+import org.uma.jmetal.operator.crossover.CrossoverOperator;
+import org.uma.jmetal.operator.mutation.MutationOperator;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.problem.ProblemFactory;
+import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.errorchecking.JMetalException;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
+
+/**
+ * Class to configure AGE-MOEA with an argument string using class {@link EvolutionaryAlgorithm}.
+ *
+ * <p>The AGE family variant and the environmental selection are independently configurable so they
+ * can be tuned with auto-configuration tools such as irace.
+ */
+public class AutoAGEMOEA implements AutoConfigurableAlgorithm {
+  private final List<Parameter<?>> configurableParameterList = new ArrayList<>();
+  private final List<Parameter<?>> fixedParameterList = new ArrayList<>();
+  private StringParameter problemNameParameter;
+  public StringParameter referenceFrontFilename;
+  private PositiveIntegerValue randomGeneratorSeedParameter;
+  private PositiveIntegerValue maximumNumberOfEvaluationsParameter;
+  private PositiveIntegerValue populationSizeParameter;
+  private CategoricalParameter algorithmVariantParameter;
+  private CategoricalParameter environmentalSelectionParameter;
+  private CategoricalParameter replacementParameter;
+  private CreateInitialSolutionsParameter createInitialSolutionsParameter;
+  private SelectionParameter<DoubleSolution> selectionParameter;
+  private VariationParameter variationParameter;
+
+  @Override
+  public List<Parameter<?>> configurableParameterList() {
+    return configurableParameterList;
+  }
+
+  @Override
+  public List<Parameter<?>> fixedParameterList() {
+    return fixedParameterList;
+  }
+
+  public AutoAGEMOEA() {
+    configure();
+  }
+
+  private void configure() {
+    problemNameParameter = new StringParameter("problemName");
+    randomGeneratorSeedParameter = new PositiveIntegerValue("randomGeneratorSeed");
+    referenceFrontFilename = new StringParameter("referenceFrontFileName");
+    maximumNumberOfEvaluationsParameter =
+        new PositiveIntegerValue("maximumNumberOfEvaluations");
+    populationSizeParameter = new PositiveIntegerValue("populationSize");
+
+    fixedParameterList.add(populationSizeParameter);
+    fixedParameterList.add(problemNameParameter);
+    fixedParameterList.add(referenceFrontFilename);
+    fixedParameterList.add(maximumNumberOfEvaluationsParameter);
+    fixedParameterList.add(randomGeneratorSeedParameter);
+
+    algorithmVariant();
+    environmentalSelection();
+    replacement();
+    createInitialSolution();
+    selection();
+    variation();
+
+    configurableParameterList.add(algorithmVariantParameter);
+    configurableParameterList.add(environmentalSelectionParameter);
+    configurableParameterList.add(replacementParameter);
+    configurableParameterList.add(createInitialSolutionsParameter);
+    configurableParameterList.add(variationParameter);
+    configurableParameterList.add(selectionParameter);
+  }
+
+  private void algorithmVariant() {
+    algorithmVariantParameter =
+        new CategoricalParameter("algorithmVariant", List.of("agemoea", "agemoeaii"));
+  }
+
+  private void environmentalSelection() {
+    environmentalSelectionParameter =
+        new CategoricalParameter("environmentalSelection", List.of("agemoea", "agemoeaii"));
+  }
+
+  private void replacement() {
+    replacementParameter =
+        new CategoricalParameter("replacement", List.of("agemoeaReplacement"));
+  }
+
+  private void variation() {
+    CrossoverParameter crossoverParameter =
+        new CrossoverParameter(List.of("SBX", "BLX_ALPHA", "wholeArithmetic"));
+    ProbabilityParameter crossoverProbability =
+        new ProbabilityParameter("crossoverProbability");
+    crossoverParameter.addGlobalParameter(crossoverProbability);
+    RepairDoubleSolutionStrategyParameter crossoverRepairStrategy =
+        new RepairDoubleSolutionStrategyParameter(
+            "crossoverRepairStrategy", Arrays.asList("random", "round", "bounds"));
+    crossoverParameter.addGlobalParameter(crossoverRepairStrategy);
+
+    RealParameter distributionIndex = new RealParameter("sbxDistributionIndex", 5.0, 400.0);
+    crossoverParameter.addSpecificParameter("SBX", distributionIndex);
+
+    RealParameter alpha = new RealParameter("blxAlphaCrossoverAlphaValue", 0.0, 1.0);
+    crossoverParameter.addSpecificParameter("BLX_ALPHA", alpha);
+
+    MutationParameter mutationParameter =
+        new MutationParameter(
+            Arrays.asList("uniform", "polynomial", "linkedPolynomial", "nonUniform"));
+
+    RealParameter mutationProbabilityFactor =
+        new RealParameter("mutationProbabilityFactor", 0.0, 2.0);
+    mutationParameter.addGlobalParameter(mutationProbabilityFactor);
+    RepairDoubleSolutionStrategyParameter mutationRepairStrategy =
+        new RepairDoubleSolutionStrategyParameter(
+            "mutationRepairStrategy", Arrays.asList("random", "round", "bounds"));
+    mutationParameter.addGlobalParameter(mutationRepairStrategy);
+
+    RealParameter distributionIndexForPolynomialMutation =
+        new RealParameter("polynomialMutationDistributionIndex", 5.0, 400.0);
+    mutationParameter.addSpecificParameter("polynomial", distributionIndexForPolynomialMutation);
+
+    RealParameter distributionIndexForLinkedPolynomialMutation =
+        new RealParameter("linkedPolynomialMutationDistributionIndex", 5.0, 400.0);
+    mutationParameter.addSpecificParameter(
+        "linkedPolynomial", distributionIndexForLinkedPolynomialMutation);
+
+    RealParameter uniformMutationPerturbation =
+        new RealParameter("uniformMutationPerturbation", 0.0, 1.0);
+    mutationParameter.addSpecificParameter("uniform", uniformMutationPerturbation);
+
+    RealParameter nonUniformMutationPerturbation =
+        new RealParameter("nonUniformMutationPerturbation", 0.0, 1.0);
+    mutationParameter.addSpecificParameter("nonUniform", nonUniformMutationPerturbation);
+
+    CategoricalIntegerParameter offspringPopulationSizeParameter =
+        new CategoricalIntegerParameter(
+            "offspringPopulationSize",
+            List.of(1, 2, 5, 10, 20, 50, 100, 150, 200, 300, 400));
+
+    variationParameter =
+        new VariationParameter(List.of("crossoverAndMutationVariation"));
+    variationParameter.addSpecificParameter("crossoverAndMutationVariation",
+        offspringPopulationSizeParameter);
+    variationParameter.addSpecificParameter("crossoverAndMutationVariation", crossoverParameter);
+    variationParameter.addSpecificParameter("crossoverAndMutationVariation", mutationParameter);
+  }
+
+  private void selection() {
+    selectionParameter = new SelectionParameter<>(Arrays.asList("tournament", "random"));
+    IntegerParameter selectionTournamentSize =
+        new IntegerParameter("selectionTournamentSize", 2, 10);
+    selectionParameter.addSpecificParameter("tournament", selectionTournamentSize);
+  }
+
+  private void createInitialSolution() {
+    createInitialSolutionsParameter =
+        new CreateInitialSolutionsParameter(
+            Arrays.asList("random", "latinHypercubeSampling", "scatterSearch"));
+  }
+
+  @Override
+  public void parse(String[] arguments) {
+    for (Parameter<?> parameter : fixedParameterList) {
+      parameter.parse(arguments).check();
+    }
+    for (Parameter<?> parameter : configurableParameterList()) {
+      parameter.parse(arguments).check();
+    }
+  }
+
+  protected Problem<DoubleSolution> problem() {
+    return ProblemFactory.loadProblem(problemNameParameter.value());
+  }
+
+  /**
+   * Creates an instance of AGE-MOEA from the parsed parameters.
+   *
+   * @return the configured evolutionary algorithm
+   */
+  public EvolutionaryAlgorithm<DoubleSolution> create() {
+    JMetalRandom.getInstance().setSeed(randomGeneratorSeedParameter.value());
+
+    DoubleProblem problem = (DoubleProblem) problem();
+    var initialSolutionsCreation =
+        (SolutionsCreation<DoubleSolution>)
+            createInitialSolutionsParameter.getParameter(problem, populationSizeParameter.value());
+
+    MutationParameter mutationParameter =
+        (MutationParameter) variationParameter.findSpecificParameter("mutation");
+    mutationParameter.addNonConfigurableParameter(
+        "numberOfProblemVariables", problem.numberOfVariables());
+
+    if (mutationParameter.value().equals("nonUniform")) {
+      mutationParameter.addSpecificParameter("nonUniform", maximumNumberOfEvaluationsParameter);
+      mutationParameter.addNonConfigurableParameter(
+          "maxIterations",
+          maximumNumberOfEvaluationsParameter.value() / populationSizeParameter.value());
+    }
+
+    CrossoverParameter crossoverParameter =
+        (CrossoverParameter) variationParameter.findSpecificParameter("crossover");
+    CrossoverOperator<DoubleSolution> crossover = crossoverParameter.getDoubleSolutionParameter();
+    MutationOperator<DoubleSolution> mutation = mutationParameter.getDoubleSolutionParameter();
+
+    Variation<DoubleSolution> variation =
+        (Variation<DoubleSolution>) variationParameter.getDoubleSolutionParameter();
+
+    AGEMOEAEnvironmentalSelection<DoubleSolution> environmentalSelection =
+        environmentalSelection(problem.numberOfObjectives());
+
+    AGEMOEABuilder<DoubleSolution> builder =
+        new AGEMOEABuilder<>(
+            problem,
+            populationSizeParameter.value(),
+            variation.offspringPopulationSize(),
+            crossover,
+            mutation,
+            variant())
+            .setCreateInitialPopulation(initialSolutionsCreation)
+            .setTermination(new TerminationByEvaluations(maximumNumberOfEvaluationsParameter.value()))
+            .setEnvironmentalSelection(environmentalSelection)
+            .setReplacement(replacement(environmentalSelection));
+
+    if ("tournament".equals(selectionParameter.value())) {
+      int tournamentSize =
+          (Integer) selectionParameter.findSpecificParameter("selectionTournamentSize").value();
+      builder.setTournamentSize(tournamentSize);
+    } else {
+      Selection<DoubleSolution> selection =
+          selectionParameter.getParameter(variation.matingPoolSize(), new SurvivalScoreComparator<>());
+      builder.setSelection(selection);
+    }
+
+    return builder.build();
+  }
+
+  private AGEMOEABuilder.Variant variant() {
+    return switch (algorithmVariantParameter.value()) {
+      case "agemoea" -> AGEMOEABuilder.Variant.AGEMOEA;
+      case "agemoeaii" -> AGEMOEABuilder.Variant.AGEMOEAII;
+      default -> throw new JMetalException(
+          "Algorithm variant unknown: " + algorithmVariantParameter.value());
+    };
+  }
+
+  private AGEMOEAEnvironmentalSelection<DoubleSolution> environmentalSelection(
+      int numberOfObjectives) {
+    return switch (environmentalSelectionParameter.value()) {
+      case "agemoea" -> new AGEMOEAEnvironmentalSelection<>(numberOfObjectives);
+      case "agemoeaii" -> new AGEMOEA2EnvironmentalSelection<>(numberOfObjectives);
+      default -> throw new JMetalException(
+          "Environmental selection unknown: " + environmentalSelectionParameter.value());
+    };
+  }
+
+  private Replacement<DoubleSolution> replacement(
+      AGEMOEAEnvironmentalSelection<DoubleSolution> environmentalSelection) {
+    return switch (replacementParameter.value()) {
+      case "agemoeaReplacement" -> new AGEMOEAReplacement<>(environmentalSelection);
+      default -> throw new JMetalException(
+          "Replacement component unknown: " + replacementParameter.value());
+    };
+  }
+
+  public static void print(List<Parameter<?>> parameterList) {
+    parameterList.forEach(System.out::println);
+  }
+}

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/irace/AutoAGEMOEAIraceNHV.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/irace/AutoAGEMOEAIraceNHV.java
@@ -1,0 +1,37 @@
+package org.uma.jmetal.auto.irace;
+
+import static org.uma.jmetal.util.SolutionListUtils.getMatrixWithObjectiveValues;
+
+import java.io.IOException;
+import org.uma.jmetal.auto.autoconfigurablealgorithm.AutoAGEMOEA;
+import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
+import org.uma.jmetal.qualityindicator.impl.NormalizedHypervolume;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.NormalizeUtils;
+import org.uma.jmetal.util.VectorUtils;
+
+public class AutoAGEMOEAIraceNHV {
+  public static void main(String[] args) throws IOException {
+    AutoAGEMOEA ageMoeaWithParameters = new AutoAGEMOEA();
+    ageMoeaWithParameters.parse(args);
+
+    EvolutionaryAlgorithm<DoubleSolution> ageMoea = ageMoeaWithParameters.create();
+    ageMoea.run();
+
+    String referenceFrontFile =
+        "resources/referenceFrontsCSV/" + ageMoeaWithParameters.referenceFrontFilename.value();
+
+    double[][] referenceFront = VectorUtils.readVectors(referenceFrontFile, ",");
+    double[][] front = getMatrixWithObjectiveValues(ageMoea.result());
+
+    double[][] normalizedReferenceFront = NormalizeUtils.normalize(referenceFront);
+    double[][] normalizedFront =
+        NormalizeUtils.normalize(
+            front,
+            NormalizeUtils.getMinValuesOfTheColumnsOfAMatrix(referenceFront),
+            NormalizeUtils.getMaxValuesOfTheColumnsOfAMatrix(referenceFront));
+
+    var qualityIndicator = new NormalizedHypervolume(normalizedReferenceFront);
+    System.out.println(qualityIndicator.compute(normalizedFront));
+  }
+}

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/irace/AutoAGEMOEASavingFront.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/irace/AutoAGEMOEASavingFront.java
@@ -1,0 +1,26 @@
+package org.uma.jmetal.auto.irace;
+
+import java.io.IOException;
+import java.util.List;
+import org.uma.jmetal.auto.autoconfigurablealgorithm.AutoAGEMOEA;
+import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.fileoutput.SolutionListOutput;
+import org.uma.jmetal.util.fileoutput.impl.DefaultFileOutputContext;
+
+public class AutoAGEMOEASavingFront {
+  public static void main(String[] args) throws IOException {
+    AutoAGEMOEA ageMoeaWithParameters = new AutoAGEMOEA();
+    ageMoeaWithParameters.parse(args);
+
+    EvolutionaryAlgorithm<DoubleSolution> ageMoea = ageMoeaWithParameters.create();
+    ageMoea.run();
+
+    List<DoubleSolution> population = ageMoea.result();
+
+    new SolutionListOutput(population)
+        .setVarFileOutputContext(new DefaultFileOutputContext("VAR.csv", ","))
+        .setFunFileOutputContext(new DefaultFileOutputContext("FUN.csv", ","))
+        .print();
+  }
+}

--- a/jmetal-auto/src/main/java/org/uma/jmetal/auto/irace/parameterfilegeneration/AutoAGEMOEAIraceParameterFileGenerator.java
+++ b/jmetal-auto/src/main/java/org/uma/jmetal/auto/irace/parameterfilegeneration/AutoAGEMOEAIraceParameterFileGenerator.java
@@ -1,0 +1,13 @@
+package org.uma.jmetal.auto.irace.parameterfilegeneration;
+
+import org.uma.jmetal.auto.autoconfigurablealgorithm.AutoAGEMOEA;
+
+/**
+ * Program to generate the irace configuration file for class {@link AutoAGEMOEA}.
+ */
+public class AutoAGEMOEAIraceParameterFileGenerator {
+  public static void main(String[] args) {
+    IraceParameterFileGenerator parameterFileGenerator = new IraceParameterFileGenerator();
+    parameterFileGenerator.generateConfigurationFile(new AutoAGEMOEA());
+  }
+}

--- a/jmetal-auto/src/main/resources/irace/autoAGEMOEAZDT/scenario-AGEMOEA.txt
+++ b/jmetal-auto/src/main/resources/irace/autoAGEMOEAZDT/scenario-AGEMOEA.txt
@@ -1,0 +1,16 @@
+###################################################### -*- mode: r -*- #####
+## Scenario setup for Iterated Race (irace).
+############################################################################
+
+parameterFile = "../parameters-AGEMOEA.txt"
+execDir = "./execdir"
+trainInstancesDir = ""
+trainInstancesFile = "../instances-list-ZDT.txt"
+testInstancesDir = ""
+testNbElites = 1
+testIterationElites = 1
+targetRunner = "../jmetal-auto-7.1-SNAPSHOT-jar-with-dependencies.jar"
+targetRunnerLauncher = "java"
+targetCmdline = "-cp {targetRunner} org.uma.jmetal.auto.irace.AutoAGEMOEAIraceNHV --randomGeneratorSeed {seed} --problemName {instance} {targetRunnerArgs}"
+maxExperiments = 100000
+sampleInstances = 0

--- a/jmetal-auto/src/main/resources/irace/parameters-AGEMOEA.txt
+++ b/jmetal-auto/src/main/resources/irace/parameters-AGEMOEA.txt
@@ -1,0 +1,26 @@
+algorithmVariant                         "--algorithmVariant "                    c       (agemoea, agemoeaii)
+#
+environmentalSelection                   "--environmentalSelection "              c       (agemoea, agemoeaii)
+#
+replacement                              "--replacement "                         c       (agemoeaReplacement)
+#
+createInitialSolutions                   "--createInitialSolutions "              c       (random, latinHypercubeSampling, scatterSearch)
+#
+variation                                "--variation "                           c       (crossoverAndMutationVariation)
+offspringPopulationSize                  "--offspringPopulationSize "             c       (1, 2, 5, 10, 20, 50, 100, 150, 200, 300, 400) | variation %in% c("crossoverAndMutationVariation")
+crossover                                "--crossover "                           c       (SBX, BLX_ALPHA, wholeArithmetic) | variation %in% c("crossoverAndMutationVariation")
+crossoverProbability                     "--crossoverProbability "                r       (0.0, 1.0)                     | crossover %in% c("SBX","BLX_ALPHA","wholeArithmetic")
+crossoverRepairStrategy                  "--crossoverRepairStrategy "             c       (random, round, bounds)        | crossover %in% c("SBX","BLX_ALPHA","wholeArithmetic")
+sbxDistributionIndex                     "--sbxDistributionIndex "                r       (5.0, 400.0)                   | crossover %in% c("SBX")
+blxAlphaCrossoverAlphaValue              "--blxAlphaCrossoverAlphaValue "         r       (0.0, 1.0)                     | crossover %in% c("BLX_ALPHA")
+mutation                                 "--mutation "                            c       (uniform, polynomial, linkedPolynomial, nonUniform) | variation %in% c("crossoverAndMutationVariation")
+mutationProbabilityFactor                "--mutationProbabilityFactor "           r       (0.0, 2.0)                     | mutation %in% c("uniform","polynomial","linkedPolynomial","nonUniform")
+mutationRepairStrategy                   "--mutationRepairStrategy "              c       (random, round, bounds)        | mutation %in% c("uniform","polynomial","linkedPolynomial","nonUniform")
+polynomialMutationDistributionIndex      "--polynomialMutationDistributionIndex " r       (5.0, 400.0)                   | mutation %in% c("polynomial")
+linkedPolynomialMutationDistributionIndex "--linkedPolynomialMutationDistributionIndex " r       (5.0, 400.0)                   | mutation %in% c("linkedPolynomial")
+uniformMutationPerturbation              "--uniformMutationPerturbation "         r       (0.0, 1.0)                     | mutation %in% c("uniform")
+nonUniformMutationPerturbation           "--nonUniformMutationPerturbation "      r       (0.0, 1.0)                     | mutation %in% c("nonUniform")
+#
+selection                                "--selection "                           c       (tournament, random)
+selectionTournamentSize                  "--selectionTournamentSize "             i       (2, 10)                        | selection %in% c("tournament")
+#

--- a/jmetal-auto/src/test/java/org/uma/jmetal/auto/autoconfigurablealgorithm/AutoAGEMOEAIT.java
+++ b/jmetal-auto/src/test/java/org/uma/jmetal/auto/autoconfigurablealgorithm/AutoAGEMOEAIT.java
@@ -1,0 +1,90 @@
+package org.uma.jmetal.auto.autoconfigurablealgorithm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
+import org.uma.jmetal.qualityindicator.QualityIndicator;
+import org.uma.jmetal.qualityindicator.impl.hypervolume.impl.PISAHypervolume;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.NormalizeUtils;
+import org.uma.jmetal.util.SolutionListUtils;
+import org.uma.jmetal.util.VectorUtils;
+
+class AutoAGEMOEAIT {
+
+  @Test
+  void autoAGEMOEAHasSixFirstLevelConfigurableParameters() {
+    assertThat(new AutoAGEMOEA().configurableParameterList()).hasSize(6);
+  }
+
+  @Test
+  void autoAGEMOEAHasFiveFixedParameters() {
+    assertThat(new AutoAGEMOEA().fixedParameterList()).hasSize(5);
+  }
+
+  @Test
+  void autoAGEMOEAHasTwentyFlattenedConfigurableParameters() {
+    assertThat(
+            AutoConfigurableAlgorithm.parameterFlattening(
+                new AutoAGEMOEA().configurableParameterList()))
+        .hasSize(20);
+  }
+
+  @Test
+  void autoAGEMOEAWithDefaultSettingsReturnsAFrontWithHVHigherThanZeroPointSixtyFiveOnProblemZDT1()
+      throws IOException {
+    String referenceFrontFileName = "ZDT1.csv";
+
+    String[] parameters =
+        ("--problemName org.uma.jmetal.problem.multiobjective.zdt.ZDT1 "
+            + "--referenceFrontFileName " + referenceFrontFileName + " "
+            + "--randomGeneratorSeed 12 "
+            + "--maximumNumberOfEvaluations 25000 "
+            + "--populationSize 100 "
+            + "--algorithmVariant agemoea "
+            + "--environmentalSelection agemoea "
+            + "--replacement agemoeaReplacement "
+            + "--createInitialSolutions random "
+            + "--variation crossoverAndMutationVariation "
+            + "--offspringPopulationSize 100 "
+            + "--selection tournament "
+            + "--selectionTournamentSize 2 "
+            + "--crossover SBX "
+            + "--crossoverProbability 0.9 "
+            + "--crossoverRepairStrategy bounds "
+            + "--sbxDistributionIndex 20.0 "
+            + "--mutation polynomial "
+            + "--mutationProbabilityFactor 1.0 "
+            + "--mutationRepairStrategy bounds "
+            + "--polynomialMutationDistributionIndex 20.0 ")
+            .split("\\s+");
+
+    AutoAGEMOEA autoAGEMOEA = new AutoAGEMOEA();
+    autoAGEMOEA.parse(parameters);
+
+    EvolutionaryAlgorithm<DoubleSolution> ageMoea = autoAGEMOEA.create();
+    ageMoea.run();
+
+    List<DoubleSolution> population = ageMoea.result();
+
+    String referenceFrontFile = "../resources/referenceFrontsCSV/" + referenceFrontFileName;
+
+    double[][] referenceFront = VectorUtils.readVectors(referenceFrontFile, ",");
+    QualityIndicator hypervolume = new PISAHypervolume(referenceFront);
+
+    double[][] normalizedFront =
+        NormalizeUtils.normalize(
+            SolutionListUtils.getMatrixWithObjectiveValues(population),
+            NormalizeUtils.getMinValuesOfTheColumnsOfAMatrix(referenceFront),
+            NormalizeUtils.getMaxValuesOfTheColumnsOfAMatrix(referenceFront));
+
+    double hv = hypervolume.compute(normalizedFront);
+
+    assertTrue(population.size() >= 95);
+    assertTrue(hv > 0.65);
+  }
+}

--- a/jmetal-component/src/main/java/org/uma/jmetal/component/algorithm/multiobjective/AGEMOEABuilder.java
+++ b/jmetal-component/src/main/java/org/uma/jmetal/component/algorithm/multiobjective/AGEMOEABuilder.java
@@ -20,6 +20,7 @@ import org.uma.jmetal.operator.crossover.CrossoverOperator;
 import org.uma.jmetal.operator.mutation.MutationOperator;
 import org.uma.jmetal.problem.Problem;
 import org.uma.jmetal.solution.Solution;
+import org.uma.jmetal.util.errorchecking.Check;
 
 /**
  * Class to configure and build an instance of the AGE-MOEA or AGE-MOEA-II algorithm
@@ -39,9 +40,13 @@ public class AGEMOEABuilder<S extends Solution<?>> {
   private Evaluation<S> evaluation;
   private SolutionsCreation<S> createInitialPopulation;
   private Termination termination;
+  private int selectionTournamentSize;
   private Selection<S> selection;
   private Variation<S> variation;
+  private AGEMOEAEnvironmentalSelection<S> environmentalSelection;
   private Replacement<S> replacement;
+  private boolean customSelectionConfigured;
+  private boolean customReplacementConfigured;
 
   public AGEMOEABuilder(Problem<S> problem, int populationSize, int offspringPopulationSize,
       CrossoverOperator<S> crossover, MutationOperator<S> mutation, Variant variant) {
@@ -50,24 +55,19 @@ public class AGEMOEABuilder<S extends Solution<?>> {
     this.problem = problem;
     this.createInitialPopulation = new RandomSolutionsCreation<>(problem, populationSize);
 
-    AGEMOEAEnvironmentalSelection<S> environmentalSelection =
-        variant == Variant.AGEMOEA
-            ? new AGEMOEAEnvironmentalSelection<>(problem.numberOfObjectives())
-            : new AGEMOEA2EnvironmentalSelection<>(problem.numberOfObjectives());
-
+    this.environmentalSelection = createEnvironmentalSelection();
     this.replacement = new AGEMOEAReplacement<>(environmentalSelection);
 
     this.variation = new CrossoverAndMutationVariation<>(
         offspringPopulationSize, crossover, mutation);
 
-    int tournamentSize = 2;
-    this.selection = new NaryTournamentSelection<>(
-        tournamentSize,
-        variation.matingPoolSize(),
-        new SurvivalScoreComparator<>());
+    this.selectionTournamentSize = 2;
+    this.selection = createDefaultSelection();
 
     this.termination = new TerminationByEvaluations(25000);
     this.evaluation = new SequentialEvaluation<>(problem);
+    this.customSelectionConfigured = false;
+    this.customReplacementConfigured = false;
   }
 
   public AGEMOEABuilder<S> setTermination(Termination termination) {
@@ -81,22 +81,98 @@ public class AGEMOEABuilder<S extends Solution<?>> {
   }
 
   public AGEMOEABuilder<S> setCreateInitialPopulation(SolutionsCreation<S> solutionsCreation) {
+    Check.notNull(solutionsCreation, "solutionsCreation");
     this.createInitialPopulation = solutionsCreation;
     return this;
   }
 
+  /**
+   * Configures the tournament size used by the default AGE-MOEA parent selection.
+   * If a custom selection component was already provided, this value is stored but
+   * does not override that custom selection.
+   *
+   * @param tournamentSize number of competitors in each tournament
+   * @return this builder
+   */
+  public AGEMOEABuilder<S> setTournamentSize(int tournamentSize) {
+    Check.that(tournamentSize >= 2, "Tournament size must be greater than or equal to 2");
+
+    this.selectionTournamentSize = tournamentSize;
+    if (!customSelectionConfigured) {
+      this.selection = createDefaultSelection();
+    }
+
+    return this;
+  }
+
   public AGEMOEABuilder<S> setSelection(Selection<S> selection) {
+    Check.notNull(selection, "selection");
     this.selection = selection;
+    this.customSelectionConfigured = true;
     return this;
   }
 
   public AGEMOEABuilder<S> setVariation(Variation<S> variation) {
+    Check.notNull(variation, "variation");
     this.variation = variation;
+    if (!customSelectionConfigured) {
+      this.selection = createDefaultSelection();
+    }
+    return this;
+  }
+
+  /**
+   * Configures the AGE environmental selection used to assign the survival scores
+   * before the first parent selection and, by default, in the AGE replacement.
+   *
+   * @param environmentalSelection environmental selection strategy
+   * @return this builder
+   */
+  public AGEMOEABuilder<S> setEnvironmentalSelection(
+      AGEMOEAEnvironmentalSelection<S> environmentalSelection) {
+    Check.notNull(environmentalSelection, "environmentalSelection");
+
+    this.environmentalSelection = environmentalSelection;
+    if (!customReplacementConfigured) {
+      this.replacement = new AGEMOEAReplacement<>(environmentalSelection);
+    }
+
+    return this;
+  }
+
+  /**
+   * Configures the replacement component.
+   *
+   * @param replacement replacement strategy
+   * @return this builder
+   */
+  public AGEMOEABuilder<S> setReplacement(Replacement<S> replacement) {
+    Check.notNull(replacement, "replacement");
+
+    this.replacement = replacement;
+    this.customReplacementConfigured = true;
+
     return this;
   }
 
   public EvolutionaryAlgorithm<S> build() {
+    Selection<S> algorithmSelection =
+        new AGEMOEASelection<>(selection, environmentalSelection);
+
     return new EvolutionaryAlgorithm<>(name, createInitialPopulation, evaluation, termination,
-        selection, variation, replacement);
+        algorithmSelection, variation, replacement);
+  }
+
+  private Selection<S> createDefaultSelection() {
+    return new NaryTournamentSelection<>(
+        selectionTournamentSize,
+        variation.matingPoolSize(),
+        new SurvivalScoreComparator<>());
+  }
+
+  private AGEMOEAEnvironmentalSelection<S> createEnvironmentalSelection() {
+    return variant == Variant.AGEMOEA
+        ? new AGEMOEAEnvironmentalSelection<>(problem.numberOfObjectives())
+        : new AGEMOEA2EnvironmentalSelection<>(problem.numberOfObjectives());
   }
 }

--- a/jmetal-component/src/main/java/org/uma/jmetal/component/algorithm/multiobjective/AGEMOEASelection.java
+++ b/jmetal-component/src/main/java/org/uma/jmetal/component/algorithm/multiobjective/AGEMOEASelection.java
@@ -1,0 +1,37 @@
+package org.uma.jmetal.component.algorithm.multiobjective;
+
+import java.util.List;
+import org.uma.jmetal.component.catalogue.ea.replacement.impl.agemoea.AGEMOEAEnvironmentalSelection;
+import org.uma.jmetal.component.catalogue.ea.selection.Selection;
+import org.uma.jmetal.solution.Solution;
+
+/**
+ * AGE-MOEA parent selection requires survival scores to be available before the first tournament.
+ * This wrapper initializes them lazily for the first population and then delegates to the wrapped
+ * selection component.
+ *
+ * @param <S> the solution type
+ */
+class AGEMOEASelection<S extends Solution<?>> implements Selection<S> {
+  private final Selection<S> delegate;
+  private final AGEMOEAEnvironmentalSelection<S> environmentalSelection;
+
+  AGEMOEASelection(
+      Selection<S> delegate, AGEMOEAEnvironmentalSelection<S> environmentalSelection) {
+    this.delegate = delegate;
+    this.environmentalSelection = environmentalSelection;
+  }
+
+  @Override
+  public List<S> select(List<S> solutionList) {
+    if (solutionList.stream().anyMatch(this::survivalScoreIsNotAssigned)) {
+      environmentalSelection.execute(solutionList, solutionList.size());
+    }
+
+    return delegate.select(solutionList);
+  }
+
+  private boolean survivalScoreIsNotAssigned(S solution) {
+    return !solution.attributes().containsKey(AGEMOEAEnvironmentalSelection.getAttributeId());
+  }
+}

--- a/jmetal-component/src/main/java/org/uma/jmetal/component/algorithm/multiobjective/RVEABuilder.java
+++ b/jmetal-component/src/main/java/org/uma/jmetal/component/algorithm/multiobjective/RVEABuilder.java
@@ -1,5 +1,7 @@
 package org.uma.jmetal.component.algorithm.multiobjective;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
 import org.uma.jmetal.component.catalogue.common.evaluation.Evaluation;
 import org.uma.jmetal.component.catalogue.common.evaluation.impl.SequentialEvaluation;
@@ -34,12 +36,14 @@ public class RVEABuilder<S extends Solution<?>> {
   private final double alpha;
   private final double fr;
   private final int numberOfDivisions;
+  private List<double[]> referenceVectors;
   private Evaluation<S> evaluation;
   private SolutionsCreation<S> createInitialPopulation;
   private Termination termination;
   private Selection<S> selection;
   private Variation<S> variation;
   private Replacement<S> replacement;
+  private boolean customSelection;
 
   public RVEABuilder(Problem<S> problem, int populationSize, int maxEvaluations,
       CrossoverOperator<S> crossover, MutationOperator<S> mutation, double alpha, double fr, int h) {
@@ -49,12 +53,15 @@ public class RVEABuilder<S extends Solution<?>> {
     this.alpha = alpha;
     this.fr = fr;
     this.numberOfDivisions = h;
+    this.referenceVectors =
+        ReferencePointGenerator.generateSingleLayer(problem.numberOfObjectives(), numberOfDivisions);
     this.createInitialPopulation = new RandomSolutionsCreation<>(problem, populationSize);
 
     this.variation = new CrossoverAndMutationVariation<>(
         populationSize, crossover, mutation);
 
     this.selection = new RandomSelection<>(variation.matingPoolSize());
+    this.customSelection = false;
 
     this.termination = new TerminationByEvaluations(maxEvaluations);
     this.evaluation = new SequentialEvaluation<>(problem);
@@ -77,6 +84,7 @@ public class RVEABuilder<S extends Solution<?>> {
 
   public RVEABuilder<S> setSelection(Selection<S> selection) {
     this.selection = selection;
+    this.customSelection = true;
     return this;
   }
 
@@ -85,12 +93,30 @@ public class RVEABuilder<S extends Solution<?>> {
     return this;
   }
 
+  /**
+   * Overrides the paper-default single-layer reference vector set with a caller-provided one.
+   * This advanced hook is intended for experimental configurations and benchmark helpers.
+   *
+   * @param referenceVectors Reference vectors to be used by environmental selection.
+   * @return The builder instance.
+   */
+  public RVEABuilder<S> setReferenceVectors(List<double[]> referenceVectors) {
+    Check.notNull(referenceVectors);
+
+    this.referenceVectors = new ArrayList<>(referenceVectors.size());
+    for (double[] referenceVector : referenceVectors) {
+      this.referenceVectors.add(referenceVector.clone());
+    }
+
+    return this;
+  }
+
   public EvolutionaryAlgorithm<S> build() {
     Check.that(termination instanceof TerminationByEvaluations,
         "RVEA requires termination by evaluations to compute APD progress and reference adaptation.");
+    Check.notNull(referenceVectors);
 
-    int referenceVectorCount =
-        ReferencePointGenerator.calculateNumberOfReferencePoints(problem.numberOfObjectives(), numberOfDivisions);
+    int referenceVectorCount = referenceVectors.size();
     Check.that(referenceVectorCount == populationSize,
         "Population size must match the number of generated reference vectors. Expected "
             + referenceVectorCount + " and found " + populationSize + ".");
@@ -100,11 +126,21 @@ public class RVEABuilder<S extends Solution<?>> {
         variation.offspringPopulationSize());
     RVEAEnvironmentalSelection<S> environmentalSelection =
         new RVEAEnvironmentalSelection<>(problem.numberOfObjectives(), maxGenerations, alpha, fr,
-            numberOfDivisions);
+            referenceVectors);
     replacement = new RVEAReplacement<>(environmentalSelection);
 
-    return new EvolutionaryAlgorithm<>(name, createInitialPopulation, evaluation, termination,
-        selection, variation, replacement);
+    Selection<S> finalSelection =
+        customSelection ? selection : new RandomSelection<>(variation.matingPoolSize());
+    SolutionsCreation<S> validatedInitialPopulationCreation = () -> {
+      var initialPopulation = createInitialPopulation.create();
+      Check.that(initialPopulation.size() == populationSize,
+          "The initial population size must be " + populationSize + " but is "
+              + initialPopulation.size() + ".");
+      return initialPopulation;
+    };
+
+    return new EvolutionaryAlgorithm<>(name, validatedInitialPopulationCreation, evaluation,
+        termination, finalSelection, variation, replacement);
   }
 
   private int estimateMaximumGenerations(int maxEvaluations, int initialPopulationSize,

--- a/jmetal-component/src/main/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/agemoea/AGEMOEAEnvironmentalSelection.java
+++ b/jmetal-component/src/main/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/agemoea/AGEMOEAEnvironmentalSelection.java
@@ -68,6 +68,8 @@ public class AGEMOEAEnvironmentalSelection<S extends Solution<?>> {
      * @param front
      */
     public void computeSurvivalScore(List<S> front){
+        resetState();
+
         // list to keep track of solutions selected when assigning the survival scores
         List<Integer> selected = new ArrayList<>();
 
@@ -221,7 +223,7 @@ public class AGEMOEAEnvironmentalSelection<S extends Solution<?>> {
         for (S solution : front){
             double[] normalizedObjective = solution.objectives().clone();
             for(int i=0; i<this.numberOfObjectives; i++){
-                if (intercepts != null && intercepts.size() == 0)
+                if (intercepts != null && !intercepts.isEmpty())
                     normalizedObjective[i] = normalizedObjective[i] / intercepts.get(i);
             }
             double value =  this.minkowskiDistance(normalizedObjective, idealPoint, P);
@@ -329,6 +331,11 @@ public class AGEMOEAEnvironmentalSelection<S extends Solution<?>> {
 
     public static String getAttributeId() {
         return attributeId;
+    }
+
+    private void resetState() {
+        P = 1.0;
+        intercepts = null;
     }
 
     public List<Double> computeIdealPoint(List<S> population) {

--- a/jmetal-component/src/main/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/rvea/RVEAEnvironmentalSelection.java
+++ b/jmetal-component/src/main/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/rvea/RVEAEnvironmentalSelection.java
@@ -25,112 +25,123 @@ public class RVEAEnvironmentalSelection<S extends Solution<?>> {
   private final int numberOfObjectives;
   private double[][] referenceVectors;
   private final double[][] initialReferenceVectors;
+  private final double[] referenceVectorNorms;
   private double[] idealPoint;
   private double[] nadirPoint;
+  private double[] gamma;
 
   public RVEAEnvironmentalSelection(int numberOfObjectives, int maxGenerations, double alpha, double fr, int H) {
+    this(numberOfObjectives, maxGenerations, alpha, fr,
+        ReferencePointGenerator.generateSingleLayer(numberOfObjectives, H));
+  }
+
+  public RVEAEnvironmentalSelection(
+      int numberOfObjectives,
+      int maxGenerations,
+      double alpha,
+      double fr,
+      List<double[]> generatedVectors) {
     Check.that(numberOfObjectives >= 2, "The number of objectives must be at least 2.");
     Check.valueIsPositive(maxGenerations, "maxGenerations");
     Check.valueIsNotNegative(alpha, "alpha");
     Check.valueIsInRange(fr, EPSILON, 1.0, "fr");
+    Check.notNull(generatedVectors);
+    Check.that(!generatedVectors.isEmpty(), "The reference vector list cannot be empty.");
 
     this.numberOfObjectives = numberOfObjectives;
     this.maxGenerations = maxGenerations;
-    this.currentGeneration = 0;
+    this.currentGeneration = -1;
     this.alpha = alpha;
     this.adaptationFrequency = Math.max(1, (int) Math.ceil(maxGenerations * fr));
 
-    List<double[]> generatedVectors = ReferencePointGenerator.generateSingleLayer(numberOfObjectives, H);
-
     this.referenceVectors = new double[generatedVectors.size()][numberOfObjectives];
     this.initialReferenceVectors = new double[generatedVectors.size()][numberOfObjectives];
+    this.referenceVectorNorms = new double[generatedVectors.size()];
 
     for (int i = 0; i < generatedVectors.size(); i++) {
+      Check.that(generatedVectors.get(i).length == numberOfObjectives,
+          "Reference vector dimension " + generatedVectors.get(i).length
+              + " does not match the number of objectives " + numberOfObjectives + ".");
       double length = calculateNorm(generatedVectors.get(i));
       for (int j = 0; j < numberOfObjectives; j++) {
         this.referenceVectors[i][j] = generatedVectors.get(i)[j] / length;
         this.initialReferenceVectors[i][j] = this.referenceVectors[i][j];
       }
+      this.referenceVectorNorms[i] = calculateNorm(this.referenceVectors[i]);
     }
+
+    this.gamma = calculateGammaValues();
   }
 
   public List<S> execute(List<S> jointPopulation, int populationSize) {
     Check.notNull(jointPopulation);
     Check.that(jointPopulation.size() >= populationSize,
         "The joint population size must be at least the population size.");
+    Check.that(referenceVectors.length == populationSize,
+        "The population size must match the number of reference vectors. Expected "
+            + referenceVectors.length + " and found " + populationSize + ".");
 
     currentGeneration++;
 
-    updateIdealPoint(jointPopulation);
+    // RVEA translates the current candidate population by the current-generation ideal point.
+    idealPoint = calculateMinimumValues(jointPopulation);
+    double[][] translatedObjectives = translatedObjectives(jointPopulation, idealPoint);
+    double[] translatedObjectiveNorms = translatedObjectiveNorms(translatedObjectives);
 
-    List<List<S>> subPopulations = new ArrayList<>(referenceVectors.length);
+    List<List<Integer>> subPopulations = new ArrayList<>(referenceVectors.length);
     for (int i = 0; i < referenceVectors.length; i++) {
       subPopulations.add(new ArrayList<>());
     }
 
-    for (S solution : jointPopulation) {
-      int closestVectorIndex = associateToReferenceVector(solution);
-      subPopulations.get(closestVectorIndex).add(solution);
+    for (int i = 0; i < jointPopulation.size(); i++) {
+      int closestVectorIndex =
+          associateToReferenceVector(translatedObjectives[i], translatedObjectiveNorms[i]);
+      subPopulations.get(closestVectorIndex).add(i);
     }
 
-    double[] gamma = calculateGamma();
-
-    List<S> nextPopulation = new ArrayList<>();
+    List<S> nextPopulation = new ArrayList<>(populationSize);
+    boolean[] selectedSolutions = new boolean[jointPopulation.size()];
     for (int i = 0; i < referenceVectors.length; i++) {
-      List<S> subPopulation = subPopulations.get(i);
-      if (!subPopulation.isEmpty()) {
-        S bestSolution = selectBestFromSubpopulation(subPopulation, i, gamma[i]);
-        nextPopulation.add(bestSolution);
-      }
+      int survivorIndex =
+          selectBestIndexForReferenceVector(
+              subPopulations.get(i),
+              i,
+              gamma[i],
+              translatedObjectives,
+              translatedObjectiveNorms,
+              selectedSolutions);
+      Check.that(
+          survivorIndex != -1,
+          "Unable to select a survivor for reference vector " + i + ".");
+      selectedSolutions[survivorIndex] = true;
+      nextPopulation.add(jointPopulation.get(survivorIndex));
     }
 
-    updateNadirPoint(nextPopulation);
+    Check.that(
+        nextPopulation.size() == populationSize,
+        "The next population size must be " + populationSize + " but is "
+            + nextPopulation.size() + ".");
+
+    // Reference-vector adaptation uses the current survivor bounds instead of historical extrema.
+    double[] survivorIdealPoint = calculateMinimumValues(nextPopulation);
+    nadirPoint = calculateMaximumValues(nextPopulation);
 
     if (mustAdaptReferenceVectors()) {
-      adaptReferenceVectors();
+      adaptReferenceVectors(survivorIdealPoint, nadirPoint);
     }
 
     return nextPopulation;
-  }
-
-  private void updateIdealPoint(List<S> population) {
-    if (idealPoint == null) {
-      idealPoint = new double[numberOfObjectives];
-      Arrays.fill(idealPoint, Double.POSITIVE_INFINITY);
-    }
-
-    for (S sol : population) {
-      for (int i = 0; i < numberOfObjectives; i++) {
-        idealPoint[i] = Math.min(idealPoint[i], sol.objectives()[i]);
-      }
-    }
-  }
-
-  private void updateNadirPoint(List<S> population) {
-    if (population.isEmpty()) {
-      nadirPoint = null;
-      return;
-    }
-
-    nadirPoint = new double[numberOfObjectives];
-    Arrays.fill(nadirPoint, Double.NEGATIVE_INFINITY);
-
-    for (S sol : population) {
-      for (int i = 0; i < numberOfObjectives; i++) {
-        nadirPoint[i] = Math.max(nadirPoint[i], sol.objectives()[i]);
-      }
-    }
   }
 
   private boolean mustAdaptReferenceVectors() {
     return nadirPoint != null && currentGeneration % adaptationFrequency == 0;
   }
 
-  private void adaptReferenceVectors() {
+  private void adaptReferenceVectors(double[] survivorIdealPoint, double[] survivorNadirPoint) {
     for (int i = 0; i < referenceVectors.length; i++) {
       double length = 0.0;
       for (int j = 0; j < numberOfObjectives; j++) {
-        double scale = Math.max(nadirPoint[j] - idealPoint[j], EPSILON);
+        double scale = Math.max(survivorNadirPoint[j] - survivorIdealPoint[j], EPSILON);
         referenceVectors[i][j] = initialReferenceVectors[i][j] * scale;
         length += referenceVectors[i][j] * referenceVectors[i][j];
       }
@@ -139,25 +150,22 @@ public class RVEAEnvironmentalSelection<S extends Solution<?>> {
       for (int j = 0; j < numberOfObjectives; j++) {
         referenceVectors[i][j] /= length;
       }
+      referenceVectorNorms[i] = calculateNorm(referenceVectors[i]);
     }
+    gamma = calculateGammaValues();
   }
 
-  private int associateToReferenceVector(S solution) {
-    double[] translatedObjectives = new double[numberOfObjectives];
-    for (int i = 0; i < numberOfObjectives; i++) {
-      translatedObjectives[i] = solution.objectives()[i] - idealPoint[i];
-    }
-
+  private int associateToReferenceVector(double[] translatedObjectives, double norm) {
     double minAngle = Double.POSITIVE_INFINITY;
     int bestIndex = 0;
 
-    double norm = calculateNorm(translatedObjectives);
     if (norm == 0.0) {
       return 0;
     }
 
     for (int i = 0; i < referenceVectors.length; i++) {
-      double cosine = calculateCosine(translatedObjectives, referenceVectors[i], norm);
+      double cosine =
+          calculateCosine(translatedObjectives, norm, referenceVectors[i], referenceVectorNorms[i]);
       double angle = Math.acos(Math.max(-1.0, Math.min(1.0, cosine)));
       if (angle < minAngle) {
         minAngle = angle;
@@ -167,34 +175,88 @@ public class RVEAEnvironmentalSelection<S extends Solution<?>> {
     return bestIndex;
   }
 
-  private S selectBestFromSubpopulation(List<S> subPopulation, int referenceVectorIndex, double gamma) {
+  private int selectBestIndexForReferenceVector(
+      List<Integer> associatedCandidates,
+      int referenceVectorIndex,
+      double gamma,
+      double[][] translatedObjectives,
+      double[] translatedObjectiveNorms,
+      boolean[] selectedSolutions) {
     double minAPD = Double.POSITIVE_INFINITY;
-    S bestSolution = null;
+    int bestIndex = -1;
     double progress = Math.pow((double) currentGeneration / maxGenerations, alpha);
-    double objectivePenaltyFactor = numberOfObjectives > 2 ? numberOfObjectives : 1.0;
+    double objectivePenaltyFactor = numberOfObjectives;
 
-    for (S solution : subPopulation) {
-      double[] translatedObjectives = new double[numberOfObjectives];
-      for (int i = 0; i < numberOfObjectives; i++) {
-        translatedObjectives[i] = solution.objectives()[i] - idealPoint[i];
+    for (int candidateIndex : associatedCandidates) {
+      if (selectedSolutions[candidateIndex]) {
+        continue;
       }
 
-      double norm = calculateNorm(translatedObjectives);
-      double cosine = calculateCosine(translatedObjectives, referenceVectors[referenceVectorIndex], norm);
-      double theta = Math.acos(Math.max(-1.0, Math.min(1.0, cosine)));
-
-      double penalty = objectivePenaltyFactor * progress * (theta / gamma);
-      double apd = (1.0 + penalty) * norm;
-
+      double apd =
+          calculateApd(
+              candidateIndex,
+              referenceVectorIndex,
+              gamma,
+              progress,
+              objectivePenaltyFactor,
+              translatedObjectives,
+              translatedObjectiveNorms);
       if (apd < minAPD) {
         minAPD = apd;
-        bestSolution = solution;
+        bestIndex = candidateIndex;
       }
     }
-    return bestSolution;
+
+    if (bestIndex != -1) {
+      return bestIndex;
+    }
+
+    // Empty niches fall back to the best remaining APD candidate to keep the survivor count fixed.
+    for (int candidateIndex = 0; candidateIndex < selectedSolutions.length; candidateIndex++) {
+      if (selectedSolutions[candidateIndex]) {
+        continue;
+      }
+
+      double apd =
+          calculateApd(
+              candidateIndex,
+              referenceVectorIndex,
+              gamma,
+              progress,
+              objectivePenaltyFactor,
+              translatedObjectives,
+              translatedObjectiveNorms);
+      if (apd < minAPD) {
+        minAPD = apd;
+        bestIndex = candidateIndex;
+      }
+    }
+
+    return bestIndex;
   }
 
-  private double[] calculateGamma() {
+  private double calculateApd(
+      int candidateIndex,
+      int referenceVectorIndex,
+      double gamma,
+      double progress,
+      double objectivePenaltyFactor,
+      double[][] translatedObjectives,
+      double[] translatedObjectiveNorms) {
+    double norm = translatedObjectiveNorms[candidateIndex];
+    double cosine = calculateCosine(
+        translatedObjectives[candidateIndex],
+        norm,
+        referenceVectors[referenceVectorIndex],
+        referenceVectorNorms[referenceVectorIndex]);
+    double theta = Math.acos(Math.max(-1.0, Math.min(1.0, cosine)));
+
+    // APD balances convergence and angular diversity relative to the assigned vector.
+    double penalty = objectivePenaltyFactor * progress * (theta / gamma);
+    return (1.0 + penalty) * norm;
+  }
+
+  private double[] calculateGammaValues() {
     double[] gamma = new double[referenceVectors.length];
     for (int i = 0; i < referenceVectors.length; i++) {
       double minAngle = Double.POSITIVE_INFINITY;
@@ -203,7 +265,8 @@ public class RVEAEnvironmentalSelection<S extends Solution<?>> {
           continue;
         }
 
-        double cosine = calculateCosine(referenceVectors[i], referenceVectors[j], 1.0);
+        double cosine = calculateCosine(
+            referenceVectors[i], referenceVectorNorms[i], referenceVectors[j], referenceVectorNorms[j]);
         double angle = Math.acos(Math.max(-1.0, Math.min(1.0, cosine)));
         if (angle < minAngle) {
           minAngle = angle;
@@ -235,6 +298,54 @@ public class RVEAEnvironmentalSelection<S extends Solution<?>> {
     return currentGeneration;
   }
 
+  private double[] calculateMinimumValues(List<S> population) {
+    double[] minimumValues = new double[numberOfObjectives];
+    Arrays.fill(minimumValues, Double.POSITIVE_INFINITY);
+
+    for (S solution : population) {
+      for (int i = 0; i < numberOfObjectives; i++) {
+        minimumValues[i] = Math.min(minimumValues[i], solution.objectives()[i]);
+      }
+    }
+
+    return minimumValues;
+  }
+
+  private double[] calculateMaximumValues(List<S> population) {
+    double[] maximumValues = new double[numberOfObjectives];
+    Arrays.fill(maximumValues, Double.NEGATIVE_INFINITY);
+
+    for (S solution : population) {
+      for (int i = 0; i < numberOfObjectives; i++) {
+        maximumValues[i] = Math.max(maximumValues[i], solution.objectives()[i]);
+      }
+    }
+
+    return maximumValues;
+  }
+
+  private double[][] translatedObjectives(List<S> population, double[] currentIdealPoint) {
+    double[][] translatedObjectives = new double[population.size()][numberOfObjectives];
+
+    for (int i = 0; i < population.size(); i++) {
+      for (int j = 0; j < numberOfObjectives; j++) {
+        translatedObjectives[i][j] = population.get(i).objectives()[j] - currentIdealPoint[j];
+      }
+    }
+
+    return translatedObjectives;
+  }
+
+  private double[] translatedObjectiveNorms(double[][] translatedObjectives) {
+    double[] norms = new double[translatedObjectives.length];
+
+    for (int i = 0; i < translatedObjectives.length; i++) {
+      norms[i] = calculateNorm(translatedObjectives[i]);
+    }
+
+    return norms;
+  }
+
   private double calculateNorm(double[] array) {
     double sum = 0.0;
     for (double v : array) {
@@ -243,13 +354,13 @@ public class RVEAEnvironmentalSelection<S extends Solution<?>> {
     return Math.sqrt(sum);
   }
 
-  private double calculateCosine(double[] v1, double[] v2, double norm1) {
+  private double calculateCosine(double[] v1, double norm1, double[] v2, double norm2) {
     double dotProduct = 0;
     for (int i = 0; i < v1.length; i++) {
       dotProduct += v1[i] * v2[i];
     }
 
-    double denominator = norm1;
+    double denominator = norm1 * norm2;
     if (denominator == 0.0) {
       return 1.0;
     }

--- a/jmetal-component/src/main/java/org/uma/jmetal/component/examples/multiobjective/rvea/RVEABenchmarkPop100Eval100000.java
+++ b/jmetal-component/src/main/java/org/uma/jmetal/component/examples/multiobjective/rvea/RVEABenchmarkPop100Eval100000.java
@@ -1,0 +1,299 @@
+package org.uma.jmetal.component.examples.multiobjective.rvea;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
+import org.uma.jmetal.component.algorithm.multiobjective.RVEABuilder;
+import org.uma.jmetal.component.catalogue.common.termination.Termination;
+import org.uma.jmetal.component.catalogue.common.termination.impl.TerminationByEvaluations;
+import org.uma.jmetal.operator.crossover.impl.SBXCrossover;
+import org.uma.jmetal.operator.mutation.impl.PolynomialMutation;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.problem.ProblemFactory;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.SolutionListUtils;
+import org.uma.jmetal.util.fileoutput.SolutionListOutput;
+import org.uma.jmetal.util.fileoutput.impl.DefaultFileOutputContext;
+import org.uma.jmetal.util.referencepoint.ReferencePointGenerator;
+
+public class RVEABenchmarkPop100Eval100000 {
+  private static final Path OUTPUT_DIRECTORY = Paths.get("results", "rvea_pop100_eval100000");
+  private static final int POPULATION_SIZE = 100;
+  private static final int MAX_EVALUATIONS = 100000;
+  private static final double CROSSOVER_PROBABILITY = 0.9;
+  private static final double CROSSOVER_DISTRIBUTION_INDEX = 30.0;
+  private static final double MUTATION_DISTRIBUTION_INDEX = 20.0;
+  private static final double ALPHA = 2.0;
+  private static final double FR = 0.1;
+
+  public static void main(String[] args) throws IOException {
+    Files.createDirectories(OUTPUT_DIRECTORY);
+
+    List<BenchmarkRun> runs = List.of(
+        new BenchmarkRun("ZDT1",
+            "ZDT1",
+            "org.uma.jmetal.problem.multiobjective.zdt.ZDT1",
+            "resources/referenceFrontsCSV/ZDT1.csv",
+            99,
+            ReferencePointGenerator.generateSingleLayer(2, 99),
+            "single-layer(99)"),
+        new BenchmarkRun("ZDT4",
+            "ZDT4",
+            "org.uma.jmetal.problem.multiobjective.zdt.ZDT4",
+            "resources/referenceFrontsCSV/ZDT4.csv",
+            99,
+            ReferencePointGenerator.generateSingleLayer(2, 99),
+            "single-layer(99)"),
+        new BenchmarkRun("DTLZ1",
+            "DTLZ1 (experimental custom reference vectors)",
+            "org.uma.jmetal.problem.multiobjective.dtlz.DTLZ1",
+            "resources/referenceFrontsCSV/DTLZ1.3D.csv",
+            12,
+            ReferencePointGenerator.generateTwoLayers(3, 9, 8),
+            "two-layer(9,8)"));
+
+    List<RunSummary> summaries = new ArrayList<>();
+    for (BenchmarkRun run : runs) {
+      summaries.add(execute(run));
+    }
+
+    writeRuntimeCsv(summaries);
+    JMetalLogger.logger.info("Benchmark results written to " + OUTPUT_DIRECTORY.toAbsolutePath());
+  }
+
+  private static RunSummary execute(BenchmarkRun benchmarkRun) throws IOException {
+    Problem<DoubleSolution> problem = ProblemFactory.loadProblem(benchmarkRun.problemName());
+
+    var crossover = new SBXCrossover(CROSSOVER_PROBABILITY, CROSSOVER_DISTRIBUTION_INDEX);
+    var mutation = new PolynomialMutation(
+        1.0 / problem.numberOfVariables(), MUTATION_DISTRIBUTION_INDEX);
+
+    Termination termination = new TerminationByEvaluations(MAX_EVALUATIONS);
+
+    EvolutionaryAlgorithm<DoubleSolution> rvea =
+        new RVEABuilder<>(problem, POPULATION_SIZE, MAX_EVALUATIONS, crossover, mutation, ALPHA,
+            FR, benchmarkRun.divisions())
+            .setReferenceVectors(benchmarkRun.referenceVectors())
+            .setTermination(termination)
+            .build();
+
+    rvea.run();
+
+    List<DoubleSolution> paretoFront = SolutionListUtils.getNonDominatedSolutions(rvea.result());
+
+    Path funPath = OUTPUT_DIRECTORY.resolve("FUN_" + benchmarkRun.label() + ".csv");
+    Path varPath = OUTPUT_DIRECTORY.resolve("VAR_" + benchmarkRun.label() + ".csv");
+
+    new SolutionListOutput(paretoFront)
+        .setVarFileOutputContext(new DefaultFileOutputContext(varPath.toString(), ","))
+        .setFunFileOutputContext(new DefaultFileOutputContext(funPath.toString(), ","))
+        .print();
+
+    int referenceVectors = benchmarkRun.referenceVectors().size();
+
+    JMetalLogger.logger.info(
+        String.format(
+            Locale.US,
+            "%s finished. Runtime=%dms, evaluations=%d, nonDominated=%d, referenceVectors=%d",
+            benchmarkRun.displayName(),
+            rvea.totalComputingTime(),
+            rvea.numberOfEvaluations(),
+            paretoFront.size(),
+            referenceVectors));
+
+    return new RunSummary(
+        benchmarkRun.displayName(),
+        benchmarkRun.referenceFront(),
+        POPULATION_SIZE,
+        MAX_EVALUATIONS,
+        benchmarkRun.divisions(),
+        benchmarkRun.referenceVectorScheme(),
+        referenceVectors,
+        rvea.totalComputingTime(),
+        rvea.numberOfEvaluations(),
+        paretoFront.size(),
+        funPath,
+        varPath);
+  }
+
+  private static void writeRuntimeCsv(List<RunSummary> summaries) throws IOException {
+    Path runtimePath = OUTPUT_DIRECTORY.resolve("runtime.csv");
+    try (BufferedWriter writer = Files.newBufferedWriter(runtimePath)) {
+      writer.write(
+          "problem,populationSize,maxEvaluations,divisions,referenceVectorScheme,referenceVectors,runtimeMs,evaluations,nonDominatedSolutions,funFile,varFile,referenceFront");
+      writer.newLine();
+
+      for (RunSummary summary : summaries) {
+        writer.write(
+            String.format(
+                Locale.US,
+                "%s,%d,%d,%d,%s,%d,%d,%d,%d,%s,%s,%s",
+                summary.problem(),
+                summary.populationSize(),
+                summary.maxEvaluations(),
+                summary.divisions(),
+                summary.referenceVectorScheme(),
+                summary.referenceVectors(),
+                summary.runtimeMs(),
+                summary.evaluations(),
+                summary.nonDominatedSolutions(),
+                summary.funFile().toString().replace('\\', '/'),
+                summary.varFile().toString().replace('\\', '/'),
+                summary.referenceFront().replace('\\', '/')));
+        writer.newLine();
+      }
+    }
+  }
+
+  private static class BenchmarkRun {
+    private final String label;
+    private final String displayName;
+    private final String problemName;
+    private final String referenceFront;
+    private final int divisions;
+    private final List<double[]> referenceVectors;
+    private final String referenceVectorScheme;
+
+    private BenchmarkRun(
+        String label,
+        String displayName,
+        String problemName,
+        String referenceFront,
+        int divisions,
+        List<double[]> referenceVectors,
+        String referenceVectorScheme) {
+      this.label = label;
+      this.displayName = displayName;
+      this.problemName = problemName;
+      this.referenceFront = referenceFront;
+      this.divisions = divisions;
+      this.referenceVectors = referenceVectors;
+      this.referenceVectorScheme = referenceVectorScheme;
+    }
+
+    private String label() {
+      return label;
+    }
+
+    private String problemName() {
+      return problemName;
+    }
+
+    private String displayName() {
+      return displayName;
+    }
+
+    private String referenceFront() {
+      return referenceFront;
+    }
+
+    private int divisions() {
+      return divisions;
+    }
+
+    private List<double[]> referenceVectors() {
+      return referenceVectors;
+    }
+
+    private String referenceVectorScheme() {
+      return referenceVectorScheme;
+    }
+  }
+
+  private static class RunSummary {
+    private final String problem;
+    private final String referenceFront;
+    private final int populationSize;
+    private final int maxEvaluations;
+    private final int divisions;
+    private final String referenceVectorScheme;
+    private final int referenceVectors;
+    private final long runtimeMs;
+    private final int evaluations;
+    private final int nonDominatedSolutions;
+    private final Path funFile;
+    private final Path varFile;
+
+    private RunSummary(
+        String problem,
+        String referenceFront,
+        int populationSize,
+        int maxEvaluations,
+        int divisions,
+        String referenceVectorScheme,
+        int referenceVectors,
+        long runtimeMs,
+        int evaluations,
+        int nonDominatedSolutions,
+        Path funFile,
+        Path varFile) {
+      this.problem = problem;
+      this.referenceFront = referenceFront;
+      this.populationSize = populationSize;
+      this.maxEvaluations = maxEvaluations;
+      this.divisions = divisions;
+      this.referenceVectorScheme = referenceVectorScheme;
+      this.referenceVectors = referenceVectors;
+      this.runtimeMs = runtimeMs;
+      this.evaluations = evaluations;
+      this.nonDominatedSolutions = nonDominatedSolutions;
+      this.funFile = funFile;
+      this.varFile = varFile;
+    }
+
+    private String problem() {
+      return problem;
+    }
+
+    private String referenceFront() {
+      return referenceFront;
+    }
+
+    private int populationSize() {
+      return populationSize;
+    }
+
+    private int maxEvaluations() {
+      return maxEvaluations;
+    }
+
+    private int divisions() {
+      return divisions;
+    }
+
+    private String referenceVectorScheme() {
+      return referenceVectorScheme;
+    }
+
+    private int referenceVectors() {
+      return referenceVectors;
+    }
+
+    private long runtimeMs() {
+      return runtimeMs;
+    }
+
+    private int evaluations() {
+      return evaluations;
+    }
+
+    private int nonDominatedSolutions() {
+      return nonDominatedSolutions;
+    }
+
+    private Path funFile() {
+      return funFile;
+    }
+
+    private Path varFile() {
+      return varFile;
+    }
+  }
+}

--- a/jmetal-component/src/main/java/org/uma/jmetal/component/examples/multiobjective/rvea/RVEABenchmarkPop100Eval25000.java
+++ b/jmetal-component/src/main/java/org/uma/jmetal/component/examples/multiobjective/rvea/RVEABenchmarkPop100Eval25000.java
@@ -1,0 +1,299 @@
+package org.uma.jmetal.component.examples.multiobjective.rvea;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
+import org.uma.jmetal.component.algorithm.multiobjective.RVEABuilder;
+import org.uma.jmetal.component.catalogue.common.termination.Termination;
+import org.uma.jmetal.component.catalogue.common.termination.impl.TerminationByEvaluations;
+import org.uma.jmetal.operator.crossover.impl.SBXCrossover;
+import org.uma.jmetal.operator.mutation.impl.PolynomialMutation;
+import org.uma.jmetal.problem.Problem;
+import org.uma.jmetal.problem.ProblemFactory;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.JMetalLogger;
+import org.uma.jmetal.util.SolutionListUtils;
+import org.uma.jmetal.util.fileoutput.SolutionListOutput;
+import org.uma.jmetal.util.fileoutput.impl.DefaultFileOutputContext;
+import org.uma.jmetal.util.referencepoint.ReferencePointGenerator;
+
+public class RVEABenchmarkPop100Eval25000 {
+  private static final Path OUTPUT_DIRECTORY = Paths.get("results", "rvea_pop100_eval25000");
+  private static final int POPULATION_SIZE = 100;
+  private static final int MAX_EVALUATIONS = 25000;
+  private static final double CROSSOVER_PROBABILITY = 0.9;
+  private static final double CROSSOVER_DISTRIBUTION_INDEX = 30.0;
+  private static final double MUTATION_DISTRIBUTION_INDEX = 20.0;
+  private static final double ALPHA = 2.0;
+  private static final double FR = 0.1;
+
+  public static void main(String[] args) throws IOException {
+    Files.createDirectories(OUTPUT_DIRECTORY);
+
+    List<BenchmarkRun> runs = List.of(
+        new BenchmarkRun("ZDT1",
+            "ZDT1",
+            "org.uma.jmetal.problem.multiobjective.zdt.ZDT1",
+            "resources/referenceFrontsCSV/ZDT1.csv",
+            99,
+            ReferencePointGenerator.generateSingleLayer(2, 99),
+            "single-layer(99)"),
+        new BenchmarkRun("ZDT4",
+            "ZDT4",
+            "org.uma.jmetal.problem.multiobjective.zdt.ZDT4",
+            "resources/referenceFrontsCSV/ZDT4.csv",
+            99,
+            ReferencePointGenerator.generateSingleLayer(2, 99),
+            "single-layer(99)"),
+        new BenchmarkRun("DTLZ1",
+            "DTLZ1 (experimental custom reference vectors)",
+            "org.uma.jmetal.problem.multiobjective.dtlz.DTLZ1",
+            "resources/referenceFrontsCSV/DTLZ1.3D.csv",
+            12,
+            ReferencePointGenerator.generateTwoLayers(3, 9, 8),
+            "two-layer(9,8)"));
+
+    List<RunSummary> summaries = new ArrayList<>();
+    for (BenchmarkRun run : runs) {
+      summaries.add(execute(run));
+    }
+
+    writeRuntimeCsv(summaries);
+    JMetalLogger.logger.info("Benchmark results written to " + OUTPUT_DIRECTORY.toAbsolutePath());
+  }
+
+  private static RunSummary execute(BenchmarkRun benchmarkRun) throws IOException {
+    Problem<DoubleSolution> problem = ProblemFactory.loadProblem(benchmarkRun.problemName());
+
+    var crossover = new SBXCrossover(CROSSOVER_PROBABILITY, CROSSOVER_DISTRIBUTION_INDEX);
+    var mutation = new PolynomialMutation(
+        1.0 / problem.numberOfVariables(), MUTATION_DISTRIBUTION_INDEX);
+
+    Termination termination = new TerminationByEvaluations(MAX_EVALUATIONS);
+
+    EvolutionaryAlgorithm<DoubleSolution> rvea =
+        new RVEABuilder<>(problem, POPULATION_SIZE, MAX_EVALUATIONS, crossover, mutation, ALPHA,
+            FR, benchmarkRun.divisions())
+            .setReferenceVectors(benchmarkRun.referenceVectors())
+            .setTermination(termination)
+            .build();
+
+    rvea.run();
+
+    List<DoubleSolution> paretoFront = SolutionListUtils.getNonDominatedSolutions(rvea.result());
+
+    Path funPath = OUTPUT_DIRECTORY.resolve("FUN_" + benchmarkRun.label() + ".csv");
+    Path varPath = OUTPUT_DIRECTORY.resolve("VAR_" + benchmarkRun.label() + ".csv");
+
+    new SolutionListOutput(paretoFront)
+        .setVarFileOutputContext(new DefaultFileOutputContext(varPath.toString(), ","))
+        .setFunFileOutputContext(new DefaultFileOutputContext(funPath.toString(), ","))
+        .print();
+
+    int referenceVectors = benchmarkRun.referenceVectors().size();
+
+    JMetalLogger.logger.info(
+        String.format(
+            Locale.US,
+            "%s finished. Runtime=%dms, evaluations=%d, nonDominated=%d, referenceVectors=%d",
+            benchmarkRun.displayName(),
+            rvea.totalComputingTime(),
+            rvea.numberOfEvaluations(),
+            paretoFront.size(),
+            referenceVectors));
+
+    return new RunSummary(
+        benchmarkRun.displayName(),
+        benchmarkRun.referenceFront(),
+        POPULATION_SIZE,
+        MAX_EVALUATIONS,
+        benchmarkRun.divisions(),
+        benchmarkRun.referenceVectorScheme(),
+        referenceVectors,
+        rvea.totalComputingTime(),
+        rvea.numberOfEvaluations(),
+        paretoFront.size(),
+        funPath,
+        varPath);
+  }
+
+  private static void writeRuntimeCsv(List<RunSummary> summaries) throws IOException {
+    Path runtimePath = OUTPUT_DIRECTORY.resolve("runtime.csv");
+    try (BufferedWriter writer = Files.newBufferedWriter(runtimePath)) {
+      writer.write(
+          "problem,populationSize,maxEvaluations,divisions,referenceVectorScheme,referenceVectors,runtimeMs,evaluations,nonDominatedSolutions,funFile,varFile,referenceFront");
+      writer.newLine();
+
+      for (RunSummary summary : summaries) {
+        writer.write(
+            String.format(
+                Locale.US,
+                "%s,%d,%d,%d,%s,%d,%d,%d,%d,%s,%s,%s",
+                summary.problem(),
+                summary.populationSize(),
+                summary.maxEvaluations(),
+                summary.divisions(),
+                summary.referenceVectorScheme(),
+                summary.referenceVectors(),
+                summary.runtimeMs(),
+                summary.evaluations(),
+                summary.nonDominatedSolutions(),
+                summary.funFile().toString().replace('\\', '/'),
+                summary.varFile().toString().replace('\\', '/'),
+                summary.referenceFront().replace('\\', '/')));
+        writer.newLine();
+      }
+    }
+  }
+
+  private static class BenchmarkRun {
+    private final String label;
+    private final String displayName;
+    private final String problemName;
+    private final String referenceFront;
+    private final int divisions;
+    private final List<double[]> referenceVectors;
+    private final String referenceVectorScheme;
+
+    private BenchmarkRun(
+        String label,
+        String displayName,
+        String problemName,
+        String referenceFront,
+        int divisions,
+        List<double[]> referenceVectors,
+        String referenceVectorScheme) {
+      this.label = label;
+      this.displayName = displayName;
+      this.problemName = problemName;
+      this.referenceFront = referenceFront;
+      this.divisions = divisions;
+      this.referenceVectors = referenceVectors;
+      this.referenceVectorScheme = referenceVectorScheme;
+    }
+
+    private String label() {
+      return label;
+    }
+
+    private String problemName() {
+      return problemName;
+    }
+
+    private String displayName() {
+      return displayName;
+    }
+
+    private String referenceFront() {
+      return referenceFront;
+    }
+
+    private int divisions() {
+      return divisions;
+    }
+
+    private List<double[]> referenceVectors() {
+      return referenceVectors;
+    }
+
+    private String referenceVectorScheme() {
+      return referenceVectorScheme;
+    }
+  }
+
+  private static class RunSummary {
+    private final String problem;
+    private final String referenceFront;
+    private final int populationSize;
+    private final int maxEvaluations;
+    private final int divisions;
+    private final String referenceVectorScheme;
+    private final int referenceVectors;
+    private final long runtimeMs;
+    private final int evaluations;
+    private final int nonDominatedSolutions;
+    private final Path funFile;
+    private final Path varFile;
+
+    private RunSummary(
+        String problem,
+        String referenceFront,
+        int populationSize,
+        int maxEvaluations,
+        int divisions,
+        String referenceVectorScheme,
+        int referenceVectors,
+        long runtimeMs,
+        int evaluations,
+        int nonDominatedSolutions,
+        Path funFile,
+        Path varFile) {
+      this.problem = problem;
+      this.referenceFront = referenceFront;
+      this.populationSize = populationSize;
+      this.maxEvaluations = maxEvaluations;
+      this.divisions = divisions;
+      this.referenceVectorScheme = referenceVectorScheme;
+      this.referenceVectors = referenceVectors;
+      this.runtimeMs = runtimeMs;
+      this.evaluations = evaluations;
+      this.nonDominatedSolutions = nonDominatedSolutions;
+      this.funFile = funFile;
+      this.varFile = varFile;
+    }
+
+    private String problem() {
+      return problem;
+    }
+
+    private String referenceFront() {
+      return referenceFront;
+    }
+
+    private int populationSize() {
+      return populationSize;
+    }
+
+    private int maxEvaluations() {
+      return maxEvaluations;
+    }
+
+    private int divisions() {
+      return divisions;
+    }
+
+    private String referenceVectorScheme() {
+      return referenceVectorScheme;
+    }
+
+    private int referenceVectors() {
+      return referenceVectors;
+    }
+
+    private long runtimeMs() {
+      return runtimeMs;
+    }
+
+    private int evaluations() {
+      return evaluations;
+    }
+
+    private int nonDominatedSolutions() {
+      return nonDominatedSolutions;
+    }
+
+    private Path funFile() {
+      return funFile;
+    }
+
+    private Path varFile() {
+      return varFile;
+    }
+  }
+}

--- a/jmetal-component/src/test/java/org/uma/jmetal/component/algorithm/multiobjective/AGEMOEABuilderIT.java
+++ b/jmetal-component/src/test/java/org/uma/jmetal/component/algorithm/multiobjective/AGEMOEABuilderIT.java
@@ -1,0 +1,262 @@
+package org.uma.jmetal.component.algorithm.multiobjective;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.uma.jmetal.component.algorithm.EvolutionaryAlgorithm;
+import org.uma.jmetal.component.catalogue.common.termination.impl.TerminationByEvaluations;
+import org.uma.jmetal.component.catalogue.ea.replacement.Replacement;
+import org.uma.jmetal.component.catalogue.ea.replacement.impl.agemoea.AGEMOEAEnvironmentalSelection;
+import org.uma.jmetal.component.catalogue.ea.selection.Selection;
+import org.uma.jmetal.component.catalogue.ea.variation.Variation;
+import org.uma.jmetal.operator.crossover.impl.SBXCrossover;
+import org.uma.jmetal.operator.mutation.impl.PolynomialMutation;
+import org.uma.jmetal.problem.doubleproblem.DoubleProblem;
+import org.uma.jmetal.problem.doubleproblem.impl.FakeDoubleProblem;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+import org.uma.jmetal.util.errorchecking.exception.InvalidConditionException;
+
+class AGEMOEABuilderIT {
+
+  @Test
+  void ageMoeaScoresTheInitialPopulationBeforeTheFirstSelection() {
+    DoubleProblem problem = new FakeDoubleProblem(2, 2, 0);
+    List<DoubleSolution> initialPopulation = createPopulation(problem);
+    AtomicBoolean initialPopulationWasScored = new AtomicBoolean(false);
+
+    Selection<DoubleSolution> selection = population -> {
+      initialPopulationWasScored.set(
+          population.stream()
+              .allMatch(
+                  solution ->
+                      solution.attributes()
+                          .containsKey(AGEMOEAEnvironmentalSelection.getAttributeId())));
+
+      List<DoubleSolution> matingPool = new ArrayList<>(2);
+      for (int i = 0; i < 2; i++) {
+        matingPool.add((DoubleSolution) population.get(i).copy());
+      }
+
+      return matingPool;
+    };
+
+    Variation<DoubleSolution> variation = copyVariation(2);
+
+    double crossoverProbability = 0.9;
+    double crossoverDistributionIndex = 20.0;
+    var crossover = new SBXCrossover(crossoverProbability, crossoverDistributionIndex);
+
+    double mutationProbability = 1.0 / problem.numberOfVariables();
+    double mutationDistributionIndex = 20.0;
+    var mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+
+    EvolutionaryAlgorithm<DoubleSolution> algorithm =
+        new AGEMOEABuilder<>(
+            problem,
+            initialPopulation.size(),
+            variation.offspringPopulationSize(),
+            crossover,
+            mutation,
+            AGEMOEABuilder.Variant.AGEMOEA)
+            .setCreateInitialPopulation(() -> initialPopulation)
+            .setSelection(selection)
+            .setVariation(variation)
+            .setTermination(new TerminationByEvaluations(initialPopulation.size() + 2))
+            .build();
+
+    algorithm.run();
+
+    assertTrue(initialPopulationWasScored.get());
+  }
+
+  @Test
+  void ageMoeaAllowsConfiguringTheTournamentSizeWithoutReplacingTheSelectionComponent() {
+    DoubleProblem problem = new FakeDoubleProblem(2, 2, 0);
+    List<DoubleSolution> initialPopulation = createPopulation(problem);
+
+    double crossoverProbability = 0.9;
+    double crossoverDistributionIndex = 20.0;
+    var crossover = new SBXCrossover(crossoverProbability, crossoverDistributionIndex);
+
+    double mutationProbability = 1.0 / problem.numberOfVariables();
+    double mutationDistributionIndex = 20.0;
+    var mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+
+    EvolutionaryAlgorithm<DoubleSolution> algorithm =
+        new AGEMOEABuilder<>(
+            problem,
+            initialPopulation.size(),
+            2,
+            crossover,
+            mutation,
+            AGEMOEABuilder.Variant.AGEMOEA)
+            .setCreateInitialPopulation(() -> initialPopulation)
+            .setTournamentSize(initialPopulation.size() + 1)
+            .setTermination(new TerminationByEvaluations(initialPopulation.size() + 2))
+            .build();
+
+    assertThrows(InvalidConditionException.class, algorithm::run);
+  }
+
+  @Test
+  void ageMoeaUsesTheConfiguredEnvironmentalSelectionForInitialScoringAndDefaultReplacement() {
+    DoubleProblem problem = new FakeDoubleProblem(2, 2, 0);
+    List<DoubleSolution> initialPopulation = createPopulation(problem);
+    AtomicInteger executionCounter = new AtomicInteger();
+
+    Selection<DoubleSolution> selection = population -> {
+      List<DoubleSolution> matingPool = new ArrayList<>(2);
+      for (int i = 0; i < 2; i++) {
+        matingPool.add((DoubleSolution) population.get(i).copy());
+      }
+
+      return matingPool;
+    };
+
+    Variation<DoubleSolution> variation = copyVariation(2);
+    var environmentalSelection = new CountingEnvironmentalSelection(problem.numberOfObjectives(),
+        executionCounter);
+
+    double crossoverProbability = 0.9;
+    double crossoverDistributionIndex = 20.0;
+    var crossover = new SBXCrossover(crossoverProbability, crossoverDistributionIndex);
+
+    double mutationProbability = 1.0 / problem.numberOfVariables();
+    double mutationDistributionIndex = 20.0;
+    var mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+
+    EvolutionaryAlgorithm<DoubleSolution> algorithm =
+        new AGEMOEABuilder<>(
+            problem,
+            initialPopulation.size(),
+            variation.offspringPopulationSize(),
+            crossover,
+            mutation,
+            AGEMOEABuilder.Variant.AGEMOEA)
+            .setCreateInitialPopulation(() -> initialPopulation)
+            .setSelection(selection)
+            .setVariation(variation)
+            .setEnvironmentalSelection(environmentalSelection)
+            .setTermination(new TerminationByEvaluations(initialPopulation.size() + 2))
+            .build();
+
+    algorithm.run();
+
+    assertEquals(2, executionCounter.get());
+  }
+
+  @Test
+  void ageMoeaAllowsProvidingACustomReplacementComponent() {
+    DoubleProblem problem = new FakeDoubleProblem(2, 2, 0);
+    List<DoubleSolution> initialPopulation = createPopulation(problem);
+    AtomicBoolean replacementWasInvoked = new AtomicBoolean(false);
+
+    Selection<DoubleSolution> selection = population -> {
+      List<DoubleSolution> matingPool = new ArrayList<>(2);
+      for (int i = 0; i < 2; i++) {
+        matingPool.add((DoubleSolution) population.get(i).copy());
+      }
+
+      return matingPool;
+    };
+
+    Variation<DoubleSolution> variation = copyVariation(2);
+    Replacement<DoubleSolution> replacement = (population, offspringPopulation) -> {
+      replacementWasInvoked.set(true);
+      return population;
+    };
+
+    double crossoverProbability = 0.9;
+    double crossoverDistributionIndex = 20.0;
+    var crossover = new SBXCrossover(crossoverProbability, crossoverDistributionIndex);
+
+    double mutationProbability = 1.0 / problem.numberOfVariables();
+    double mutationDistributionIndex = 20.0;
+    var mutation = new PolynomialMutation(mutationProbability, mutationDistributionIndex);
+
+    EvolutionaryAlgorithm<DoubleSolution> algorithm =
+        new AGEMOEABuilder<>(
+            problem,
+            initialPopulation.size(),
+            variation.offspringPopulationSize(),
+            crossover,
+            mutation,
+            AGEMOEABuilder.Variant.AGEMOEA)
+            .setCreateInitialPopulation(() -> initialPopulation)
+            .setSelection(selection)
+            .setVariation(variation)
+            .setReplacement(replacement)
+            .setTermination(new TerminationByEvaluations(initialPopulation.size() + 2))
+            .build();
+
+    algorithm.run();
+
+    assertTrue(replacementWasInvoked.get());
+  }
+
+  private static List<DoubleSolution> createPopulation(DoubleProblem problem) {
+    return List.of(
+        solutionWithObjectives(problem, 1.0, 0.0),
+        solutionWithObjectives(problem, 0.0, 1.0),
+        solutionWithObjectives(problem, 0.5, 0.5),
+        solutionWithObjectives(problem, 0.2, 0.8));
+  }
+
+  private static DoubleSolution solutionWithObjectives(
+      DoubleProblem problem, double firstObjective, double secondObjective) {
+    DoubleSolution solution = problem.createSolution();
+    solution.objectives()[0] = firstObjective;
+    solution.objectives()[1] = secondObjective;
+
+    return solution;
+  }
+
+  private static Variation<DoubleSolution> copyVariation(int populationSize) {
+    return new Variation<>() {
+      @Override
+      public List<DoubleSolution> variate(
+          List<DoubleSolution> solutionList, List<DoubleSolution> matingPool) {
+        List<DoubleSolution> offspringPopulation = new ArrayList<>(populationSize);
+        for (int i = 0; i < populationSize; i++) {
+          offspringPopulation.add((DoubleSolution) matingPool.get(i).copy());
+        }
+
+        return offspringPopulation;
+      }
+
+      @Override
+      public int matingPoolSize() {
+        return populationSize;
+      }
+
+      @Override
+      public int offspringPopulationSize() {
+        return populationSize;
+      }
+    };
+  }
+
+  private static class CountingEnvironmentalSelection
+      extends AGEMOEAEnvironmentalSelection<DoubleSolution> {
+    private final AtomicInteger executionCounter;
+
+    CountingEnvironmentalSelection(int numberOfObjectives, AtomicInteger executionCounter) {
+      super(numberOfObjectives);
+      this.executionCounter = executionCounter;
+    }
+
+    @Override
+    public List<DoubleSolution> execute(
+        List<DoubleSolution> solutionList, int solutionsToSelect) {
+      executionCounter.incrementAndGet();
+
+      return super.execute(solutionList, solutionsToSelect);
+    }
+  }
+}

--- a/jmetal-component/src/test/java/org/uma/jmetal/component/algorithm/multiobjective/RVEABuilderTest.java
+++ b/jmetal-component/src/test/java/org/uma/jmetal/component/algorithm/multiobjective/RVEABuilderTest.java
@@ -1,19 +1,26 @@
 package org.uma.jmetal.component.algorithm.multiobjective;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.uma.jmetal.component.catalogue.common.termination.Termination;
 import org.uma.jmetal.component.catalogue.common.termination.impl.TerminationByEvaluations;
+import org.uma.jmetal.component.catalogue.ea.selection.impl.RandomSelection;
+import org.uma.jmetal.component.catalogue.ea.variation.Variation;
 import org.uma.jmetal.operator.crossover.impl.SBXCrossover;
 import org.uma.jmetal.operator.mutation.impl.PolynomialMutation;
 import org.uma.jmetal.problem.multiobjective.dtlz.DTLZ2;
 import org.uma.jmetal.solution.doublesolution.DoubleSolution;
 import org.uma.jmetal.util.errorchecking.exception.InvalidConditionException;
+import org.uma.jmetal.util.referencepoint.ReferencePointGenerator;
 
 @DisplayName("RVEABuilder tests")
 class RVEABuilderTest {
@@ -64,6 +71,71 @@ class RVEABuilderTest {
       RVEABuilder<DoubleSolution> builder =
           new RVEABuilder<>(problem, 6, 1000, crossover, mutation, 2.0, 0.1, 2)
               .setTermination(new TerminationByEvaluations(1000));
+
+      // Act
+      var algorithm = builder.build();
+
+      // Assert
+      assertNotNull(algorithm);
+    }
+
+    @Test
+    @DisplayName("Given a custom variation and no custom selection, when build is called, then the default selection uses the final mating pool size")
+    @SuppressWarnings("unchecked")
+    void givenACustomVariationAndNoCustomSelection_whenBuildIsCalled_thenTheDefaultSelectionUsesTheFinalMatingPoolSize() {
+      // Arrange
+      var problem = new DTLZ2(12, 3);
+      var crossover = new SBXCrossover(0.9, 20.0);
+      var mutation = new PolynomialMutation(1.0 / problem.numberOfVariables(), 20.0);
+      Variation<DoubleSolution> variation = mock(Variation.class);
+      when(variation.matingPoolSize()).thenReturn(8);
+      when(variation.offspringPopulationSize()).thenReturn(6);
+
+      RVEABuilder<DoubleSolution> builder =
+          new RVEABuilder<>(problem, 6, 1000, crossover, mutation, 2.0, 0.1, 2)
+              .setVariation(variation);
+
+      // Act
+      var algorithm = builder.build();
+
+      // Assert
+      RandomSelection<DoubleSolution> selection =
+          (RandomSelection<DoubleSolution>) algorithm.selection();
+      assertEquals(8, selection.getNumberOfElementsToSelect());
+    }
+
+    @Test
+    @DisplayName("Given a custom initial population with a wrong size, when the algorithm runs, then it fails fast")
+    void givenACustomInitialPopulationWithAWrongSize_whenTheAlgorithmRuns_thenItFailsFast() {
+      // Arrange
+      var problem = new DTLZ2(12, 3);
+      var crossover = new SBXCrossover(0.9, 20.0);
+      var mutation = new PolynomialMutation(1.0 / problem.numberOfVariables(), 20.0);
+
+      RVEABuilder<DoubleSolution> builder =
+          new RVEABuilder<>(problem, 6, 1000, crossover, mutation, 2.0, 0.1, 2)
+              .setCreateInitialPopulation(() ->
+                  IntStream.range(0, 5).mapToObj(i -> problem.createSolution()).toList());
+
+      var algorithm = builder.build();
+
+      // Act + Assert
+      assertThrows(InvalidConditionException.class, algorithm::run);
+    }
+
+    @Test
+    @DisplayName("Given custom reference vectors matching the population size, when build is called, then an algorithm instance is returned")
+    void givenCustomReferenceVectorsMatchingThePopulationSize_whenBuildIsCalled_thenAnAlgorithmInstanceIsReturned() {
+      // Arrange
+      var problem = new DTLZ2(12, 3);
+      var crossover = new SBXCrossover(0.9, 20.0);
+      var mutation = new PolynomialMutation(1.0 / problem.numberOfVariables(), 20.0);
+      List<double[]> referenceVectors =
+          ReferencePointGenerator.generateTwoLayers(problem.numberOfObjectives(), 9, 8);
+
+      RVEABuilder<DoubleSolution> builder =
+          new RVEABuilder<>(problem, 100, 1000, crossover, mutation, 2.0, 0.1, 12)
+              .setReferenceVectors(referenceVectors);
 
       // Act
       var algorithm = builder.build();

--- a/jmetal-component/src/test/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/RVEAReplacementTest.java
+++ b/jmetal-component/src/test/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/RVEAReplacementTest.java
@@ -1,0 +1,49 @@
+package org.uma.jmetal.component.catalogue.ea.replacement.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.uma.jmetal.component.catalogue.ea.replacement.impl.rvea.RVEAEnvironmentalSelection;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+
+@DisplayName("RVEAReplacement tests")
+class RVEAReplacementTest {
+
+  @Test
+  @DisplayName("Given empty niches, when replace is called, then the result size matches the current population size")
+  void givenEmptyNiches_whenReplaceIsCalled_thenTheResultSizeMatchesTheCurrentPopulationSize() {
+    // Arrange
+    RVEAReplacement<DoubleSolution> replacement =
+        new RVEAReplacement<>(new RVEAEnvironmentalSelection<>(3, 10, 2.0, 0.5, 1));
+
+    DoubleSolution solution1 = solutionWithObjectives(1.0, 10.0, 10.0);
+    DoubleSolution solution2 = solutionWithObjectives(10.0, 1.0, 10.0);
+    DoubleSolution solution3 = solutionWithObjectives(2.0, 2.0, 10.0);
+    DoubleSolution solution4 = solutionWithObjectives(3.0, 2.5, 10.0);
+
+    List<DoubleSolution> currentPopulation = List.of(solution1, solution2, solution3);
+    List<DoubleSolution> offspringPopulation = List.of(solution4);
+    List<DoubleSolution> jointPopulation =
+        List.of(solution1, solution2, solution3, solution4);
+
+    // Act
+    List<DoubleSolution> result = replacement.replace(currentPopulation, offspringPopulation);
+
+    // Assert
+    assertThat(result)
+        .hasSize(currentPopulation.size())
+        .allMatch(jointPopulation::contains)
+        .doesNotHaveDuplicates();
+  }
+
+  private DoubleSolution solutionWithObjectives(double... objectives) {
+    DoubleSolution solution = mock(DoubleSolution.class);
+    when(solution.objectives()).thenReturn(objectives);
+
+    return solution;
+  }
+}

--- a/jmetal-component/src/test/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/agemoea/AGEMOEAEnvironmentalSelectionTest.java
+++ b/jmetal-component/src/test/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/agemoea/AGEMOEAEnvironmentalSelectionTest.java
@@ -1,0 +1,80 @@
+package org.uma.jmetal.component.catalogue.ea.replacement.impl.agemoea;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.uma.jmetal.problem.doubleproblem.impl.FakeDoubleProblem;
+import org.uma.jmetal.solution.doublesolution.DoubleSolution;
+
+class AGEMOEAEnvironmentalSelectionTest {
+
+  @Test
+  void assignConvergenceScoreNormalizesObjectivesWhenInterceptsAreAvailable() {
+    FakeDoubleProblem problem = new FakeDoubleProblem(2, 2, 0);
+    DoubleSolution solution = solutionWithObjectives(problem, 1.0, 1.0);
+
+    TestEnvironmentalSelection environmentalSelection = new TestEnvironmentalSelection(2);
+    environmentalSelection.setState(1.0, List.of(2.0, 2.0));
+
+    environmentalSelection.assignConvergenceScores(List.of(solution));
+
+    assertEquals(
+        1.0,
+        solution.attributes().get(AGEMOEAEnvironmentalSelection.getAttributeId()));
+  }
+
+  @Test
+  void executeResetsTheInternalStateBeforeScoringAnotherPopulation() {
+    FakeDoubleProblem problem = new FakeDoubleProblem(2, 2, 0);
+    TestEnvironmentalSelection environmentalSelection = new TestEnvironmentalSelection(2);
+
+    List<DoubleSolution> firstPopulation =
+        List.of(
+            solutionWithObjectives(problem, 1.0, 0.0),
+            solutionWithObjectives(problem, 0.0, 1.0),
+            solutionWithObjectives(problem, 1.0 / Math.sqrt(2.0), 1.0 / Math.sqrt(2.0)));
+
+    environmentalSelection.execute(firstPopulation, 3);
+
+    DoubleSolution dominatedSolution = solutionWithObjectives(problem, 2.0, 2.0);
+    List<DoubleSolution> secondPopulation =
+        List.of(
+            solutionWithObjectives(problem, 0.0, 1.0),
+            solutionWithObjectives(problem, 1.0, 0.0),
+            dominatedSolution);
+
+    environmentalSelection.execute(secondPopulation, 3);
+
+    assertEquals(
+        4.0,
+        dominatedSolution.attributes().get(AGEMOEAEnvironmentalSelection.getAttributeId()));
+  }
+
+  private static DoubleSolution solutionWithObjectives(
+      FakeDoubleProblem problem, double firstObjective, double secondObjective) {
+    DoubleSolution solution = problem.createSolution();
+    solution.objectives()[0] = firstObjective;
+    solution.objectives()[1] = secondObjective;
+
+    return solution;
+  }
+
+  private static class TestEnvironmentalSelection
+      extends AGEMOEAEnvironmentalSelection<DoubleSolution> {
+
+    TestEnvironmentalSelection(int numberOfObjectives) {
+      super(numberOfObjectives);
+    }
+
+    void setState(double p, List<Double> intercepts) {
+      P = p;
+      this.intercepts = new ArrayList<>(intercepts);
+    }
+
+    void assignConvergenceScores(List<DoubleSolution> front) {
+      assignConvergenceScore(front);
+    }
+  }
+}

--- a/jmetal-component/src/test/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/rvea/RVEAEnvironmentalSelectionTest.java
+++ b/jmetal-component/src/test/java/org/uma/jmetal/component/catalogue/ea/replacement/impl/rvea/RVEAEnvironmentalSelectionTest.java
@@ -19,8 +19,8 @@ class RVEAEnvironmentalSelectionTest {
   class ExecuteMethodBehaviorTests {
 
     @Test
-    @DisplayName("Given empty niches, when execute is called, then result size equals the number of occupied reference vectors")
-    void givenEmptyNiches_whenExecuteIsCalled_thenResultSizeEqualsTheNumberOfOccupiedReferenceVectors() {
+    @DisplayName("Given empty niches, when execute is called, then the configured population size is preserved without duplicates")
+    void givenEmptyNiches_whenExecuteIsCalled_thenTheConfiguredPopulationSizeIsPreservedWithoutDuplicates() {
       // Arrange
       RVEAEnvironmentalSelection<DoubleSolution> environmentalSelection =
           new RVEAEnvironmentalSelection<>(3, 10, 2.0, 0.5, 1);
@@ -35,36 +35,130 @@ class RVEAEnvironmentalSelectionTest {
       List<DoubleSolution> result = environmentalSelection.execute(jointPopulation, 3);
 
       // Assert
-      assertThat(result).hasSize(2);
-      assertThat(result).allMatch(jointPopulation::contains);
+      assertThat(result).hasSize(3).allMatch(jointPopulation::contains).doesNotHaveDuplicates();
     }
 
     @Test
-    @DisplayName("Given an adaptation generation, when execute is called, then reference vectors adapt using the survivor nadir point")
-    void givenAnAdaptationGeneration_whenExecuteIsCalled_thenReferenceVectorsAdaptUsingTheSurvivorNadirPoint() {
+    @DisplayName("Given multiple executions, when execute is called, then the ideal point is recomputed from the current candidate population")
+    void givenMultipleExecutions_whenExecuteIsCalled_thenTheIdealPointIsRecomputedFromTheCurrentCandidatePopulation() {
       // Arrange
       RVEAEnvironmentalSelection<DoubleSolution> environmentalSelection =
-          new RVEAEnvironmentalSelection<>(2, 1, 2.0, 1.0, 2);
+          new RVEAEnvironmentalSelection<>(
+              2,
+              5,
+              2.0,
+              0.1,
+              List.of(new double[] {1.0, 0.0}, new double[] {0.0, 1.0}));
 
-      DoubleSolution idealSolution = solutionWithObjectives(1.0, 1.0);
-      DoubleSolution xAxisSolution = solutionWithObjectives(11.0, 1.0);
-      DoubleSolution yAxisSolution = solutionWithObjectives(1.0, 2.0);
-      DoubleSolution diagonalSolution = solutionWithObjectives(2.0, 2.0);
-      DoubleSolution discardedOutlier = solutionWithObjectives(101.0, 1.2);
-
-      List<DoubleSolution> jointPopulation =
-          List.of(idealSolution, xAxisSolution, yAxisSolution, diagonalSolution, discardedOutlier);
+      List<DoubleSolution> firstPopulation =
+          List.of(solutionWithObjectives(1.0, 2.0), solutionWithObjectives(2.0, 1.0));
+      List<DoubleSolution> secondPopulation =
+          List.of(solutionWithObjectives(5.0, 6.0), solutionWithObjectives(7.0, 5.0));
 
       // Act
-      environmentalSelection.execute(jointPopulation, 3);
+      environmentalSelection.execute(firstPopulation, 2);
+      environmentalSelection.execute(secondPopulation, 2);
+
+      // Assert
+      assertThat(environmentalSelection.idealPoint()).containsExactly(5.0, 5.0);
+    }
+
+    @Test
+    @DisplayName("Given adaptive reference vectors, when execute is called, then the adaptation uses the current survivor ideal and nadir points")
+    void givenAdaptiveReferenceVectors_whenExecuteIsCalled_thenTheAdaptationUsesTheCurrentSurvivorIdealAndNadirPoints() {
+      // Arrange
+      RVEAEnvironmentalSelection<DoubleSolution> environmentalSelection =
+          new RVEAEnvironmentalSelection<>(
+              2,
+              2,
+              2.0,
+              0.1,
+              List.of(new double[] {1.0, 0.0}, new double[] {1.0, 1.0}, new double[] {0.0, 1.0}));
+
+      List<DoubleSolution> firstPopulation = List.of(
+          solutionWithObjectives(2.0, 1.0),
+          solutionWithObjectives(1.0, 2.0),
+          solutionWithObjectives(2.0, 2.0));
+      List<DoubleSolution> secondPopulation = List.of(
+          solutionWithObjectives(7.0, 5.0),
+          solutionWithObjectives(5.0, 6.0),
+          solutionWithObjectives(7.0, 6.0));
+
+      // Act
+      environmentalSelection.execute(firstPopulation, 3);
+      environmentalSelection.execute(secondPopulation, 3);
       double[][] adaptedReferenceVectors = environmentalSelection.referenceVectors();
 
       // Assert
-      double expectedX = 10.0 / Math.sqrt(101.0);
-      double expectedY = 1.0 / Math.sqrt(101.0);
+      double expectedX = 2.0 / Math.sqrt(5.0);
+      double expectedY = 1.0 / Math.sqrt(5.0);
 
+      assertThat(environmentalSelection.idealPoint()).containsExactly(5.0, 5.0);
+      assertThat(environmentalSelection.nadirPoint()).containsExactly(7.0, 6.0);
       assertThat(adaptedReferenceVectors[1][0]).isCloseTo(expectedX, within(1.0e-12));
       assertThat(adaptedReferenceVectors[1][1]).isCloseTo(expectedY, within(1.0e-12));
+    }
+
+    @Test
+    @DisplayName("Given the first generation, when execute is called, then reference vectors adapt on the first eligible generation")
+    void givenTheFirstGeneration_whenExecuteIsCalled_thenReferenceVectorsAdaptOnTheFirstEligibleGeneration() {
+      // Arrange
+      RVEAEnvironmentalSelection<DoubleSolution> environmentalSelection =
+          new RVEAEnvironmentalSelection<>(
+              2,
+              10,
+              2.0,
+              0.5,
+              List.of(new double[] {1.0, 0.0}, new double[] {1.0, 1.0}, new double[] {0.0, 1.0}));
+
+      List<DoubleSolution> population = List.of(
+          solutionWithObjectives(7.0, 5.0),
+          solutionWithObjectives(5.0, 6.0),
+          solutionWithObjectives(7.0, 6.0));
+
+      // Act
+      environmentalSelection.execute(population, 3);
+      double[][] adaptedReferenceVectors = environmentalSelection.referenceVectors();
+
+      // Assert
+      double expectedX = 2.0 / Math.sqrt(5.0);
+      double expectedY = 1.0 / Math.sqrt(5.0);
+
+      assertThat(environmentalSelection.currentGeneration()).isEqualTo(0);
+      assertThat(adaptedReferenceVectors[1][0]).isCloseTo(expectedX, within(1.0e-12));
+      assertThat(adaptedReferenceVectors[1][1]).isCloseTo(expectedY, within(1.0e-12));
+    }
+
+    @Test
+    @DisplayName("Given two candidates in the same bi objective niche, when execute is called, then APD uses the number of objectives as the penalty factor")
+    void givenTwoCandidatesInTheSameBiObjectiveNiche_whenExecuteIsCalled_thenAPDUsesTheNumberOfObjectivesAsThePenaltyFactor() {
+      // Arrange
+      RVEAEnvironmentalSelection<DoubleSolution> environmentalSelection =
+          new RVEAEnvironmentalSelection<>(
+              2,
+              1,
+              1.0,
+              1.0,
+              List.of(new double[] {1.0, 0.0}, new double[] {0.0, 1.0}));
+
+      List<DoubleSolution> warmUpPopulation =
+          List.of(solutionWithObjectives(1.0, 0.0), solutionWithObjectives(0.0, 1.0));
+
+      DoubleSolution idealSolution = solutionWithObjectives(0.0, 0.0);
+      double gamma = Math.PI / 2.0;
+      DoubleSolution widerAngleSolution =
+          solutionWithObjectives(1.02 * Math.sin(gamma * 0.4), 1.02 * Math.cos(gamma * 0.4));
+      DoubleSolution narrowerAngleSolution =
+          solutionWithObjectives(1.5 * Math.sin(gamma * 0.05), 1.5 * Math.cos(gamma * 0.05));
+
+      // Act
+      environmentalSelection.execute(warmUpPopulation, 2);
+      List<DoubleSolution> result = environmentalSelection.execute(
+          List.of(idealSolution, widerAngleSolution, narrowerAngleSolution), 2);
+
+      // Assert
+      assertThat(result).contains(idealSolution, narrowerAngleSolution);
+      assertThat(result).doesNotContain(widerAngleSolution);
     }
   }
 

--- a/jmetal-core/src/main/java/org/uma/jmetal/util/referencepoint/ReferencePointGenerator.java
+++ b/jmetal-core/src/main/java/org/uma/jmetal/util/referencepoint/ReferencePointGenerator.java
@@ -55,17 +55,13 @@ public class ReferencePointGenerator {
     // Generate inner layer
     List<double[]> innerLayer = generateSingleLayer(numberOfObjectives, innerDivisions);
 
-    // Shrink inner layer points towards center (0.5, 0.5, ..., 0.5)
+    // Shrink inner-layer points toward the simplex center so the shifted points remain on
+    // the unit simplex while covering the interior more uniformly.
     double shrinkFactor = 0.5;
+    double centerCoordinate = (1.0 - shrinkFactor) / numberOfObjectives;
     for (double[] point : innerLayer) {
-      double sum = 0.0;
       for (int i = 0; i < point.length; i++) {
-        point[i] = shrinkFactor + point[i] * shrinkFactor;
-        sum += point[i];
-      }
-      // Normalize to sum to 1
-      for (int i = 0; i < point.length; i++) {
-        point[i] = point[i] / sum;
+        point[i] = centerCoordinate + point[i] * shrinkFactor;
       }
     }
 

--- a/jmetal-core/src/test/java/org/uma/jmetal/util/referencepoint/ReferencePointGeneratorTest.java
+++ b/jmetal-core/src/test/java/org/uma/jmetal/util/referencepoint/ReferencePointGeneratorTest.java
@@ -1,0 +1,58 @@
+package org.uma.jmetal.util.referencepoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ReferencePointGeneratorTest {
+
+  @Test
+  void generatedTwoLayerReferencePointsShouldRemainOnTheUnitSimplex() {
+    List<double[]> referencePoints = ReferencePointGenerator.generateTwoLayers(3, 9, 8);
+
+    for (double[] point : referencePoints) {
+      double sum = 0.0;
+      for (double coordinate : point) {
+        sum += coordinate;
+      }
+
+      assertEquals(1.0, sum, 1.0e-10, "Reference point should sum to 1.0");
+    }
+  }
+
+  @Test
+  void generatedTwoLayerReferencePointsShouldShiftTheInnerLayerTowardTheSimplexCenter() {
+    List<double[]> referencePoints = ReferencePointGenerator.generateTwoLayers(3, 9, 8);
+
+    assertTrue(
+        containsPoint(referencePoints, new double[] {2.0 / 3.0, 1.0 / 6.0, 1.0 / 6.0}, 1.0e-12),
+        "The inner layer should contain the simplex-centered shift of a boundary direction.");
+    assertTrue(
+        containsPoint(referencePoints, new double[] {1.0 / 6.0, 1.0 / 6.0, 2.0 / 3.0}, 1.0e-12),
+        "The inner layer should preserve symmetric simplex-centered directions.");
+  }
+
+  private boolean containsPoint(List<double[]> points, double[] expectedPoint, double tolerance) {
+    for (double[] point : points) {
+      if (point.length != expectedPoint.length) {
+        continue;
+      }
+
+      boolean matches = true;
+      for (int i = 0; i < point.length; i++) {
+        if (Math.abs(point[i] - expectedPoint[i]) > tolerance) {
+          matches = false;
+          break;
+        }
+      }
+
+      if (matches) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## What changed
- fixed AGE-MOEA environmental selection state reset and lower-front normalization in the algorithm and component modules
- exposed AGE-MOEA builder knobs for tournament size, environmental selection, and replacement
- added `AutoAGEMOEA` plus irace runners, parameter files, and integration tests
- ignored generated AGE-MOEA tuning artifacts

## Why it changed
- AGE-MOEA first-generation selection and survival scoring needed regression fixes
- the component builder needed direct hooks for tuning instead of requiring full component replacement
- `jmetal-auto` needed an AGE-MOEA entry point so `irace` can configure the algorithm family

## How to verify locally
```powershell
& 'C:\Program Files\JetBrains\IntelliJ IDEA 261.17801.55\plugins\maven\lib\maven3\bin\mvn.cmd' --% -pl jmetal-auto -am -Dtest=AGEMOEAEnvironmentalSelectionTest,AGEMOEABuilderIT,AutoAGEMOEAIT -Dsurefire.failIfNoSpecifiedTests=false test
```